### PR TITLE
Separate player-only and no-permission messages

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BackpackCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BackpackCommand.java
@@ -61,7 +61,8 @@ class BackpackCommand extends SubCommand {
                         SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.restored-backpack-given");
                     });
                 });
-            } else {
+            }
+            else {
                 SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BackpackCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BackpackCommand.java
@@ -26,43 +26,47 @@ class BackpackCommand extends SubCommand {
 
     @Override
     public void onExecute(CommandSender sender, String[] args) {
-        if (!(sender instanceof Player) || !sender.hasPermission("slimefun.command.backpack")) {
-            SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);
-            return;
-        }
+        if (sender instanceof Player) {
+            if (sender.hasPermission("slimefun.command.backpack")) {
+                if (args.length != 3) {
+                    SlimefunPlugin.getLocalization().sendMessage(sender, "messages.usage", true, msg -> msg.replace("%usage%", "/sf backpack <Player> <ID>"));
+                    return;
+                }
 
-        if (args.length != 3) {
-            SlimefunPlugin.getLocalization().sendMessage(sender, "messages.usage", true, msg -> msg.replace("%usage%", "/sf backpack <Player> <ID>"));
-            return;
-        }
+                if (!PatternUtils.NUMERIC.matcher(args[2]).matches()) {
+                    SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.invalid-id");
+                    return;
+                }
 
-        if (!PatternUtils.NUMERIC.matcher(args[2]).matches()) {
-            SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.invalid-id");
-            return;
-        }
+                @SuppressWarnings("deprecation")
+                OfflinePlayer backpackOwner = Bukkit.getOfflinePlayer(args[1]);
 
-        @SuppressWarnings("deprecation")
-        OfflinePlayer backpackOwner = Bukkit.getOfflinePlayer(args[1]);
+                if (!(backpackOwner instanceof Player) && !backpackOwner.hasPlayedBefore()) {
+                    SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.player-never-joined");
+                    return;
+                }
 
-        if (!(backpackOwner instanceof Player) && !backpackOwner.hasPlayedBefore()) {
-            SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.player-never-joined");
-            return;
-        }
+                int id = Integer.parseInt(args[2]);
 
-        int id = Integer.parseInt(args[2]);
+                PlayerProfile.get(backpackOwner, profile -> {
+                    if (!profile.getBackpack(id).isPresent()) {
+                        SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.backpack-does-not-exist");
+                        return;
+                    }
 
-        PlayerProfile.get(backpackOwner, profile -> {
-            if (!profile.getBackpack(id).isPresent()) {
-                SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.backpack-does-not-exist");
-                return;
+                    SlimefunPlugin.runSync(() -> {
+                        ItemStack item = SlimefunItems.RESTORED_BACKPACK.clone();
+                        SlimefunPlugin.getBackpackListener().setBackpackId(backpackOwner, item, 2, id);
+                        ((Player) sender).getInventory().addItem(item);
+                        SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.restored-backpack-given");
+                    });
+                });
+            } else {
+                SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);
             }
-
-            SlimefunPlugin.runSync(() -> {
-                ItemStack item = SlimefunItems.RESTORED_BACKPACK.clone();
-                SlimefunPlugin.getBackpackListener().setBackpackId(backpackOwner, item, 2, id);
-                ((Player) sender).getInventory().addItem(item);
-                SlimefunPlugin.getLocalization().sendMessage(sender, "commands.backpack.restored-backpack-given");
-            });
-        });
+        }
+        else {
+            SlimefunPlugin.getLocalization().sendMessage(sender, "messages.only-players", true);
+        }
     }
 }


### PR DESCRIPTION
## Description
All other commands have a separate message for player-only and no-permission messages, while backpackcommand instead just sent a no-permission message for both cases. I have split it so it sends the appropriate message for the appropriate case.

## Changes
Split checks in BackpackCommand.java for `no-permission` and `player-only` messages

## Related Issues
N/A

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
