### PR TITLE
Added AsyncReactorProcessCompleteEvent and AsyncGeneratorProcessCompleteEvent

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncGeneratorProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncGeneratorProcessCompleteEvent.java
@@ -1,0 +1,77 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AGenerator;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+
+/**
+ * This {@link Event} is fired whenever an {@link AGenerator} has completed its process.
+ *
+ * @author poma123
+ *
+ */
+public class AsyncGeneratorProcessCompleteEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Location location;
+    private final AGenerator generator;
+    private final MachineFuel machineFuel;
+
+    @ParametersAreNonnullByDefault
+    public AsyncGeneratorProcessCompleteEvent(Location l, AGenerator generator, MachineFuel machineFuel) {
+        super(true);
+
+        this.location = l;
+        this.generator = generator;
+        this.machineFuel = machineFuel;
+    }
+
+    /**
+     * This returns the {@link Location} of the generator.
+     *
+     * @return The {@link Location} of the generator
+     */
+    @Nonnull
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * The {@link SlimefunItem} instance of the generator.
+     *
+     * @return The {@link SlimefunItem} instance of the generator
+     */
+    @Nonnull
+    public AGenerator getGenerator() {
+        return generator;
+    }
+
+    /**
+     * This returns the used {@link MachineFuel} in the process.
+     *
+     * @return The {@link MachineFuel} of the process
+     */
+    @Nonnull
+    public MachineFuel getMachineFuel() {
+        return machineFuel;
+    }
+
+    @Nonnull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncGeneratorProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncGeneratorProcessCompleteEvent.java
@@ -17,31 +17,19 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
  * @author poma123
  *
  */
