### PR TITLE
Added optional lore to categories

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/Category.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/Category.java
@@ -132,6 +132,9 @@ public class Category implements Keyed {
      * This method returns a localized display item of this {@link Category}
      * for the specified {@link Player}.
      * 
+     * If the first line is set to "lore", up to 4 following lines will be
+     * added to the category ItemStack before the space and click hint.
+     *
      * @param p
      *            The Player to create this {@link ItemStack} for
      * @return A localized display item for this {@link Category}
@@ -140,6 +143,7 @@ public class Category implements Keyed {
     public ItemStack getItem(@Nonnull Player p) {
         return new CustomItem(item, meta -> {
             String name = SlimefunPlugin.getLocalization().getCategoryName(p, getKey());
+            String clickToOpen = ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + SlimefunPlugin.getLocalization().getMessage(p, "guide.tooltips.open-category");
 
             if (name == null) {
                 name = item.getItemMeta().getDisplayName();
@@ -151,7 +155,18 @@ public class Category implements Keyed {
                 meta.setDisplayName(ChatColor.YELLOW + name);
             }
 
-            meta.setLore(Arrays.asList("", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + SlimefunPlugin.getLocalization().getMessage(p, "guide.tooltips.open-category")));
+            if (item.getItemMeta() != null && item.getItemMeta().getLore() != null && item.getItemMeta().getLore().get(0).equals("lore")) {
+                List<String> lore = item.getItemMeta().getLore();
+                lore.remove(0);
+                if (lore.size() > 5) {
+                    lore.subList(5, lore.size()).clear();
+                }
+                lore.add("");
+                lore.add(clickToOpen);
+                meta.setLore(lore);
+            } else {
+                meta.setLore(Arrays.asList("", clickToOpen));
+            }
         });
     }
 


### PR DESCRIPTION
## Description
Addon makers can add up to 5 lines of lore to their category before the "" and "click to open" by setting the first line of their categories ItemStack to "lore", and the following 5 lines to what they want. 

![image](https://user-images.githubusercontent.com/69326411/95413310-a9ddf100-08f0-11eb-94e3-278c23bd1458.png)

## Changes
Added variable for the click to open string

If the Categories ItemStack has line 1 as "lore", it will take the following 5 lines and add them to the category icon as well as the click to open string. Any extra lines past 5 will be cut off. If they only add 3, it wont have 2 extra spaces.

Current categories aren't affected.
![image](https://user-images.githubusercontent.com/69326411/95413323-b06c6880-08f0-11eb-934f-20181a2d47d0.png)

## Related Issues
none

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
