### PR TITLE
Fixed GoldPan entity interaction

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -15,6 +15,7 @@ import io.github.thebusybiscuit.cscorelib2.collections.RandomizedSet;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
+import io.github.thebusybiscuit.slimefun4.core.handlers.EntityInteractHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
@@ -47,6 +48,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
 
         drops.addAll(getGoldPanDrops());
         addItemSetting(drops.toArray(new GoldPanDrop[0]));
+        addItemHandler(onEntityInteract());
     }
 
     protected Material getInput() {
@@ -113,6 +115,16 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
 
             e.cancel();
         };
+    }
+
+    /**
+     * This method cancels {@link EntityInteractHandler} to prevent interacting {@link GoldPan}
+     * with entities.
+     *
+     * @return the {@link EntityInteractHandler} of this {@link SlimefunItem}
+     */
+    public EntityInteractHandler onEntityInteract() {
+        return (e, item, offHand) -> e.setCancelled(true);
     }
 
     @Override


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Added a cancelled EntityInteractHandler to prevent interacting GoldPans with entities.

## Changes
<!-- Please list all the changes you have made. -->
- Added a cancelled EntityInteractHandler

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #2356 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