-public class AsyncGeneratorProcessCompleteEvent extends Event {
+public class AsyncGeneratorProcessCompleteEvent extends AsyncMachineProcessCompleteEvent {
 
     private static final HandlerList handlers = new HandlerList();
 
-    private final Location location;
     private final AGenerator generator;
     private final MachineFuel machineFuel;
 
     @ParametersAreNonnullByDefault
     public AsyncGeneratorProcessCompleteEvent(Location l, AGenerator generator, MachineFuel machineFuel) {
-        super(true);
+        super(l, null, null);
 
-        this.location = l;
         this.generator = generator;
         this.machineFuel = machineFuel;
-    }
-
-    /**
-     * This returns the {@link Location} of the generator.
-     *
-     * @return The {@link Location} of the generator
-     */
-    @Nonnull
-    public Location getLocation() {
-        return location;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncMachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncMachineProcessCompleteEvent.java
@@ -1,7 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
 import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.Nullable;
 
 import org.bukkit.Location;
 import org.bukkit.event.Event;
@@ -25,8 +25,7 @@ public class AsyncMachineProcessCompleteEvent extends Event {
     private final AContainer container;
     private final MachineRecipe machineRecipe;
 
-    @ParametersAreNonnullByDefault
-    public AsyncMachineProcessCompleteEvent(Location l, AContainer container, MachineRecipe machineRecipe) {
+    public AsyncMachineProcessCompleteEvent(@Nonnull Location l, @Nullable AContainer container, @Nullable MachineRecipe machineRecipe) {
         super(true);
 
         this.location = l;
@@ -49,7 +48,7 @@ public class AsyncMachineProcessCompleteEvent extends Event {
      *
      * @return The {@link SlimefunItem} instance of the machine
      */
-    @Nonnull
+    @Nullable
     public AContainer getMachine() {
         return container;
     }
@@ -59,7 +58,7 @@ public class AsyncMachineProcessCompleteEvent extends Event {
      *
      * @return The {@link MachineRecipe} of the process
      */
-    @Nonnull
+    @Nullable
     public MachineRecipe getMachineRecipe() {
         return machineRecipe;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncMachineProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncMachineProcessCompleteEvent.java
@@ -3,12 +3,13 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.bukkit.block.Block;
+import org.bukkit.Location;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
 /**
  * This {@link Event} is fired whenever an {@link AContainer} has completed its process.
@@ -20,31 +21,43 @@ public class AsyncMachineProcessCompleteEvent extends Event {
 
     private static final HandlerList handlers = new HandlerList();
 
-    private final Block block;
+    private final Location location;
+    private final AContainer container;
     private final MachineRecipe machineRecipe;
 
     @ParametersAreNonnullByDefault
-    public AsyncMachineProcessCompleteEvent(Block block, MachineRecipe machineRecipe) {
+    public AsyncMachineProcessCompleteEvent(Location l, AContainer container, MachineRecipe machineRecipe) {
         super(true);
 
-        this.block = block;
+        this.location = l;
+        this.container = container;
         this.machineRecipe = machineRecipe;
     }
 
     /**
-     * This method returns the {@link Block} of the machine.
+     * This returns the {@link Location} of the machine.
      *
-     * @return the {@link Block} of the machine
+     * @return The {@link Location} of the machine
      */
     @Nonnull
-    public Block getMachine() {
-        return block;
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * The {@link SlimefunItem} instance of the machine.
+     *
+     * @return The {@link SlimefunItem} instance of the machine
+     */
+    @Nonnull
+    public AContainer getMachine() {
+        return container;
     }
 
     /**
      * This returns the used {@link MachineRecipe} in the process.
      *
-     * @return the {@link MachineRecipe} of the process.
+     * @return The {@link MachineRecipe} of the process
      */
     @Nonnull
     public MachineRecipe getMachineRecipe() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncReactorProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncReactorProcessCompleteEvent.java
@@ -17,31 +17,19 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
  * @author poma123
  *
  */
-public class AsyncReactorProcessCompleteEvent extends Event {
+public class AsyncReactorProcessCompleteEvent extends AsyncMachineProcessCompleteEvent {
 
     private static final HandlerList handlers = new HandlerList();
 
-    private final Location location;
     private final Reactor reactor;
     private final MachineFuel machineFuel;
 
     @ParametersAreNonnullByDefault
     public AsyncReactorProcessCompleteEvent(Location l, Reactor reactor, MachineFuel machineFuel) {
-        super(true);
+        super(l, null, null);
 
-        this.location = l;
         this.reactor = reactor;
         this.machineFuel = machineFuel;
-    }
-
-    /**
-     * This returns the {@link Location} of the reactor.
-     *
-     * @return The {@link Location} of the reactor
-     */
-    @Nonnull
-    public Location getLocation() {
-        return location;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncReactorProcessCompleteEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncReactorProcessCompleteEvent.java
@@ -1,0 +1,77 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.electric.reactors.Reactor;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+
+/**
+ * This {@link Event} is fired whenever a {@link Reactor} has completed its process.
+ *
+ * @author poma123
+ *
+ */
+public class AsyncReactorProcessCompleteEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Location location;
+    private final Reactor reactor;
+    private final MachineFuel machineFuel;
+
+    @ParametersAreNonnullByDefault
+    public AsyncReactorProcessCompleteEvent(Location l, Reactor reactor, MachineFuel machineFuel) {
+        super(true);
+
+        this.location = l;
+        this.reactor = reactor;
+        this.machineFuel = machineFuel;
+    }
+
+    /**
+     * This returns the {@link Location} of the reactor.
+     *
+     * @return The {@link Location} of the reactor
+     */
+    @Nonnull
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * The {@link SlimefunItem} instance of the reactor.
+     *
+     * @return The {@link SlimefunItem} instance of the reactor
+     */
+    @Nonnull
+    public Reactor getReactor() {
+        return reactor;
+    }
+
+    /**
+     * This returns the used {@link MachineFuel} in the process.
+     *
+     * @return The {@link MachineFuel} of the process
+     */
+    @Nonnull
+    public MachineFuel getMachineFuel() {
+        return machineFuel;
+    }
+
+    @Nonnull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
+import io.github.thebusybiscuit.slimefun4.api.events.AsyncReactorProcessCompleteEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.ReactorExplodeEvent;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
@@ -375,6 +376,8 @@ public abstract class Reactor extends AbstractEnergyProvider {
                 }
             }
         }
+
+        Bukkit.getPluginManager().callEvent(new AsyncReactorProcessCompleteEvent(l, Reactor.this, getProcessing(l)));
 
         progress.remove(l);
         processing.remove(l);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.github.thebusybiscuit.slimefun4.api.events.AsyncMachineProcessCompleteEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -16,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
+import io.github.thebusybiscuit.slimefun4.api.events.AsyncMachineProcessCompleteEvent;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
@@ -253,7 +253,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
                     inv.pushItem(output.clone(), getOutputSlots());
                 }
 
-                Bukkit.getPluginManager().callEvent(new AsyncMachineProcessCompleteEvent(b, getProcessing(b)));
+                Bukkit.getPluginManager().callEvent(new AsyncMachineProcessCompleteEvent(b.getLocation(), AContainer.this, getProcessing(b)));
 
                 progress.remove(b);
                 processing.remove(b);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -3,6 +3,7 @@ package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -12,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
+import io.github.thebusybiscuit.slimefun4.api.events.AsyncGeneratorProcessCompleteEvent;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.AbstractEnergyProvider;
@@ -162,6 +164,8 @@ public abstract class AGenerator extends AbstractEnergyProvider {
                 }
 
                 inv.replaceExistingItem(22, new CustomItem(Material.BLACK_STAINED_GLASS_PANE, " "));
+
+                Bukkit.getPluginManager().callEvent(new AsyncGeneratorProcessCompleteEvent(l, AGenerator.this, getProcessing(l)));
 
                 progress.remove(l);
                 processing.remove(l);


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Added AsyncGeneratorProcessCompleteEvent which fires whenever an AGenerator has completed its process.
Added AsyncReactorProcessCompleteEvent which fires whenever a Reactor has completed its process.
Also, I changed AsyncMachineProcessCompleteEvent a little bit to be more cleaner.

This time I tested every change carefully.

## Changes
<!-- Please list all the changes you have made. -->
- Added AsyncGeneratorProcessCompleteEvent
- Added AsyncReactorProcessCompleteEvent
- Minor improvement in AsyncMachineProcessCompleteEvent

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
