### PR TITLE
Added Blackstone and Basalt to Crucibles

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Crucible.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Crucible.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.Tag;
@@ -50,12 +51,6 @@ public class Crucible extends SimpleSlimefunItem<BlockUseHandler> implements Rec
         items.add(new ItemStack(Material.COBBLESTONE, 16));
         items.add(new ItemStack(Material.LAVA_BUCKET));
 
-        items.add(new ItemStack(Material.BLACKSTONE, 16));
-        items.add(new ItemStack(Material.LAVA_BUCKET));
-
-        items.add(new ItemStack(Material.BASALT, 16));
-        items.add(new ItemStack(Material.LAVA_BUCKET));
-
         items.add(new ItemStack(Material.NETHERRACK, 16));
         items.add(new ItemStack(Material.LAVA_BUCKET));
 
@@ -75,6 +70,14 @@ public class Crucible extends SimpleSlimefunItem<BlockUseHandler> implements Rec
 
         for (Material sapling : MaterialCollections.getAllTerracottaColors()) {
             items.add(new ItemStack(sapling, 12));
+            items.add(new ItemStack(Material.LAVA_BUCKET));
+        }
+
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
+            items.add(new ItemStack(Material.BLACKSTONE, 16));
+            items.add(new ItemStack(Material.LAVA_BUCKET));
+
+            items.add(new ItemStack(Material.BASALT, 16));
             items.add(new ItemStack(Material.LAVA_BUCKET));
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Crucible.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Crucible.java
@@ -50,6 +50,12 @@ public class Crucible extends SimpleSlimefunItem<BlockUseHandler> implements Rec
         items.add(new ItemStack(Material.COBBLESTONE, 16));
         items.add(new ItemStack(Material.LAVA_BUCKET));
 
+        items.add(new ItemStack(Material.BLACKSTONE, 16));
+        items.add(new ItemStack(Material.LAVA_BUCKET));
+
+        items.add(new ItemStack(Material.BASALT, 16));
+        items.add(new ItemStack(Material.LAVA_BUCKET));
+
         items.add(new ItemStack(Material.NETHERRACK, 16));
         items.add(new ItemStack(Material.LAVA_BUCKET));
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
@@ -1,5 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.inventory.ItemStack;
@@ -19,8 +21,6 @@ public abstract class ElectrifiedCrucible extends AContainer {
     @Override
     protected void registerDefaultRecipes() {
         registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.COBBLESTONE, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
-        registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BLACKSTONE, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
-        registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BASALT, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         registerRecipe(8, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.TERRACOTTA, 12) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.OBSIDIAN) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
 
@@ -30,6 +30,11 @@ public abstract class ElectrifiedCrucible extends AContainer {
 
         for (Material leaves : Tag.LEAVES.getValues()) {
             registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(leaves, 16) }, new ItemStack[] { new ItemStack(Material.WATER_BUCKET) });
+        }
+
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
+            registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BLACKSTONE, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
+            registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BASALT, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
@@ -19,6 +19,8 @@ public abstract class ElectrifiedCrucible extends AContainer {
     @Override
     protected void registerDefaultRecipes() {
         registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.COBBLESTONE, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
+        registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BASALT, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
+        registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BLACKSTONE, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         registerRecipe(8, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.TERRACOTTA, 12) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.OBSIDIAN) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
@@ -19,8 +19,8 @@ public abstract class ElectrifiedCrucible extends AContainer {
     @Override
     protected void registerDefaultRecipes() {
         registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.COBBLESTONE, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
-        registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BASALT, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BLACKSTONE, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
+        registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.BASALT, 16) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         registerRecipe(8, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.TERRACOTTA, 12) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
         registerRecipe(10, new ItemStack[] { new ItemStack(Material.BUCKET), new ItemStack(Material.OBSIDIAN) }, new ItemStack[] { new ItemStack(Material.LAVA_BUCKET) });
 


### PR DESCRIPTION
## Description
Added Blackstone and Basalt -> Lava in both Crucible and Electrified Crucible. 

## Changes
- Added 2 recipes to Crucible and Electric Crucible, melting the new nether blocks

## Related Issues
N/A, suggestion #491 in Discord's approved mentioned Basalt -> Lava though.

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
