### PR TITLE
Made MachineProcessCompleteEvent async

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncMachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncMachineProcessCompleteEvent.java
@@ -15,7 +15,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * @author poma123
  *
  */
-public class MachineProcessCompleteEvent extends Event {
+public class AsyncMachineProcessCompleteEvent extends Event {
 
     private static final HandlerList handlerList = new HandlerList();
 
@@ -23,7 +23,7 @@ public class MachineProcessCompleteEvent extends Event {
     private final MachineRecipe machineRecipe;
 
     @ParametersAreNonnullByDefault
-    public MachineProcessCompleteEvent(Block block, MachineRecipe machineRecipe) {
+    public AsyncMachineProcessCompleteEvent(Block block, MachineRecipe machineRecipe) {
         super(true);
         
         this.block = block;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MachineProcessCompleteEvent.java
@@ -24,6 +24,8 @@ public class MachineProcessCompleteEvent extends Event {
 
     @ParametersAreNonnullByDefault
     public MachineProcessCompleteEvent(Block block, MachineRecipe machineRecipe) {
+        super(true);
+        
         this.block = block;
         this.machineRecipe = machineRecipe;
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.github.thebusybiscuit.slimefun4.api.events.MachineProcessCompleteEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.AsyncMachineProcessCompleteEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -253,7 +253,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
                     inv.pushItem(output.clone(), getOutputSlots());
                 }
 
-                Bukkit.getPluginManager().callEvent(new MachineProcessCompleteEvent(b, getProcessing(b)));
+                Bukkit.getPluginManager().callEvent(new AsyncMachineProcessCompleteEvent(b, getProcessing(b)));
 
                 progress.remove(b);
                 processing.remove(b);


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Made the event async, because it is called asynchronously. I didn't notice this tbh, but here I am with the fix.

## Changes
<!-- Please list all the changes you have made. -->
- Made MachineProcessCompleteEvent async
- Renamed to AsyncMachineProcessCompleteEvent

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixed that this sync event was called asynchronously, so I made it async.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
