### PR TITLE
Added PlayerPreResearchEvent

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
@@ -33,8 +33,7 @@ public class PlayerPreResearchEvent extends Event implements Cancellable {
     private final Research research;
     private final SlimefunItem slimefunItem;
     private boolean cancelled;
-
-
+    
     @ParametersAreNonnullByDefault
     public PlayerPreResearchEvent(Player p, Research research, SlimefunItem slimefunItem) {
         Validate.notNull(p, "The Player cannot be null");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
@@ -11,11 +11,12 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.researching.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.guide.BookSlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.implementation.guide.ChestSlimefunGuide;
+import io.github.thebusybiscuit.slimefun4.implementation.guide.CheatSheetSlimefunGuide;
 
 /**
- * This {@link Event} is called whenever a {@link Player} clicks to unlock a research.
+ * This {@link Event} is called whenever a {@link Player} clicks to unlock a {@link Research}.
  * This is called before {@link Research#canUnlock(Player)}.
- * The event is not called for the cheat sheet.
+ * The {@link Event} is not called for {@link CheatSheetSlimefunGuide}.
  *
  * @author uiytt
  *
@@ -23,7 +24,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.guide.ChestSlimefunGuid
  * @see BookSlimefunGuide
  *
  */
-public class PreCanUnlockResearchEvent extends Event implements Cancellable {
+public class PlayerPreResearchEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
 
@@ -34,7 +35,7 @@ public class PreCanUnlockResearchEvent extends Event implements Cancellable {
 
 
     @ParametersAreNonnullByDefault
-    public PreCanUnlockResearchEvent(Player p, Research research, SlimefunItem slimefunItem) {
+    public PlayerPreResearchEvent(Player p, Research research, SlimefunItem slimefunItem) {
         Validate.notNull(p, "The Player cannot be null");
         Validate.notNull(research, "Research cannot be null");
         Validate.notNull(slimefunItem, "SlimefunItem cannot be null");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
@@ -13,64 +13,55 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+/**
+ * This {@link Event} is called whenever a {@link Player} click to unlock a research.
+ * This is called called before {@link Research#canUnlock(Player)}
+ * The event is not called for the cheat sheet
+ *
+ * @author uiytt
+ *
+ * @see ChestSlimefunGuide
+ * @see BookSlimefunGuide
+ *
+ */
 public class PreCanUnlockResearchEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
-    private boolean cancelled = false;
 
     private final Player player;
     private final Research research;
-    private final PlayerProfile profile;
     private final SlimefunItem slimefunItem;
-    private final Category category;
 
-    /**
-     * This {@link Event} is called whenever a {@link Player} click to unlock a research.
-     * This is called called before {@link Research#canUnlock(Player)}
-     * The event is not called for the cheat sheet
-     *
-     * @author uiytt
-     *
-     * @see ChestSlimefunGuide
-     * @see BookSlimefunGuide
-     *
-     */
-    public PreCanUnlockResearchEvent(@Nonnull Player p, @Nonnull Research research, @Nonnull PlayerProfile profile, @Nonnull SlimefunItem slimefunItem, @Nonnull Category category) {
+    private boolean cancelled;
+
+
+    @ParametersAreNonnullByDefault
+    public PreCanUnlockResearchEvent(Player p, Research research, SlimefunItem slimefunItem) {
         Validate.notNull(p, "The Player cannot be null");
         Validate.notNull(research, "Research cannot be null");
-        Validate.notNull(profile, "PlayerProfile cannot be null");
         Validate.notNull(slimefunItem, "SlimefunItem cannot be null");
-        Validate.notNull(category, "Category cannot be null");
 
         this.player = p;
         this.research = research;
-        this.profile = profile;
         this.slimefunItem = slimefunItem;
-        this.category = category;
     }
 
     @Nonnull
     public Player getPlayer() {
-        return this.player;
-    }
-    @Nonnull
-    public Research getResearch() {
-        return this.research;
-    }
-    @Nonnull
-    public PlayerProfile getProfile() {
-        return this.profile;
-    }
-    @Nonnull
-    public SlimefunItem getSlimefunItem() {
-        return this.slimefunItem;
-    }
-    @Nonnull
-    public Category getCategory() {
-        return this.category;
+        return player;
     }
 
+    @Nonnull
+    public Research getResearch() {
+        return research;
+    }
+
+    @Nonnull
+    public SlimefunItem getSlimefunItem() {
+        return slimefunItem;
+    }
 
     @Nonnull
     public static HandlerList getHandlerList() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
@@ -1,19 +1,16 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
-import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
-import io.github.thebusybiscuit.slimefun4.core.researching.Research;
-import io.github.thebusybiscuit.slimefun4.implementation.guide.BookSlimefunGuide;
-import io.github.thebusybiscuit.slimefun4.implementation.guide.ChestSlimefunGuide;
-import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import org.apache.commons.lang.Validate;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.commons.lang.Validate;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.core.researching.Research;
+import io.github.thebusybiscuit.slimefun4.implementation.guide.BookSlimefunGuide;
+import io.github.thebusybiscuit.slimefun4.implementation.guide.ChestSlimefunGuide;
 
 /**
  * This {@link Event} is called whenever a {@link Player} clicks to unlock a research.
@@ -33,7 +30,6 @@ public class PreCanUnlockResearchEvent extends Event implements Cancellable {
     private final Player player;
     private final Research research;
     private final SlimefunItem slimefunItem;
-
     private boolean cancelled;
 
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
@@ -1,0 +1,95 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
+import io.github.thebusybiscuit.slimefun4.core.researching.Research;
+import io.github.thebusybiscuit.slimefun4.implementation.guide.BookSlimefunGuide;
+import io.github.thebusybiscuit.slimefun4.implementation.guide.ChestSlimefunGuide;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import org.apache.commons.lang.Validate;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import javax.annotation.Nonnull;
+
+public class PreCanUnlockResearchEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled = false;
+
+    private final Player player;
+    private final Research research;
+    private final PlayerProfile profile;
+    private final SlimefunItem slimefunItem;
+    private final Category category;
+
+    /**
+     * This {@link Event} is called whenever a {@link Player} click to unlock a research.
+     * This is called called before {@link Research#canUnlock(Player)}
+     * The event is not called for the cheat sheet
+     *
+     * @author uiytt
+     *
+     * @see ChestSlimefunGuide
+     * @see BookSlimefunGuide
+     *
+     */
+    public PreCanUnlockResearchEvent(@Nonnull Player p, @Nonnull Research research, @Nonnull PlayerProfile profile, @Nonnull SlimefunItem slimefunItem, @Nonnull Category category) {
+        Validate.notNull(p, "The Player cannot be null");
+        Validate.notNull(research, "Research cannot be null");
+        Validate.notNull(profile, "PlayerProfile cannot be null");
+        Validate.notNull(slimefunItem, "SlimefunItem cannot be null");
+        Validate.notNull(category, "Category cannot be null");
+
+        this.player = p;
+        this.research = research;
+        this.profile = profile;
+        this.slimefunItem = slimefunItem;
+        this.category = category;
+    }
+
+    @Nonnull
+    public Player getPlayer() {
+        return this.player;
+    }
+    @Nonnull
+    public Research getResearch() {
+        return this.research;
+    }
+    @Nonnull
+    public PlayerProfile getProfile() {
+        return this.profile;
+    }
+    @Nonnull
+    public SlimefunItem getSlimefunItem() {
+        return this.slimefunItem;
+    }
+    @Nonnull
+    public Category getCategory() {
+        return this.category;
+    }
+
+
+    @Nonnull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PreCanUnlockResearchEvent.java
@@ -16,9 +16,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * This {@link Event} is called whenever a {@link Player} click to unlock a research.
- * This is called called before {@link Research#canUnlock(Player)}
- * The event is not called for the cheat sheet
+ * This {@link Event} is called whenever a {@link Player} clicks to unlock a research.
+ * This is called before {@link Research#canUnlock(Player)}.
+ * The event is not called for the cheat sheet.
  *
  * @author uiytt
  *

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/researching/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/researching/Research.java
@@ -10,10 +10,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.events.PreCanUnlockResearchEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.PlayerPreResearchEvent;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
-import io.github.thebusybiscuit.slimefun4.implementation.guide.BookSlimefunGuide;
-import io.github.thebusybiscuit.slimefun4.implementation.guide.ChestSlimefunGuide;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
@@ -199,9 +197,6 @@ public class Research implements Keyed {
      * Handle what to do when a {@link Player} clicks on an un-researched item in
      * a {@link SlimefunGuideImplementation}.
      *
-     * @author TheBusyBiscuit
-     * @author uiytt
-     *
      * @param guide The {@link SlimefunGuideImplementation} used.
      * @param player The {@link Player} who clicked on the item.
      * @param profile The {@link PlayerProfile} of that {@link Player}.
@@ -209,16 +204,14 @@ public class Research implements Keyed {
      * @param category The {@link Category} where the {@link Player} was.
      * @param page The page number of where the {@link Player} was in the {@link Category};
      *
-     * @see ChestSlimefunGuide
-     * @see BookSlimefunGuide
      */
     @ParametersAreNonnullByDefault
-    public void guideClickInteraction(SlimefunGuideImplementation guide, Player player, PlayerProfile profile, SlimefunItem sfItem, Category category, int page) {
+    public void unlockFromGuide(SlimefunGuideImplementation guide, Player player, PlayerProfile profile, SlimefunItem sfItem, Category category, int page) {
         if (!SlimefunPlugin.getRegistry().getCurrentlyResearchingPlayers().contains(player.getUniqueId())) {
             if (profile.hasUnlocked(this)) {
                 guide.openCategory(profile, category, page);
             } else {
-                PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(player, this, sfItem);
+                PlayerPreResearchEvent event = new PlayerPreResearchEvent(player, this, sfItem);
                 Bukkit.getPluginManager().callEvent(event);
 
                 if (!event.isCancelled()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/researching/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/researching/Research.java
@@ -199,7 +199,8 @@ public class Research implements Keyed {
      * Handle what to do when a {@link Player} clicks on an un-researched item in
      * a {@link SlimefunGuideImplementation}.
      *
-     * @author TheBusyBiscuit, uiytt
+     * @author TheBusyBiscuit
+     * @author uiytt
      *
      * @param guide The {@link SlimefunGuideImplementation} used.
      * @param player The {@link Player} who clicked on the item.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/researching/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/researching/Research.java
@@ -10,9 +10,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.events.PlayerPreResearchEvent;
-import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
-import me.mrCookieSlime.Slimefun.Objects.Category;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -29,6 +26,9 @@ import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.setup.ResearchSetup;
 import io.github.thebusybiscuit.slimefun4.utils.FireworkUtils;
+import io.github.thebusybiscuit.slimefun4.api.events.PlayerPreResearchEvent;
+import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
+import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
 /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
@@ -242,9 +242,10 @@ public class BookSlimefunGuide implements SlimefunGuideImplementation {
                 if (profile.hasUnlocked(research)) {
                     openCategory(profile, category, page);
                 } else {
-                    PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(p,research,profile,item,category);
+                    PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(p, research, item);
                     Bukkit.getPluginManager().callEvent(event);
-                    if(!event.isCancelled()) {
+
+                    if (!event.isCancelled()) {
                         if (research.canUnlock(p)) {
                             unlockItem(p, item, pl -> openCategory(profile, category, page));
                         } else {
@@ -252,7 +253,6 @@ public class BookSlimefunGuide implements SlimefunGuideImplementation {
                         }
                     }
                 }
-
             }
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
@@ -5,8 +5,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
-import io.github.thebusybiscuit.slimefun4.api.events.PreCanUnlockResearchEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -218,9 +216,9 @@ public class BookSlimefunGuide implements SlimefunGuideImplementation {
             ChatComponent component = new ChatComponent(ChatUtils.crop(ChatColor.RED, item.getItemName()) + "\n");
             component.setHoverEvent(new HoverEvent(ChatColor.RESET + item.getItemName(), ChatColor.DARK_RED.toString() + ChatColor.BOLD + SlimefunPlugin.getLocalization().getMessage(p, "guide.locked"), "", ChatColor.GREEN + "> Click to unlock", "", ChatColor.GRAY + "Cost: " + ChatColor.AQUA.toString() + research.getCost() + " Level(s)"));
             component.setClickEvent(new ClickEvent(key, player ->
-                    SlimefunPlugin.runSync(() -> {
-                        research.guideClickInteraction(this, player, profile, item, category, page);
-                    })
+                    SlimefunPlugin.runSync(() ->
+                        research.unlockFromGuide(this, player, profile, item, category, page)
+                    )
             ));
 
             items.add(component);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
@@ -217,7 +217,11 @@ public class BookSlimefunGuide implements SlimefunGuideImplementation {
 
             ChatComponent component = new ChatComponent(ChatUtils.crop(ChatColor.RED, item.getItemName()) + "\n");
             component.setHoverEvent(new HoverEvent(ChatColor.RESET + item.getItemName(), ChatColor.DARK_RED.toString() + ChatColor.BOLD + SlimefunPlugin.getLocalization().getMessage(p, "guide.locked"), "", ChatColor.GREEN + "> Click to unlock", "", ChatColor.GRAY + "Cost: " + ChatColor.AQUA.toString() + research.getCost() + " Level(s)"));
-            component.setClickEvent(new ClickEvent(key, player -> research(player, profile, item, research, category, page)));
+            component.setClickEvent(new ClickEvent(key, player ->
+                    SlimefunPlugin.runSync(() -> {
+                        research.guideClickInteraction(this, player, profile, item, category, page);
+                    })
+            ));
 
             items.add(component);
         } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
@@ -240,27 +240,6 @@ public class BookSlimefunGuide implements SlimefunGuideImplementation {
         }
     }
 
-    private void research(Player p, PlayerProfile profile, SlimefunItem item, Research research, Category category, int page) {
-        SlimefunPlugin.runSync(() -> {
-            if (!SlimefunPlugin.getRegistry().getCurrentlyResearchingPlayers().contains(p.getUniqueId())) {
-                if (profile.hasUnlocked(research)) {
-                    openCategory(profile, category, page);
-                } else {
-                    PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(p, research, item);
-                    Bukkit.getPluginManager().callEvent(event);
-
-                    if (!event.isCancelled()) {
-                        if (research.canUnlock(p)) {
-                            unlockItem(p, item, pl -> openCategory(profile, category, page));
-                        } else {
-                            SlimefunPlugin.getLocalization().sendMessage(p, "messages.not-enough-xp", true);
-                        }
-                    }
-                }
-            }
-        });
-    }
-
     @Override
     public void openSearch(PlayerProfile profile, String input, boolean addToHistory) {
         // We need to write a book implementation for this at some point

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -10,8 +10,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Level;
 
-import io.github.thebusybiscuit.slimefun4.api.events.PreCanUnlockResearchEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -285,22 +283,7 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         } else if (isSurvivalMode() && research != null && !profile.hasUnlocked(research)) {
             menu.addItem(index, new CustomItem(Material.BARRIER, ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + SlimefunPlugin.getLocalization().getMessage(p, "guide.locked"), "", "&a> Click to unlock", "", "&7Cost: &b" + research.getCost() + " Level(s)"));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
-                if (!SlimefunPlugin.getRegistry().getCurrentlyResearchingPlayers().contains(pl.getUniqueId())) {
-                    if (profile.hasUnlocked(research)) {
-                        openCategory(profile, category, page);
-                    } else {
-                        PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(p, research, sfitem);
-                        Bukkit.getPluginManager().callEvent(event);
-
-                        if (!event.isCancelled()) {
-                            if (research.canUnlock(pl)) {
-                                unlockItem(pl, sfitem, player -> openCategory(profile, category, page));
-                            } else {
-                                SlimefunPlugin.getLocalization().sendMessage(pl, "messages.not-enough-xp", true);
-                            }
-                        }
-                    }
-                }
+                research.guideClickInteraction(this, p, profile, sfitem, category, page);
                 return false;
             });
         } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -289,9 +289,10 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
                     if (profile.hasUnlocked(research)) {
                         openCategory(profile, category, page);
                     } else {
-                        PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(p,research,profile,sfitem,category);
+                        PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(p, research, sfitem);
                         Bukkit.getPluginManager().callEvent(event);
-                        if(!event.isCancelled()) {
+
+                        if (!event.isCancelled()) {
                             if (research.canUnlock(pl)) {
                                 unlockItem(pl, sfitem, player -> openCategory(profile, category, page));
                             } else {
@@ -301,7 +302,6 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
                     }
 
                 }
-
                 return false;
             });
         } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -283,7 +283,7 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         } else if (isSurvivalMode() && research != null && !profile.hasUnlocked(research)) {
             menu.addItem(index, new CustomItem(Material.BARRIER, ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + SlimefunPlugin.getLocalization().getMessage(p, "guide.locked"), "", "&a> Click to unlock", "", "&7Cost: &b" + research.getCost() + " Level(s)"));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
-                research.guideClickInteraction(this, p, profile, sfitem, category, page);
+                research.unlockFromGuide(this, p, profile, sfitem, category, page);
                 return false;
             });
         } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -300,7 +300,6 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
                             }
                         }
                     }
-
                 }
                 return false;
             });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -10,6 +10,8 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Level;
 
+import io.github.thebusybiscuit.slimefun4.api.events.PreCanUnlockResearchEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -284,15 +286,20 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
             menu.addItem(index, new CustomItem(Material.BARRIER, ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + SlimefunPlugin.getLocalization().getMessage(p, "guide.locked"), "", "&a> Click to unlock", "", "&7Cost: &b" + research.getCost() + " Level(s)"));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
                 if (!SlimefunPlugin.getRegistry().getCurrentlyResearchingPlayers().contains(pl.getUniqueId())) {
-                    if (research.canUnlock(pl)) {
-                        if (profile.hasUnlocked(research)) {
-                            openCategory(profile, category, page);
-                        } else {
-                            unlockItem(pl, sfitem, player -> openCategory(profile, category, page));
-                        }
+                    if (profile.hasUnlocked(research)) {
+                        openCategory(profile, category, page);
                     } else {
-                        SlimefunPlugin.getLocalization().sendMessage(pl, "messages.not-enough-xp", true);
+                        PreCanUnlockResearchEvent event = new PreCanUnlockResearchEvent(p,research,profile,sfitem,category);
+                        Bukkit.getPluginManager().callEvent(event);
+                        if(!event.isCancelled()) {
+                            if (research.canUnlock(pl)) {
+                                unlockItem(pl, sfitem, player -> openCategory(profile, category, page));
+                            } else {
+                                SlimefunPlugin.getLocalization().sendMessage(pl, "messages.not-enough-xp", true);
+                            }
+                        }
                     }
+
                 }
 
                 return false;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/researches/TestResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/researches/TestResearches.java
@@ -2,6 +2,10 @@ package io.github.thebusybiscuit.slimefun4.testing.tests.researches;
 
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.api.events.PreCanUnlockResearchEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.ResearchUnlockEvent;
+import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
+import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -19,6 +23,7 @@ import io.github.thebusybiscuit.slimefun4.core.researching.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.testing.TestUtilities;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import org.mockito.Mockito;
 
 class TestResearches {
 
@@ -180,6 +185,31 @@ class TestResearches {
         Assertions.assertFalse(research.canUnlock(player));
         player.setLevel(8);
         Assertions.assertTrue(research.canUnlock(player));
+    }
+
+    @Test
+    @DisplayName("Test PreCanUnlockResearchEvent")
+    void testPreCanUnlockResearchEvent() throws InterruptedException {
+        SlimefunPlugin.getRegistry().setResearchingEnabled(true);
+
+        NamespacedKey key = new NamespacedKey(plugin, "simple_research");
+        Research research = new Research(key, 250, "Test", 10);
+        research.register();
+
+        SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);
+        Player player = server.addPlayer();
+        PlayerProfile profile = TestUtilities.awaitProfile(player);
+        SlimefunItem sfItem = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", new CustomItem(Material.TORCH, "&bResearch Test"));
+
+        research.guideClickInteraction(guide,player,profile,sfItem,sfItem.getCategory(),0);
+
+        server.getPluginManager().assertEventFired(PreCanUnlockResearchEvent.class, event -> {
+            Assertions.assertEquals(player, event.getPlayer());
+            Assertions.assertEquals(research, event.getResearch());
+            Assertions.assertEquals(sfItem,event.getSlimefunItem());
+            Assertions.assertFalse(event.isCancelled());
+            return true;
+        });
     }
 
 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/researches/TestResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/researches/TestResearches.java
@@ -2,8 +2,7 @@ package io.github.thebusybiscuit.slimefun4.testing.tests.researches;
 
 import java.util.Optional;
 
-import io.github.thebusybiscuit.slimefun4.api.events.PreCanUnlockResearchEvent;
-import io.github.thebusybiscuit.slimefun4.api.events.ResearchUnlockEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.PlayerPreResearchEvent;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
 import org.bukkit.GameMode;
@@ -188,7 +187,7 @@ class TestResearches {
     }
 
     @Test
-    @DisplayName("Test PreCanUnlockResearchEvent")
+    @DisplayName("Test PlayerPreResearchEvent")
     void testPreCanUnlockResearchEvent() throws InterruptedException {
         SlimefunPlugin.getRegistry().setResearchingEnabled(true);
 
@@ -201,9 +200,9 @@ class TestResearches {
         PlayerProfile profile = TestUtilities.awaitProfile(player);
         SlimefunItem sfItem = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", new CustomItem(Material.TORCH, "&bResearch Test"));
 
-        research.guideClickInteraction(guide,player,profile,sfItem,sfItem.getCategory(),0);
+        research.unlockFromGuide(guide, player, profile, sfItem, sfItem.getCategory(), 0);
 
-        server.getPluginManager().assertEventFired(PreCanUnlockResearchEvent.class, event -> {
+        server.getPluginManager().assertEventFired(PlayerPreResearchEvent.class, event -> {
             Assertions.assertEquals(player, event.getPlayer());
             Assertions.assertEquals(research, event.getResearch());
             Assertions.assertEquals(sfItem,event.getSlimefunItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/researches/TestResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/researches/TestResearches.java
@@ -205,7 +205,7 @@ class TestResearches {
         server.getPluginManager().assertEventFired(PlayerPreResearchEvent.class, event -> {
             Assertions.assertEquals(player, event.getPlayer());
             Assertions.assertEquals(research, event.getResearch());
-            Assertions.assertEquals(sfItem,event.getSlimefunItem());
+            Assertions.assertEquals(sfItem, event.getSlimefunItem());
             Assertions.assertFalse(event.isCancelled());
             return true;
         });


### PR DESCRIPTION

## Description
This event is called when a player click to unlock a research
This is called called before Research#canUnlock(Player)
The event is not called for the cheat sheet

This even can be very useful, with it, devs can deactivate the default research system and if they want, add their own system. 

## Changes
- Created the Event
- Add the callEvent before canUnlock in ChestSlimefunGuide and BookSlimefunGuide
- Changed the order of canUnlock and hasUnlocked (hasUnlocked now before). After some tests, this doesn't cause any problem, and now, if a player open a guide, receive a research by an admin, and then click on the item to receive the research, there won't be a red message with not enough xp send to the player  


## Checklist
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them. [X] I'm 90% sure It won't break anything
- [X] I followed the existing code standards and didn't mess up the formatting.
- [X] I did my best to add documentation to any public classes or methods I added.
- [X] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [X] I added sufficient Unit Tests to cover my code. 