### PR TITLE
Micro-optimisations for #666

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
@@ -50,6 +50,8 @@ public enum MinecraftVersion {
      */
     UNIT_TEST("Unit Test Environment");
 
+    public static final MinecraftVersion[] values = values();
+
     private final String name;
     private final String prefix;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
@@ -1,7 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.api.geo;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.OptionalInt;
@@ -175,7 +175,7 @@ public class ResourceManager {
 
         menu.addItem(4, new CustomItem(HeadTexture.MINECRAFT_CHUNK.getAsItemStack(), ChatColor.YELLOW + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.chunk"), "", "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.world") + ": " + block.getWorld().getName(), "&8\u21E8 &7X: " + x + " Z: " + z), ChestMenuUtils.getEmptyClickHandler());
         List<GEOResource> resources = new ArrayList<>(SlimefunPlugin.getRegistry().getGEOResources().values());
-        Collections.sort(resources, (a, b) -> a.getName(p).toLowerCase(Locale.ROOT).compareTo(b.getName(p).toLowerCase(Locale.ROOT)));
+        resources.sort(Comparator.comparing(a -> a.getName(p).toLowerCase(Locale.ROOT)));
 
         int index = 10;
         int pages = (resources.size() - 1) / 36 + 1;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideLayout.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideLayout.java
@@ -31,4 +31,6 @@ public enum SlimefunGuideLayout {
      */
     CHEAT_SHEET;
 
+    public static final SlimefunGuideLayout[] values = values();
+
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/GuideLayoutOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/GuideLayoutOption.java
@@ -101,7 +101,7 @@ class GuideLayoutOption implements SlimefunGuideOption<SlimefunGuideLayout> {
 
     @Override
     public Optional<SlimefunGuideLayout> getSelectedOption(Player p, ItemStack guide) {
-        for (SlimefunGuideLayout layout : SlimefunGuideLayout.values()) {
+        for (SlimefunGuideLayout layout : SlimefunGuideLayout.values) {
             if (SlimefunUtils.isItemSimilar(guide, SlimefunGuide.getItem(layout), true, false)) {
                 return Optional.of(layout);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -85,7 +85,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     protected abstract void addLanguage(@Nonnull String id, @Nonnull String texture);
 
     protected void loadEmbeddedLanguages() {
-        for (SupportedLanguage lang : SupportedLanguage.values()) {
+        for (SupportedLanguage lang : SupportedLanguage.values) {
             if (lang.isReadyForRelease() || SlimefunPlugin.getUpdater().getBranch() != SlimefunBranch.STABLE) {
                 addLanguage(lang.getLanguageId(), lang.getTexture());
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SupportedLanguage.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SupportedLanguage.java
@@ -58,6 +58,8 @@ enum SupportedLanguage {
     MACEDONIAN("mk", false, "a0e0b0b5d87a855466980a101a757bcdb5f77d9f7287889f3efa998ee0472fc0"),
     TAGALOG("tl", true, "9306c0c1ce6a9c61bb42a572c49e6d0ed20e0e6b3d122cc64c339cbf78e9e937");
 
+    public static final SupportedLanguage[] values = values();
+
     private final String id;
     private final boolean releaseReady;
     private final String textureHash;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
@@ -31,6 +31,8 @@ public enum PerformanceRating implements Predicate<Float> {
     HURTFUL(ChatColor.DARK_RED, 500),
     BAD(ChatColor.DARK_RED, Float.MAX_VALUE);
 
+    public static final PerformanceRating[] values = values();
+
     private final ChatColor color;
     private final float threshold;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
@@ -297,7 +297,7 @@ public class SlimefunProfiler {
     public PerformanceRating getPerformance() {
         float percentage = getPercentageOfTick();
 
-        for (PerformanceRating rating : PerformanceRating.values()) {
+        for (PerformanceRating rating : PerformanceRating.values) {
             if (rating.test(percentage)) {
                 return rating;
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -313,7 +313,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         String currentVersion = ReflectionUtils.getVersion();
 
         if (currentVersion.startsWith("v")) {
-            for (MinecraftVersion version : MinecraftVersion.values()) {
+            for (MinecraftVersion version : MinecraftVersion.values) {
                 if (version.matches(currentVersion)) {
                     minecraftVersion = version;
                     return false;
@@ -340,7 +340,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
     private Collection<String> getSupportedVersions() {
         List<String> list = new ArrayList<>();
 
-        for (MinecraftVersion version : MinecraftVersion.values()) {
+        for (MinecraftVersion version : MinecraftVersion.values) {
             if (version != MinecraftVersion.UNKNOWN) {
                 list.add(version.getName());
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
@@ -1,5 +1,10 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.androids;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.apache.commons.lang.Validate;
@@ -140,9 +145,19 @@ enum Instruction {
         android.refuel(inv, target);
     });
 
+    private static final Map<String, Instruction> cacheMap = new HashMap<>();
+
+    public static final Instruction[] values = values();
+
     private final ItemStack item;
     private final AndroidType type;
     private final AndroidAction method;
+
+    static {
+        for (Instruction instruction : values) {
+            cacheMap.put(instruction.name(), instruction);
+        }
+    }
 
     Instruction(AndroidType type, HeadTexture head, AndroidAction method) {
         this.type = type;
@@ -162,9 +177,23 @@ enum Instruction {
         return type;
     }
 
+    @ParametersAreNonnullByDefault
     public void execute(ProgrammableAndroid android, Block b, BlockMenu inventory, BlockFace face) {
         Validate.notNull(method, "Instruction '" + name() + "' must be executed manually!");
         method.perform(android, b, inventory, face);
     }
 
+    /**
+     * Get a value from the cache map rather than calling {@link Enum#valueOf(Class, String)}.
+     * This is 25-40% quicker than the standard {@link Enum#valueOf(Class, String)} depending on
+     * your Java version. It also means that you can avoid an IllegalArgumentException which let's
+     * face it is always good.
+     *
+     * @param value The value which you would like to look up.
+     * @return The {@link Instruction} or null if it does not exist.
+     */
+    @Nullable
+    public static Instruction getFromCache(@Nonnull String value) {
+        return cacheMap.get(value);
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/HeadTexture.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/HeadTexture.java
@@ -109,6 +109,8 @@ public enum HeadTexture {
     IRON_GOLEM("89091d79ea0f59ef7ef94d7bba6e5f17f2f7d4572c44f90f76c4819a714"),
     PIGLIN_HEAD("2882af1294a74023e6919a31d1a027310f2e142afb4667d230d155e7f21dbb41");
 
+    public static final HeadTexture[] values = values();
+
     private final String texture;
 
     HeadTexture(@Nonnull String texture) {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/utils/TestHeadTextures.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/utils/TestHeadTextures.java
@@ -16,7 +16,7 @@ class TestHeadTextures {
     void testForDuplicates() {
         Set<String> textures = new HashSet<>();
 
-        for (HeadTexture head : HeadTexture.values()) {
+        for (HeadTexture head : HeadTexture.values) {
             String texture = head.getTexture();
             Assertions.assertNotNull(texture);
 


### PR DESCRIPTION
## Description
Done some good old micro-optimisations for build #666, pls no [CI Skip]. I ask for so little.

## Changes
* For Enums I have added a global variable to avoid the value array being copied every time `values()` is called.  
Bytecode showing the array is cloned:
```
public static io.github.thebusybiscuit.slimefun4.implementation.items.androids.Instruction[] values();
    Code:
       0: getstatic     #1                  // Field $VALUES:[Lio/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction;
       3: invokevirtual #2                  // Method "[Lio/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction;".clone:()Ljava/lang/Object;
       6: checkcast     #3                  // class "[Lio/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction;"
       9: areturn
```

* Created a cacheMap for Instruction.  
  We frequently call `valueOf(String)` which can be quite slow, luckily we can utilise the speed of hashtable lookups by creating a cache map. This improves performance by about 25-40% depending on the Java version (and if it's Oracle vs OpenJDK). With this, I have also made it return null rather than throwing an exception. This can allow for a much nicer flow, for example, right now I can just do a null check and warn that Slimefun may be outdated.

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [X] I followed the existing code standards and didn't mess up the formatting.
- [X] I did my best to add documentation to any public classes or methods I added.
- [X] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
