### PR TITLE
Fixed CargoNetworkTask not checking for other slots before dropping i…

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
@@ -111,7 +111,8 @@ class CargoNetworkTask implements Runnable {
                 if (inv.getItem(previousSlot) == null) {
                     inv.setItem(previousSlot, stack);
                 }
-                else {
+                // Making sure the item cannot be added to another slot before dropping it on ground
+                else if((stack = inv.addItem(stack).get(0)) != null){
                     inputTarget.getWorld().dropItem(inputTarget.getLocation().add(0, 1, 0), stack);
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
@@ -108,12 +108,18 @@ class CargoNetworkTask implements Runnable {
             Inventory inv = inventories.get(inputTarget.getLocation());
 
             if (inv != null) {
+                // Check if the original slot hasn't been occupied in the meantime
                 if (inv.getItem(previousSlot) == null) {
                     inv.setItem(previousSlot, stack);
                 }
-                // Making sure the item cannot be added to another slot before dropping it on ground
-                else if((stack = inv.addItem(stack).get(0)) != null){
-                    inputTarget.getWorld().dropItem(inputTarget.getLocation().add(0, 1, 0), stack);
+                else {
+                    // Try to add the item into another available slot then
+                    ItemStack rest = inv.addItem(stack).get(0);
+                    
+                    if (rest != null) {
+                        // If the item still couldn't be inserted, simply drop it on the ground
+                        inputTarget.getWorld().dropItem(inputTarget.getLocation().add(0, 1, 0), rest);
+                    }
                 }
             }
             else {


### PR DESCRIPTION
…tems on ground

## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
I added a check for other slots for the CargoNetworkTask before items are dropped. It was necessary as it conflicted with storage units from WildChests, as they always return the item of the storage for the same slot.

## Changes
<!-- Please list all the changes you have made. -->
Instead of dropping the items, I also added a check to add items to the source inventory before dropping them.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
None

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
