### PR TITLE
Define a constant instead of duplicating "backpacks."

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerBackpack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerBackpack.java
@@ -34,6 +34,7 @@ public class PlayerBackpack {
 
     private Inventory inventory;
     private int size;
+    private static final String CONFIG_PREFIX = "backpacks.";
 
     /**
      * This constructor loads an existing Backpack
@@ -44,10 +45,10 @@ public class PlayerBackpack {
      *            The id of this Backpack
      */
     public PlayerBackpack(@Nonnull PlayerProfile profile, int id) {
-        this(profile, id, profile.getConfig().getInt("backpacks." + id + ".size"));
+        this(profile, id, profile.getConfig().getInt(CONFIG_PREFIX + id + ".size"));
 
         for (int i = 0; i < size; i++) {
-            inventory.setItem(i, cfg.getItem("backpacks." + id + ".contents." + i));
+            inventory.setItem(i, cfg.getItem(CONFIG_PREFIX + id + ".contents." + i));
         }
     }
 
@@ -71,7 +72,7 @@ public class PlayerBackpack {
         this.cfg = profile.getConfig();
         this.size = size;
 
-        cfg.setValue("backpacks." + id + ".size", size);
+        cfg.setValue(CONFIG_PREFIX + id + ".size", size);
         markDirty();
 
         inventory = Bukkit.createInventory(null, size, "Backpack [" + size + " Slots]");
@@ -142,7 +143,7 @@ public class PlayerBackpack {
         }
 
         this.size = size;
-        cfg.setValue("backpacks." + id + ".size", size);
+        cfg.setValue(CONFIG_PREFIX + id + ".size", size);
 
         Inventory inv = Bukkit.createInventory(null, size, "Backpack [" + size + " Slots]");
 
@@ -160,7 +161,7 @@ public class PlayerBackpack {
      */
     public void save() {
         for (int i = 0; i < size; i++) {
-            cfg.setValue("backpacks." + id + ".contents." + i, inventory.getItem(i));
+            cfg.setValue(CONFIG_PREFIX + id + ".contents." + i, inventory.getItem(i));
         }
     }
 


### PR DESCRIPTION
## Description
I found this small problem in https://sonarcloud.io/project/issues?id=Slimefun_Slimefun4&open=AXTBL6kaIVI46B1gLWcP&resolved=false
I defined a new private variable for it. I am not sure about the name and also i believe that this could also be defined as static in the class.

## Changes
- define private variable `backpacks`
- replace hardcoded string with the new variable

## Related Issues
NA

## Checklist

- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
