### PR TITLE
Add remaining carat golds to ore crusher

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -54,34 +54,34 @@ public class OreCrusher extends MultiBlockMachine {
         recipes.add(SlimefunItems.GOLD_DUST);
 
         recipes.add(SlimefunItems.GOLD_6K);
-        recipes.add(SlimefunItems.GOLD_DUST);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
 
         recipes.add(SlimefunItems.GOLD_8K);
-        recipes.add(SlimefunItems.GOLD_DUST);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
 
         recipes.add(SlimefunItems.GOLD_10K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
 
         recipes.add(SlimefunItems.GOLD_12K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
 
         recipes.add(SlimefunItems.GOLD_14K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 4));
 
         recipes.add(SlimefunItems.GOLD_16K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 4));
 
         recipes.add(SlimefunItems.GOLD_18K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 5));
 
         recipes.add(SlimefunItems.GOLD_20K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 5));
 
         recipes.add(SlimefunItems.GOLD_22K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 6));
 
         recipes.add(SlimefunItems.GOLD_24K);
-        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 6));
 
         recipes.add(new ItemStack(Material.GRAVEL));
         recipes.add(new ItemStack(Material.SAND));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -53,6 +53,36 @@ public class OreCrusher extends MultiBlockMachine {
         recipes.add(SlimefunItems.GOLD_4K);
         recipes.add(SlimefunItems.GOLD_DUST);
 
+        recipes.add(SlimefunItems.GOLD_6K);
+        recipes.add(SlimefunItems.GOLD_DUST);
+
+        recipes.add(SlimefunItems.GOLD_8K);
+        recipes.add(SlimefunItems.GOLD_DUST);
+
+        recipes.add(SlimefunItems.GOLD_10K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+
+        recipes.add(SlimefunItems.GOLD_12K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+
+        recipes.add(SlimefunItems.GOLD_14K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+
+        recipes.add(SlimefunItems.GOLD_16K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 2));
+
+        recipes.add(SlimefunItems.GOLD_18K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+
+        recipes.add(SlimefunItems.GOLD_20K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+
+        recipes.add(SlimefunItems.GOLD_22K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+
+        recipes.add(SlimefunItems.GOLD_24K);
+        recipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, 3));
+
         recipes.add(new ItemStack(Material.GRAVEL));
         recipes.add(new ItemStack(Material.SAND));
 


### PR DESCRIPTION
## Description
Add all Carat Gold types to the Ore Crusher. As suggested (and approved) on the Discord.

## Changes
Added following recipes in the file `OreCrusher.java`, in the method `registerDefaultRecipes(List<ItemStack> recipes)`:
- 6 - 8 carat gold now yields 1 gold dust
- 10 - 16 carat gold now yields 2 gold dust
- 18 - 24 carat gold now yields 3 gold dust

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
<br>
  
These are not really viable in my situation:
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
