### PR TITLE
Attempt to fix bug #2360

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
@@ -62,6 +62,7 @@ public class BlockPhysicsListener implements Listener {
             for (Block b : e.getBlocks()) {
                 if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
                     e.setCancelled(true);
+                    break;
                 }
             }
         }
@@ -76,6 +77,7 @@ public class BlockPhysicsListener implements Listener {
             for (Block b : e.getBlocks()) {
                 if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
                     e.setCancelled(true);
+                    break;
                 }
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
@@ -62,7 +62,6 @@ public class BlockPhysicsListener implements Listener {
             for (Block b : e.getBlocks()) {
                 if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
                     e.setCancelled(true);
-                    return;
                 }
             }
         }
@@ -77,7 +76,6 @@ public class BlockPhysicsListener implements Listener {
             for (Block b : e.getBlocks()) {
                 if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
                     e.setCancelled(true);
-                    return;
                 }
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
@@ -32,6 +32,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
  * @author VoidAngel
  * @author Poslovitch
  * @author TheBusyBiscuit
+ * @author AccelShark
  *
  */
 public class BlockPhysicsListener implements Listener {
@@ -54,17 +55,23 @@ public class BlockPhysicsListener implements Listener {
 
     @EventHandler
     public void onPistonExtend(BlockPistonExtendEvent e) {
-        for (Block b : e.getBlocks()) {
-            if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
-                e.setCancelled(true);
-                return;
+        if(BlockStorage.check(e.getBlock()) != null) {
+            e.setCancelled(true);
+        } else {
+            for (Block b : e.getBlocks()) {
+                if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
+                    e.setCancelled(true);
+                    return;
+                }
             }
         }
     }
 
     @EventHandler
     public void onPistonRetract(BlockPistonRetractEvent e) {
-        if (e.isSticky()) {
+        if(BlockStorage.check(e.getBlock()) != null) {
+            e.setCancelled(true);
+        } else if (e.isSticky()) {
             for (Block b : e.getBlocks()) {
                 if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
                     e.setCancelled(true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockPhysicsListener.java
@@ -55,9 +55,10 @@ public class BlockPhysicsListener implements Listener {
 
     @EventHandler
     public void onPistonExtend(BlockPistonExtendEvent e) {
-        if(BlockStorage.check(e.getBlock()) != null) {
+        if (BlockStorage.hasBlockInfo(e.getBlock())) {
             e.setCancelled(true);
-        } else {
+        }
+        else {
             for (Block b : e.getBlocks()) {
                 if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
                     e.setCancelled(true);
@@ -69,9 +70,10 @@ public class BlockPhysicsListener implements Listener {
 
     @EventHandler
     public void onPistonRetract(BlockPistonRetractEvent e) {
-        if(BlockStorage.check(e.getBlock()) != null) {
+        if (BlockStorage.hasBlockInfo(e.getBlock())) {
             e.setCancelled(true);
-        } else if (e.isSticky()) {
+        } 
+        else if (e.isSticky()) {
             for (Block b : e.getBlocks()) {
                 if (BlockStorage.hasBlockInfo(b) || (b.getRelative(e.getDirection()).getType() == Material.AIR && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection())))) {
                     e.setCancelled(true);


### PR DESCRIPTION
## Description
Attempt to fix a bug where refineries can be used as pistons
## Changes
Checks if the following condition has been met (Check if the event fired on a piston that has Slimefun block data)
```java
BlockStorage.check(e.getBlock()) != null
```

## Related Issues
Resolves #2360 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
