### PR TITLE
Fixed colors & functionality of cheat sheet

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunGuideListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunGuideListener.java
@@ -62,9 +62,14 @@ public class SlimefunGuideListener implements Listener {
             }
         }
         else if (openGuide(e, SlimefunGuideLayout.CHEAT_SHEET) == Result.ALLOW) {
-            // We rather just run the command here,
-            // all necessary permission checks will be handled there.
-            p.chat("/sf cheat");
+            if (p.isSneaking()) {
+                SlimefunGuideSettings.openSettings(p, e.getItem());
+            }
+            else {
+                // We rather just run the command here,
+                // all necessary permission checks will be handled there.
+                p.chat("/sf cheat");
+            }
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/SlimefunGuideItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/SlimefunGuideItem.java
@@ -33,7 +33,7 @@ public class SlimefunGuideItem extends ItemStack {
         meta.setDisplayName(ChatColors.color(name));
 
         List<String> lore = new LinkedList<>();
-        lore.add(implementation instanceof CheatSheetSlimefunGuide ? "&4&lOnly openable by Admins" : "");
+        lore.add(implementation instanceof CheatSheetSlimefunGuide ? ChatColors.color("&4&lOnly openable by Admins") : "");
         lore.add(ChatColors.color("&eRight Click &8\u21E8 &7Browse Items"));
         lore.add(ChatColors.color("&eShift + Right Click &8\u21E8 &7Open Settings / Credits"));
 


### PR DESCRIPTION
## Description
Fixed non-colored string in Cheat Sheet lore
Fixed Shift + Right Click on Cheat Sheet not opening Settings Menu instead 

## Changes
Added missing coloring to lore in SimefunGuideItem
Added check in SlimefunGuideListener for sneaking in order to open Settings Menu

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
