### PR TITLE
Added seasonal categories to the Cheat Sheet

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
@@ -1,8 +1,11 @@
 package io.github.thebusybiscuit.slimefun4.implementation.guide;
 
+import javax.annotation.Nonnull;
+
 import java.util.LinkedList;
 import java.util.List;
 
+import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
@@ -39,6 +42,16 @@ public class CheatSheetSlimefunGuide extends ChestSlimefunGuide {
         return false;
     }
 
+    /**
+     * Returns a {@link List} of visible {@link Category} instances that the {@link SlimefunGuide} would display.
+     *
+     * @param p
+     *            The {@link Player} who opened his {@link SlimefunGuide}
+     * @param profile
+     *            The {@link PlayerProfile} of the {@link Player}
+     * @return a {@link List} of visible {@link Category} instances
+     */
+    @Nonnull
     @Override
     protected List<Category> getVisibleCategories(Player p, PlayerProfile profile) {
         List<Category> categories = new LinkedList<>();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
@@ -53,7 +53,7 @@ public class CheatSheetSlimefunGuide extends ChestSlimefunGuide {
      */
     @Nonnull
     @Override
-    protected List<Category> getVisibleCategories(Player p, PlayerProfile profile) {
+    protected List<Category> getVisibleCategories(@Nonnull Player p, @Nonnull PlayerProfile profile) {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
@@ -1,14 +1,20 @@
 package io.github.thebusybiscuit.slimefun4.implementation.guide;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
+import io.github.thebusybiscuit.slimefun4.core.categories.FlexCategory;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideLayout;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.SlimefunGuideItem;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
+import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
 /**
@@ -31,6 +37,19 @@ public class CheatSheetSlimefunGuide extends ChestSlimefunGuide {
     @Override
     public boolean isSurvivalMode() {
         return false;
+    }
+
+    @Override
+    protected List<Category> getVisibleCategories(Player p, PlayerProfile profile) {
+        List<Category> categories = new LinkedList<>();
+
+        for (Category category : SlimefunPlugin.getRegistry().getCategories()) {
+            if (!(category instanceof FlexCategory)) {
+                categories.add(category);
+            }
+        }
+
+        return categories;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -1,5 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.implementation.guide;
 
+import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -96,7 +98,16 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         return true;
     }
 
-    protected List<Category> getVisibleCategories(Player p, PlayerProfile profile) {
+    /**
+     * Returns a {@link List} of visible {@link Category} instances that the {@link SlimefunGuide} would display.
+     *
+     * @param p
+     *            The {@link Player} who opened his {@link SlimefunGuide}
+     * @param profile
+     *            The {@link PlayerProfile} of the {@link Player}
+     * @return a {@link List} of visible {@link Category} instances
+     */
+    protected List<Category> getVisibleCategories(@Nonnull Player p, @Nonnull PlayerProfile profile) {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -107,6 +107,7 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
      *            The {@link PlayerProfile} of the {@link Player}
      * @return a {@link List} of visible {@link Category} instances
      */
+    @Nonnull
     protected List<Category> getVisibleCategories(@Nonnull Player p, @Nonnull PlayerProfile profile) {
         List<Category> categories = new LinkedList<>();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -29,7 +29,6 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.core.categories.FlexCategory;
 import io.github.thebusybiscuit.slimefun4.core.categories.LockedCategory;
-import io.github.thebusybiscuit.slimefun4.core.categories.SeasonalCategory;
 import io.github.thebusybiscuit.slimefun4.core.guide.GuideHistory;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
@@ -101,10 +100,8 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {
-            if ((!isSurvivalMode() && category instanceof SeasonalCategory) || !category.isHidden(p)) {
-                if (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getLayout())) {
-                    categories.add(category);
-                }
+            if (!category.isHidden(p) && (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getLayout()))) {
+                categories.add(category);
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -29,6 +29,7 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.core.categories.FlexCategory;
 import io.github.thebusybiscuit.slimefun4.core.categories.LockedCategory;
+import io.github.thebusybiscuit.slimefun4.core.categories.SeasonalCategory;
 import io.github.thebusybiscuit.slimefun4.core.guide.GuideHistory;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
@@ -100,7 +101,7 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {
-            if (!category.isHidden(p) && (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getLayout()))) {
+            if (((!isSurvivalMode() && category instanceof SeasonalCategory) || !category.isHidden(p)) && (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getLayout()))) {
                 categories.add(category);
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -101,8 +101,10 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {
-            if (((!isSurvivalMode() && category instanceof SeasonalCategory) || !category.isHidden(p)) && (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getLayout()))) {
-                categories.add(category);
+            if ((!isSurvivalMode() && category instanceof SeasonalCategory) || !category.isHidden(p)) {
+                if (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getLayout())) {
+                    categories.add(category);
+                }
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -96,7 +96,7 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         return true;
     }
 
-    private List<Category> getVisibleCategories(Player p, PlayerProfile profile) {
+    protected List<Category> getVisibleCategories(Player p, PlayerProfile profile) {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Added a check to ChestSlimefunGuide#getVisibleCategories that adds SeasonalCategories to Cheat Sheets. I think this is logically fine, but if it could be simplified then tell me.

<details><summary><b>Some screenshots (Click me!)</b></summary>
<img src="https://user-images.githubusercontent.com/25465545/94732679-ddf06980-0366-11eb-814d-f273117d31f4.png">
</img>

Haha, in less than a month:
<img src="https://user-images.githubusercontent.com/25465545/94732739-efd20c80-0366-11eb-936f-815d6268ca43.png"></img>
TheBusySanta:
<img src="https://user-images.githubusercontent.com/25465545/94732853-214ad800-0367-11eb-956f-9d5ff188fcb2.png"></img>
</details>

## Changes
<!-- Please list all the changes you have made. -->
- Added seasonal categories to the Cheat Sheet

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #2316 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
