### PR TITLE
Fix #2433

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -12,6 +12,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.collections.RandomizedSet;
@@ -141,7 +143,11 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
      * @return the {@link EntityInteractHandler} of this {@link SlimefunItem}
      */
     public EntityInteractHandler onEntityInteract() {
-        return (e, item, offHand) -> e.setCancelled(true);
+        return (e, item, offHand) -> {
+            if (!(e.getRightClicked() instanceof ItemFrame)) {
+                e.setCancelled(true);
+            }
+        };
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -13,7 +13,6 @@ import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ItemFrame;
-import org.bukkit.entity.Villager;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.collections.RandomizedSet;


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Gold pan and Nether pan can now be put into Item frame.

## Changes
<!-- Please list all the changes you have made. -->
`public EntityInteractHandler onEntityInteract()` excludes `ItemFrame`
https://streamable.com/qxxczs
## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #2433 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
