### PR TITLE
Cartography Table fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -99,8 +99,8 @@ public class VanillaMachinesListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onCartographyTable(InventoryClickEvent e) {
-        if (e.getRawSlot() == 2 && e.getInventory().getType() == InventoryType.CARTOGRAPHY
-                && e.getWhoClicked() instanceof Player) {
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_14) && e.getRawSlot() == 2
+                && e.getInventory().getType() == InventoryType.CARTOGRAPHY && e.getWhoClicked() instanceof Player) {
             ItemStack item1 = e.getInventory().getContents()[0];
             ItemStack item2 = e.getInventory().getContents()[1];
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -99,7 +99,8 @@ public class VanillaMachinesListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onCartographyTable(InventoryClickEvent e) {
-        if (e.getRawSlot() == 2 && e.getInventory().getType() == InventoryType.CARTOGRAPHY && e.getWhoClicked() instanceof Player) {
+        if (e.getRawSlot() == 2 && e.getInventory().getType() == InventoryType.CARTOGRAPHY
+                && e.getWhoClicked() instanceof Player) {
             ItemStack item1 = e.getInventory().getContents()[0];
             ItemStack item2 = e.getInventory().getContents()[1];
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -99,8 +99,13 @@ public class VanillaMachinesListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onCartographyTable(InventoryClickEvent e) {
-        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_14) && e.getRawSlot() == 2
-                && e.getInventory().getType() == InventoryType.CARTOGRAPHY && e.getWhoClicked() instanceof Player) {
+        // The Cartography Table was only ever added in MC 1.14
+        MinecraftVersion minecraftVersion = SlimefunPlugin.getMinecraftVersion();
+        if (!minecraftVersion.isAtLeast(MinecraftVersion.MINECRAFT_1_14)) {
+            return;
+        }
+        
+        if (e.getRawSlot() == 2 && e.getInventory().getType() == InventoryType.CARTOGRAPHY && e.getWhoClicked() instanceof Player) {
             ItemStack item1 = e.getInventory().getContents()[0];
             ItemStack item2 = e.getInventory().getContents()[1];
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -41,8 +41,7 @@ public class VanillaMachinesListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onGrindstone(InventoryClickEvent e) {
         // The Grindstone was only ever added in MC 1.14
-        MinecraftVersion minecraftVersion = SlimefunPlugin.getMinecraftVersion();
-        if (!minecraftVersion.isAtLeast(MinecraftVersion.MINECRAFT_1_14)) {
+        if (!SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_14)) {
             return;
         }
 
@@ -100,8 +99,7 @@ public class VanillaMachinesListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onCartographyTable(InventoryClickEvent e) {
         // The Cartography Table was only ever added in MC 1.14
-        MinecraftVersion minecraftVersion = SlimefunPlugin.getMinecraftVersion();
-        if (!minecraftVersion.isAtLeast(MinecraftVersion.MINECRAFT_1_14)) {
+        if (!SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_14)) {
             return;
         }
         

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -98,6 +98,19 @@ public class VanillaMachinesListener implements Listener {
     }
 
     @EventHandler(ignoreCancelled = true)
+    public void onCartographyTable(InventoryClickEvent e) {
+        if (e.getRawSlot() == 2 && e.getInventory().getType() == InventoryType.CARTOGRAPHY && e.getWhoClicked() instanceof Player) {
+            ItemStack item1 = e.getInventory().getContents()[0];
+            ItemStack item2 = e.getInventory().getContents()[1];
+
+            if (checkForUnallowedItems(item1, item2)) {
+                e.setResult(Result.DENY);
+                SlimefunPlugin.getLocalization().sendMessage((Player) e.getWhoClicked(), "cartography_table.not-working", true);
+            }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
     public void onPreBrew(InventoryClickEvent e) {
         Inventory clickedInventory = e.getClickedInventory();
         Inventory topInventory = e.getView().getTopInventory();

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -264,6 +264,9 @@ anvil:
 brewing_stand:
   not-working: '&4You cannot use Slimefun Items in a brewing stand!'
 
+cartography_table:
+  not-working: '&4You cannot use Slimefun Items in a cartography table!'
+
 villagers:
   no-trading: '&4You cannot trade Slimefun Items with Villagers!'
 

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -259,23 +259,23 @@ machines:
     finished: '&eYour Industrial Miner has finished! It obtained a total of %ores% ore(s)!'
     
 anvil:
-  not-working: '&4You cannot use Slimefun Items in an anvil!'
+  not-working: '&4You cannot use Slimefun items in an anvil!'
 
 brewing_stand:
-  not-working: '&4You cannot use Slimefun Items in a brewing stand!'
+  not-working: '&4You cannot use Slimefun items in a brewing stand!'
 
 cartography_table:
-  not-working: '&4You cannot use Slimefun Items in a cartography table!'
+  not-working: '&4You cannot use Slimefun items in a cartography table!'
 
 villagers:
-  no-trading: '&4You cannot trade Slimefun Items with Villagers!'
+  no-trading: '&4You cannot trade Slimefun items with Villagers!'
 
 backpack:
   already-open: '&cSorry, this Backpack is open somewhere else!'
   no-stack: '&cYou cannot stack Backpacks'
 
 workbench:
-  not-enhanced: '&4You cannot use Slimefun Items in a normal workbench'
+  not-enhanced: '&4You cannot use Slimefun items in a normal workbench'
 
 gps:
   deathpoint: '&4Deathpoint &7%date%'

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestVanillaMachinesListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestVanillaMachinesListener.java
@@ -76,6 +76,16 @@ public class TestVanillaMachinesListener {
         return event;
     }
 
+    private InventoryClickEvent mockCartographyTableEvent(ItemStack item) {
+        Player player = server.addPlayer();
+        Inventory inv = TestUtilities.mockInventory(InventoryType.CARTOGRAPHY, new ItemStack(Material.FILLED_MAP), item, new ItemStack(Material.FILLED_MAP));
+        InventoryView view = player.openInventory(inv);
+        InventoryClickEvent event = new InventoryClickEvent(view, SlotType.CONTAINER, 2, ClickType.LEFT, InventoryAction.PICKUP_ONE);
+
+        listener.onCartographyTable(event);
+        return event;
+    }
+
     private InventoryClickEvent mockBrewingEvent(ItemStack item) {
         Player player = server.addPlayer();
         Inventory inv = TestUtilities.mockInventory(InventoryType.BREWING);
@@ -239,6 +249,30 @@ public class TestVanillaMachinesListener {
         item.register(plugin);
 
         InventoryClickEvent event = mockAnvilEvent(item.getItem());
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+    @Test
+    public void testCartographyTableWithoutSlimefunItems() {
+        InventoryClickEvent event = mockCartographyTableEvent(new ItemStack(Material.PAPER));
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+    @Test
+    public void testCartographyTableWithSlimefunItem() {
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCKED_PAPER", new CustomItem(Material.PAPER, "&6Mock"));
+        item.register(plugin);
+
+        InventoryClickEvent event = mockCartographyTableEvent(item.getItem());
+        Assertions.assertEquals(Result.DENY, event.getResult());
+    }
+
+    @Test
+    public void testCartographyTableWithVanillaItem() {
+        VanillaItem item = TestUtilities.mockVanillaItem(plugin, Material.PAPER, true);
+        item.register(plugin);
+
+        InventoryClickEvent event = mockCartographyTableEvent(item.getItem());
         Assertions.assertEquals(Result.DEFAULT, event.getResult());
     }
 


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Added an EventHandler to `VanillaMachinesListener` class to prevent Slimefun items from being used in Cartography Tables.

## Changes
<!-- Please list all the changes you have made. -->
- Added `onCartographyTable()` EventHandler to `VanillaMachinesListener` class
- Added Unit Tests
- Added `cartography_table.not-working` message to `messages_en.yml`

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #2357 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those checkboxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.