### PR TITLE
MachineProcessCompleteEvent

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/GEOResourceGenerationEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/GEOResourceGenerationEvent.java
@@ -17,7 +17,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.geo.GEOScanner;
 
 /**
  * This {@link Event} is fired whenever a {@link GEOResource} is being freshly generated.
- * This only ocurs when a {@link GEOScanner} queries the {@link Chunk} for a {@link GEOResource}
+ * This only occurs when a {@link GEOScanner} queries the {@link Chunk} for a {@link GEOResource}
  * but cannot find it.
  * 
  * You can modify this {@link Event} by listening to it.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
@@ -23,7 +23,7 @@ public class MachineProcessCompleteEvent extends Event {
     private final MachineRecipe machineRecipe;
 
     @ParametersAreNonnullByDefault
-    public MachineProcessCompleteEvent(@Nonnull Block block, @Nonnull MachineRecipe machineRecipe) {
+    public MachineProcessCompleteEvent(Block block, MachineRecipe machineRecipe) {
         this.block = block;
         this.machineRecipe = machineRecipe;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
@@ -6,6 +6,7 @@ import org.bukkit.block.Block;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -22,7 +23,7 @@ public class MachineProcessCompleteEvent extends Event {
     private final MachineRecipe machineRecipe;
 
     @ParametersAreNonnullByDefault
-    public MachineProcessCompleteEvent(Block block, MachineRecipe machineRecipe) {
+    public MachineProcessCompleteEvent(@Nonnull Block block, @Nonnull MachineRecipe machineRecipe) {
         this.block = block;
         this.machineRecipe = machineRecipe;
     }
@@ -31,6 +32,7 @@ public class MachineProcessCompleteEvent extends Event {
      *
      * @return the {@link Block} of the machine
      */
+    @Nonnull
     public Block getMachine() {
         return block;
     }
@@ -39,16 +41,19 @@ public class MachineProcessCompleteEvent extends Event {
      *
      * @return the {@link MachineRecipe} of the process.
      */
+    @Nonnull
     public MachineRecipe getMachineRecipe() {
         return machineRecipe;
     }
 
-    @Override
-    public HandlerList getHandlers() {
+    @Nonnull
+    public static HandlerList getHandlerList() {
         return handlerList;
     }
 
-    public static HandlerList getHandlerList() {
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
         return handlerList;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
@@ -28,7 +28,8 @@ public class MachineProcessCompleteEvent extends Event {
         this.machineRecipe = machineRecipe;
     }
 
-    /** This method returns the {@link Block} of the machine.
+    /**
+     * This method returns the {@link Block} of the machine.
      *
      * @return the {@link Block} of the machine
      */
@@ -37,7 +38,8 @@ public class MachineProcessCompleteEvent extends Event {
         return block;
     }
 
-    /** This returns the used {@link MachineRecipe} in the process.
+    /**
+     * This returns the used {@link MachineRecipe} in the process.
      *
      * @return the {@link MachineRecipe} of the process.
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
@@ -1,0 +1,54 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import org.bukkit.block.Block;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * This {@link Event} is fired whenever an {@link AContainer} has completed its process.
+ *
+ * @author poma123
+ *
+ */
+public class MachineProcessCompleteEvent extends Event {
+
+    private static final HandlerList handlerList = new HandlerList();
+
+    private final Block block;
+    private final MachineRecipe machineRecipe;
+
+    @ParametersAreNonnullByDefault
+    public MachineProcessCompleteEvent(Block block, MachineRecipe machineRecipe) {
+        this.block = block;
+        this.machineRecipe = machineRecipe;
+    }
+
+    /** This method returns the {@link Block} of the machine.
+     *
+     * @return the {@link Block} of the machine
+     */
+    public Block getMachine() {
+        return block;
+    }
+
+    /** This returns the used {@link MachineRecipe} in the process.
+     *
+     * @return the {@link MachineRecipe} of the process.
+     */
+    public MachineRecipe getMachineRecipe() {
+        return machineRecipe;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlerList;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlerList;
+    }
+}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.github.thebusybiscuit.slimefun4.api.events.MachineProcessCompleteEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -253,6 +255,8 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
                 for (ItemStack output : processing.get(b).getOutput()) {
                     inv.pushItem(output.clone(), getOutputSlots());
                 }
+
+                Bukkit.getPluginManager().callEvent(new MachineProcessCompleteEvent(b, getProcessing(b)));
 
                 progress.remove(b);
                 processing.remove(b);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -243,11 +243,8 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
                     }
 
                     removeCharge(b.getLocation(), getEnergyConsumption());
-                    progress.put(b, timeleft - 1);
                 }
-                else {
-                    progress.put(b, timeleft - 1);
-                }
+                progress.put(b, timeleft - 1);
             }
             else {
                 inv.replaceExistingItem(22, new CustomItem(Material.BLACK_STAINED_GLASS_PANE, " "));


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Added MachineProcessCompleteEvent, which fires whenever an AContainer has completed its process. This was the best name I could came up with. If you have a better idea, then tell me.

I can add a Unit Test, if needed.

## Changes
<!-- Please list all the changes you have made. -->
- Added MachineProcessCompleteEvent.class
- Fixed a small typo in GEOResourceGenerationEvent.class
- Added the #callEvent() method to AContainer.class
- Finally a minor impovement in AContainer.class

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
