### PR TITLE
Pull request for an additional customizable option in grappling hooks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
@@ -22,14 +22,14 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
 
-    private final ItemSetting<Boolean> stayininvonuse = new ItemSetting<>("stay-in-inv-on-use", false);
+    private final ItemSetting<Boolean> consumeOnUse = new ItemSetting<>("consume-on-use", true);
     private final ItemSetting<Integer> despawnTicks = new ItemSetting<>("despawn-seconds", 60);
 
     public GrapplingHook(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
         addItemSetting(despawnTicks);
-        addItemSetting(stayininvonuse);
+        addItemSetting(consumeOnUse);
     }
 
     @Override
@@ -37,7 +37,7 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
         return e -> {
             Player p = e.getPlayer();
             UUID uuid = p.getUniqueId();
-            Boolean keepininv = stayininvonuse.getValue();
+            boolean consumeOnUseValue = consumeOnUse.getValue();
 
             if (!e.getClickedBlock().isPresent() && !SlimefunPlugin.getGrapplingHookListener().isGrappling(uuid)) {
                 e.cancel();
@@ -50,8 +50,8 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 ItemStack item = e.getItem();
 
                 if (item.getType() == Material.LEAD) {
-                    if (!keepininv) {
-                        item.setAmount(item.getAmount() - 1);
+                    if (consumeOnUseValue) {
+                        item.setAmount(item.getAmount() - 1); //If consume on use is enabled, this line will take 1 grappling hook out of player's hand
                     }
                 }
 
@@ -68,7 +68,7 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 bat.setLeashHolder(arrow);
 
                 boolean state = item.getType() != Material.SHEARS;
-                SlimefunPlugin.getGrapplingHookListener().addGrapplingHook(p, arrow, bat, state, despawnTicks.getValue(), keepininv);
+                SlimefunPlugin.getGrapplingHookListener().addGrapplingHook(p, arrow, bat, state, despawnTicks.getValue(), consumeOnUseValue);
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
@@ -50,8 +50,9 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 ItemStack item = e.getItem();
 
                 if (item.getType() == Material.LEAD) {
+                    //If consume on use is enabled, the if statement below will take 1 grappling hook out of player's hand
                     if (consumeOnUseValue) {
-                        item.setAmount(item.getAmount() - 1); //If consume on use is enabled, this line will take 1 grappling hook out of player's hand
+                        item.setAmount(item.getAmount() - 1);
                     }
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
@@ -22,6 +22,7 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
 
+    private final ItemSetting<Boolean> stayininvonuse = new ItemSetting<>("stay-in-inv-on-use", false); //this set to false will override despawnTicks option
     private final ItemSetting<Integer> despawnTicks = new ItemSetting<>("despawn-seconds", 60);
 
     public GrapplingHook(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -47,7 +48,9 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 ItemStack item = e.getItem();
 
                 if (item.getType() == Material.LEAD) {
-                    item.setAmount(item.getAmount() - 1);
+                    if (!stayininvonuse.getValue()) {
+                        item.setAmount(item.getAmount() - 1);
+                    }
                 }
 
                 Vector direction = p.getEyeLocation().getDirection().multiply(2.0);
@@ -62,8 +65,10 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 bat.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 100000, 100000));
                 bat.setLeashHolder(arrow);
 
-                boolean state = item.getType() != Material.SHEARS;
-                SlimefunPlugin.getGrapplingHookListener().addGrapplingHook(p, arrow, bat, state, despawnTicks.getValue());
+                if (!stayininvonuse.getValue()) {
+                    boolean state = item.getType() != Material.SHEARS;
+                    SlimefunPlugin.getGrapplingHookListener().addGrapplingHook(p, arrow, bat, state, despawnTicks.getValue());
+                }
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
@@ -22,13 +22,14 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
 
-    private final ItemSetting<Boolean> stayininvonuse = new ItemSetting<>("stay-in-inv-on-use", false); //this set to false will override despawnTicks option
+    private final ItemSetting<Boolean> stayininvonuse = new ItemSetting<>("stay-in-inv-on-use", false);
     private final ItemSetting<Integer> despawnTicks = new ItemSetting<>("despawn-seconds", 60);
 
     public GrapplingHook(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
         addItemSetting(despawnTicks);
+        addItemSetting(stayininvonuse);
     }
 
     @Override
@@ -36,6 +37,7 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
         return e -> {
             Player p = e.getPlayer();
             UUID uuid = p.getUniqueId();
+            Boolean keepininv = stayininvonuse.getValue();
 
             if (!e.getClickedBlock().isPresent() && !SlimefunPlugin.getGrapplingHookListener().isGrappling(uuid)) {
                 e.cancel();
@@ -48,7 +50,7 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 ItemStack item = e.getItem();
 
                 if (item.getType() == Material.LEAD) {
-                    if (!stayininvonuse.getValue()) {
+                    if (!keepininv) {
                         item.setAmount(item.getAmount() - 1);
                     }
                 }
@@ -65,10 +67,8 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 bat.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 100000, 100000));
                 bat.setLeashHolder(arrow);
 
-                if (!stayininvonuse.getValue()) {
-                    boolean state = item.getType() != Material.SHEARS;
-                    SlimefunPlugin.getGrapplingHookListener().addGrapplingHook(p, arrow, bat, state, despawnTicks.getValue());
-                }
+                boolean state = item.getType() != Material.SHEARS;
+                SlimefunPlugin.getGrapplingHookListener().addGrapplingHook(p, arrow, bat, state, despawnTicks.getValue(), keepininv);
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookEntity.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookEntity.java
@@ -15,13 +15,14 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 final class GrapplingHookEntity {
 
     private final boolean dropItem;
-
+    private final boolean keepininv;
     private final Arrow arrow;
     private final Entity leashTarget;
 
     @ParametersAreNonnullByDefault
-    GrapplingHookEntity(Player p, Arrow arrow, Entity leashTarget, boolean dropItem) {
+    GrapplingHookEntity(Player p, Arrow arrow, Entity leashTarget, boolean dropItem, boolean keepininv) {
         this.arrow = arrow;
+        this.keepininv = keepininv;
         this.leashTarget = leashTarget;
         this.dropItem = p.getGameMode() != GameMode.CREATIVE && dropItem;
     }
@@ -33,8 +34,10 @@ final class GrapplingHookEntity {
 
     public void drop(@Nonnull Location l) {
         if (dropItem) {
-            Item item = l.getWorld().dropItem(l, SlimefunItems.GRAPPLING_HOOK.clone());
-            item.setPickupDelay(16);
+            if (!keepininv) {
+                Item item = l.getWorld().dropItem(l, SlimefunItems.GRAPPLING_HOOK.clone());
+                item.setPickupDelay(16);
+            }
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookEntity.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookEntity.java
@@ -34,10 +34,11 @@ final class GrapplingHookEntity {
 
     public void drop(@Nonnull Location l) {
         if (dropItem) {
+            //If a grappling hook was consumed, then the below if statement will be executed and will drop one grappling hook on the floor
             if (wasConsumed) {
                 Item item = l.getWorld().dropItem(l, SlimefunItems.GRAPPLING_HOOK.clone());
                 item.setPickupDelay(16);
-            } //If a grappling hook was consumed, then this will drop one on the floor
+            }
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookEntity.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookEntity.java
@@ -15,14 +15,14 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 final class GrapplingHookEntity {
 
     private final boolean dropItem;
-    private final boolean keepininv;
+    private final boolean wasConsumed;
     private final Arrow arrow;
     private final Entity leashTarget;
 
     @ParametersAreNonnullByDefault
-    GrapplingHookEntity(Player p, Arrow arrow, Entity leashTarget, boolean dropItem, boolean keepininv) {
+    GrapplingHookEntity(Player p, Arrow arrow, Entity leashTarget, boolean dropItem, boolean wasConsumed) {
         this.arrow = arrow;
-        this.keepininv = keepininv;
+        this.wasConsumed = wasConsumed;
         this.leashTarget = leashTarget;
         this.dropItem = p.getGameMode() != GameMode.CREATIVE && dropItem;
     }
@@ -34,10 +34,10 @@ final class GrapplingHookEntity {
 
     public void drop(@Nonnull Location l) {
         if (dropItem) {
-            if (!keepininv) {
+            if (wasConsumed) {
                 Item item = l.getWorld().dropItem(l, SlimefunItems.GRAPPLING_HOOK.clone());
                 item.setPickupDelay(16);
-            }
+            } //If a grappling hook was consumed, then this will drop one on the floor
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookListener.java
@@ -183,8 +183,8 @@ public class GrapplingHookListener implements Listener {
     }
 
     @ParametersAreNonnullByDefault
-    public void addGrapplingHook(Player p, Arrow arrow, Bat bat, boolean dropItem, long despawnTicks) {
-        GrapplingHookEntity hook = new GrapplingHookEntity(p, arrow, bat, dropItem);
+    public void addGrapplingHook(Player p, Arrow arrow, Bat bat, boolean dropItem, long despawnTicks, boolean keepininv) {
+        GrapplingHookEntity hook = new GrapplingHookEntity(p, arrow, bat, dropItem, keepininv);
         UUID uuid = p.getUniqueId();
 
         activeHooks.put(uuid, hook);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GrapplingHookListener.java
@@ -183,8 +183,8 @@ public class GrapplingHookListener implements Listener {
     }
 
     @ParametersAreNonnullByDefault
-    public void addGrapplingHook(Player p, Arrow arrow, Bat bat, boolean dropItem, long despawnTicks, boolean keepininv) {
-        GrapplingHookEntity hook = new GrapplingHookEntity(p, arrow, bat, dropItem, keepininv);
+    public void addGrapplingHook(Player p, Arrow arrow, Bat bat, boolean dropItem, long despawnTicks, boolean wasConsumed) {
+        GrapplingHookEntity hook = new GrapplingHookEntity(p, arrow, bat, dropItem, wasConsumed);
         UUID uuid = p.getUniqueId();
 
         activeHooks.put(uuid, hook);


### PR DESCRIPTION
[+] Added a setting to allow the grappling hook to stay in inventory instead of being dropped on the floor on use

## Description
I added an item setting to allow players to set if they want the grappling hook to drop on the floor on use or just stay in the inventory. I did this because I use slimefun on a small server with friends and they complained about the grappling hooks dropping on the floor as annoying

## Changes
[+] Item Setting named "stay-in-inv-on-use"

## Related Issues
None

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
