### PR TITLE
Add sticks recipe to table saw

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.ItemStack;
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialConverter;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
@@ -68,6 +69,7 @@ public class TableSaw extends MultiBlockMachine {
         ItemStack output = getItemsToOutput(item.getType());
 
         if (output == null) {
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.wrong-item", true);
             return;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -22,6 +22,7 @@ import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * The {@link TableSaw} is an implementation of a {@link MultiBlockMachine} that allows
@@ -79,6 +80,7 @@ public class TableSaw extends MultiBlockMachine {
         b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, item.getType());
     }
 
+    @Nullable
     private ItemStack getItemsToOutput(@Nonnull ItemStack item) {
         boolean itemIsAPlank = Tag.PLANKS.isTagged(item.getType());
         boolean itemIsALog = Tag.LOGS.isTagged(item.getType());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -60,16 +60,32 @@ public class TableSaw extends MultiBlockMachine {
 
     @Override
     public void onInteract(Player p, Block b) {
-        ItemStack log = p.getInventory().getItemInMainHand();
+        ItemStack item = p.getInventory().getItemInMainHand();
 
-        Optional<Material> planks = MaterialConverter.getPlanksFromLog(log.getType());
+        boolean itemIsAPlank = false;
+        Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
 
-        if (planks.isPresent()) {
+        for (Material plank: Tag.PLANKS.getValues()) {
+            if (item.getType() == plank) {
+                itemIsAPlank = true;
+                break;
+            }
+        }
+
+        if (planks.isPresent() || itemIsAPlank) {
+            ItemStack output = null;
+
             if (p.getGameMode() != GameMode.CREATIVE) {
-                ItemUtils.consumeItem(log, true);
+                ItemUtils.consumeItem(item, true);
             }
 
-            ItemStack output = new ItemStack(planks.get(), 8);
+            if (planks.isPresent()) {
+                output = new ItemStack(planks.get(), 8);
+            }
+            else if (itemIsAPlank) {
+                output = new ItemStack(Material.STICK, 4);
+            }
+
             Inventory outputChest = findOutputChest(b, output);
 
             if (outputChest != null) {
@@ -79,7 +95,7 @@ public class TableSaw extends MultiBlockMachine {
                 b.getWorld().dropItemNaturally(b.getLocation(), output);
             }
 
-            b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, log.getType());
+            b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, item.getType());
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -30,6 +30,7 @@ import javax.annotation.Nonnull;
  * It also replaced the old "Saw Mill" from earlier versions.
  * 
  * @author dniym
+ * @author svr333
  * 
  * @see MultiBlockMachine
  *

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -64,16 +64,17 @@ public class TableSaw extends MultiBlockMachine {
         ItemStack item = p.getInventory().getItemInMainHand();
 
         boolean itemIsAPlank = Tag.PLANKS.isTagged(item.getType());
-        Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
+        boolean itemIsALog = Tag.LOGS.isTagged(item.getType());
 
-        if (planks.isPresent() || itemIsAPlank) {
+        if (itemIsALog || itemIsAPlank) {
             ItemStack output = null;
 
             if (p.getGameMode() != GameMode.CREATIVE) {
                 ItemUtils.consumeItem(item, true);
             }
 
-            if (planks.isPresent()) {
+            if (itemIsALog) {
+                Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
                 output = new ItemStack(planks.get(), 8);
             }
             else if (itemIsAPlank) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -77,7 +77,7 @@ public class TableSaw extends MultiBlockMachine {
                 Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
                 output = new ItemStack(planks.get(), 8);
             }
-            else if (itemIsAPlank) {
+            else {
                 output = new ItemStack(Material.STICK, 4);
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -52,10 +51,10 @@ public class TableSaw extends MultiBlockMachine {
             }
         }
 
-        CustomItem ci = new CustomItem(Material.OAK_PLANKS, "Any Wooden Plank");
-
-        displayedRecipes.add(new ItemStack(ci));
-        displayedRecipes.add(new ItemStack(Material.STICK, 4));
+        for (Material plank : Tag.PLANKS.getValues()) {
+            displayedRecipes.add(new ItemStack(plank));
+            displayedRecipes.add(new ItemStack(Material.STICK, 4));
+        }
     }
 
     @Override
@@ -66,7 +65,7 @@ public class TableSaw extends MultiBlockMachine {
     @Override
     public void onInteract(@Nonnull Player p, @Nonnull Block b) {
         ItemStack item = p.getInventory().getItemInMainHand();
-        ItemStack output = getItemsToOutput(item);
+        ItemStack output = getItemsToOutput(item.getType());
 
         if (output == null) {
             return;
@@ -81,12 +80,12 @@ public class TableSaw extends MultiBlockMachine {
     }
 
     @Nullable
-    private ItemStack getItemsToOutput(@Nonnull ItemStack item) {
-        if (Tag.LOGS.isTagged(item.getType())) {
-            Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
+    private ItemStack getItemsToOutput(@Nonnull Material item) {
+        if (Tag.LOGS.isTagged(item)) {
+            Optional<Material> planks = MaterialConverter.getPlanksFromLog(item);
             return new ItemStack(planks.get(), 8);
         }
-        else if (Tag.PLANKS.isTagged(item.getType())) {
+        else if (Tag.PLANKS.isTagged(item)) {
             return new ItemStack(Material.STICK, 4);
         }
         else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -47,10 +48,10 @@ public class TableSaw extends MultiBlockMachine {
             }
         }
 
-        for (Material plank : Tag.PLANKS.getValues()) {
-            displayedRecipes.add(new ItemStack(plank));
-            displayedRecipes.add(new ItemStack(Material.STICK, 4));
-        }
+        CustomItem ci = new CustomItem(Material.OAK_PLANKS, "Any Wooden Plank");
+
+        displayedRecipes.add(new ItemStack(ci));
+        displayedRecipes.add(new ItemStack(Material.STICK, 4));
     }
 
     @Override
@@ -62,15 +63,8 @@ public class TableSaw extends MultiBlockMachine {
     public void onInteract(Player p, Block b) {
         ItemStack item = p.getInventory().getItemInMainHand();
 
-        boolean itemIsAPlank = false;
+        boolean itemIsAPlank = Tag.PLANKS.isTagged(item.getType());
         Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
-
-        for (Material plank: Tag.PLANKS.getValues()) {
-            if (item.getType() == plank) {
-                itemIsAPlank = true;
-                break;
-            }
-        }
 
         if (planks.isPresent() || itemIsAPlank) {
             ItemStack output = null;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -47,7 +47,7 @@ public class TableSaw extends MultiBlockMachine {
             }
         }
 
-        for (Material plank: Tag.PLANKS.getValues()) {
+        for (Material plank : Tag.PLANKS.getValues()) {
             displayedRecipes.add(new ItemStack(plank));
             displayedRecipes.add(new ItemStack(Material.STICK, 4));
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -46,6 +46,11 @@ public class TableSaw extends MultiBlockMachine {
                 displayedRecipes.add(new ItemStack(planks.get(), 8));
             }
         }
+
+        for (Material plank: Tag.PLANKS.getValues()) {
+            displayedRecipes.add(new ItemStack(plank));
+            displayedRecipes.add(new ItemStack(Material.STICK, 4));
+        }
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -83,7 +83,12 @@ public class TableSaw extends MultiBlockMachine {
     private ItemStack getItemsToOutput(@Nonnull Material item) {
         if (Tag.LOGS.isTagged(item)) {
             Optional<Material> planks = MaterialConverter.getPlanksFromLog(item);
-            return new ItemStack(planks.get(), 8);
+            if (planks.isPresent()) {
+                return new ItemStack(planks.get(), 8);
+            }
+            else {
+                return null;
+            }
         }
         else if (Tag.PLANKS.isTagged(item)) {
             return new ItemStack(Material.STICK, 4);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -21,6 +21,8 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
+import javax.annotation.Nonnull;
+
 /**
  * The {@link TableSaw} is an implementation of a {@link MultiBlockMachine} that allows
  * you to turn Logs into Wooden Planks.
@@ -60,7 +62,7 @@ public class TableSaw extends MultiBlockMachine {
     }
 
     @Override
-    public void onInteract(Player p, Block b) {
+    public void onInteract(@Nonnull Player p, @Nonnull Block b) {
         ItemStack item = p.getInventory().getItemInMainHand();
 
         boolean itemIsAPlank = Tag.PLANKS.isTagged(item.getType());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -66,32 +66,33 @@ public class TableSaw extends MultiBlockMachine {
         boolean itemIsAPlank = Tag.PLANKS.isTagged(item.getType());
         boolean itemIsALog = Tag.LOGS.isTagged(item.getType());
 
-        if (itemIsALog || itemIsAPlank) {
-            ItemStack output = null;
+        ItemStack output = null;
 
-            if (p.getGameMode() != GameMode.CREATIVE) {
-                ItemUtils.consumeItem(item, true);
-            }
-
-            if (itemIsALog) {
-                Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
-                output = new ItemStack(planks.get(), 8);
-            }
-            else {
-                output = new ItemStack(Material.STICK, 4);
-            }
-
-            Inventory outputChest = findOutputChest(b, output);
-
-            if (outputChest != null) {
-                outputChest.addItem(output);
-            }
-            else {
-                b.getWorld().dropItemNaturally(b.getLocation(), output);
-            }
-
-            b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, item.getType());
+        if (itemIsALog) {
+            Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
+            output = new ItemStack(planks.get(), 8);
         }
+        else if (itemIsAPlank){
+            output = new ItemStack(Material.STICK, 4);
+        }
+        else {
+            return;
+        }
+
+        if (p.getGameMode() != GameMode.CREATIVE) {
+            ItemUtils.consumeItem(item, true);
+        }
+
+        Inventory outputChest = findOutputChest(b, output);
+
+        if (outputChest != null) {
+            outputChest.addItem(output);
+        }
+        else {
+            b.getWorld().dropItemNaturally(b.getLocation(), output);
+        }
+
+        b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, item.getType());
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -82,19 +82,16 @@ public class TableSaw extends MultiBlockMachine {
 
     @Nullable
     private ItemStack getItemsToOutput(@Nonnull ItemStack item) {
-        boolean itemIsAPlank = Tag.PLANKS.isTagged(item.getType());
-        boolean itemIsALog = Tag.LOGS.isTagged(item.getType());
-        ItemStack output = null;
-
-        if (itemIsALog) {
+        if (Tag.LOGS.isTagged(item.getType())) {
             Optional<Material> planks = MaterialConverter.getPlanksFromLog(item.getType());
-            output = new ItemStack(planks.get(), 8);
+            return new ItemStack(planks.get(), 8);
         }
-        else if (itemIsAPlank){
-            output = new ItemStack(Material.STICK, 4);
+        else if (Tag.PLANKS.isTagged(item.getType())) {
+            return new ItemStack(Material.STICK, 4);
         }
-
-        return output;
+        else {
+            return null;
+        }
     }
 
     private void outputItems(@Nonnull Block b, @Nonnull ItemStack output) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/TableSaw.java
@@ -65,10 +65,23 @@ public class TableSaw extends MultiBlockMachine {
     @Override
     public void onInteract(@Nonnull Player p, @Nonnull Block b) {
         ItemStack item = p.getInventory().getItemInMainHand();
+        ItemStack output = getItemsToOutput(item);
 
+        if (output == null) {
+            return;
+        }
+
+        if (p.getGameMode() != GameMode.CREATIVE) {
+            ItemUtils.consumeItem(item, true);
+        }
+
+        outputItems(b, output);
+        b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, item.getType());
+    }
+
+    private ItemStack getItemsToOutput(@Nonnull ItemStack item) {
         boolean itemIsAPlank = Tag.PLANKS.isTagged(item.getType());
         boolean itemIsALog = Tag.LOGS.isTagged(item.getType());
-
         ItemStack output = null;
 
         if (itemIsALog) {
@@ -78,14 +91,11 @@ public class TableSaw extends MultiBlockMachine {
         else if (itemIsAPlank){
             output = new ItemStack(Material.STICK, 4);
         }
-        else {
-            return;
-        }
 
-        if (p.getGameMode() != GameMode.CREATIVE) {
-            ItemUtils.consumeItem(item, true);
-        }
+        return output;
+    }
 
+    private void outputItems(@Nonnull Block b, @Nonnull ItemStack output) {
         Inventory outputChest = findOutputChest(b, output);
 
         if (outputChest != null) {
@@ -94,8 +104,5 @@ public class TableSaw extends MultiBlockMachine {
         else {
             b.getWorld().dropItemNaturally(b.getLocation(), output);
         }
-
-        b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, item.getType());
     }
-
 }


### PR DESCRIPTION
## Description
Add planks -> sticks with double yield ratio to Table Saw (as suggested and approved on the Discord)

## Changes
- Add 1 plank -> 4 sticks recipes for all plank types in table saw
- Add displayrecipes for table saw

## Feedback
Right now I loop through all the planks to check if the held item is a plank or not, is there a better way to do this?

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values

<br>
N/A

- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
