### PR TITLE
Nether Goo "Tainted Sheep"

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
@@ -67,7 +67,7 @@ public class StrangeNetherGoo extends SimpleSlimefunItem<ItemUseHandler> impleme
 
     private EntityInteractHandler onRightClickEntity() {
         return (e, item, hand) -> {
-            if ((e.getRightClicked() instanceof Sheep)) {
+            if (e.getRightClicked() instanceof Sheep) {
                 Sheep s = (Sheep) e.getRightClicked();
 
                 if (s.getCustomName() != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
@@ -8,7 +8,6 @@ import org.bukkit.DyeColor;
 import org.bukkit.GameMode;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Piglin;
 import org.bukkit.entity.Sheep;
 import org.bukkit.inventory.ItemStack;
@@ -68,13 +67,12 @@ public class StrangeNetherGoo extends SimpleSlimefunItem<ItemUseHandler> impleme
 
     private EntityInteractHandler onRightClickEntity() {
         return (e, item, hand) -> {
-            if ((e.getRightClicked() instanceof Sheep) && (e.getRightClicked() instanceof LivingEntity)) {
+            if ((e.getRightClicked() instanceof Sheep)) {
                 Sheep s = (Sheep) e.getRightClicked();
 
                 if (s.getCustomName() != null) {
-                    if (s.getCustomName().equals(ChatColor.DARK_PURPLE+"Tainted Sheep") && s.getColor() == DyeColor.PURPLE) {
-                        return;
-                    }
+                    e.setCancelled(true);
+                    return;
                 }
 
                 if (e.getPlayer().getGameMode() != GameMode.CREATIVE) {
@@ -84,7 +82,7 @@ public class StrangeNetherGoo extends SimpleSlimefunItem<ItemUseHandler> impleme
                 // Give Sheep color, name and effect
                 s.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 60, 2));
                 s.setColor(DyeColor.PURPLE);
-                s.setCustomName(ChatColor.DARK_PURPLE+"Tainted Sheep");
+                s.setCustomName(ChatColor.DARK_PURPLE + "Tainted Sheep");
                 e.setCancelled(true);
 
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
@@ -1,23 +1,32 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.misc;
 
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+import org.bukkit.ChatColor;
+import org.bukkit.DyeColor;
+import org.bukkit.GameMode;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Piglin;
+import org.bukkit.entity.Sheep;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
+import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.settings.IntRangeSetting;
-import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.core.attributes.PiglinBarterDrop;
+import io.github.thebusybiscuit.slimefun4.core.handlers.EntityInteractHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.VillagerRune;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
-
-import javax.annotation.Nonnull;
-import java.util.Optional;
 
 /**
  * This {@link SlimefunItem} can only be obtained via bartering with a {@link Piglin}, its
@@ -37,6 +46,7 @@ public class StrangeNetherGoo extends SimpleSlimefunItem<ItemUseHandler> impleme
         super(category, item, recipeType, recipe);
 
         addItemSetting(chance);
+        addItemHandler(onRightClickEntity());
     }
 
     @Override
@@ -56,4 +66,28 @@ public class StrangeNetherGoo extends SimpleSlimefunItem<ItemUseHandler> impleme
         };
     }
 
+    private EntityInteractHandler onRightClickEntity() {
+        return (e, item, hand) -> {
+            if ((e.getRightClicked() instanceof Sheep) && (e.getRightClicked() instanceof LivingEntity)) {
+                Sheep s = (Sheep) e.getRightClicked();
+
+                if (s.getCustomName() != null) {
+                    if (s.getCustomName().equals(ChatColor.DARK_PURPLE+"Tainted Sheep") && s.getColor() == DyeColor.PURPLE) {
+                        return;
+                    }
+                }
+
+                if (e.getPlayer().getGameMode() != GameMode.CREATIVE) {
+                    ItemUtils.consumeItem(item, false);
+                }
+
+                // Give Sheep color, name and effect
+                s.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 60, 2));
+                s.setColor(DyeColor.PURPLE);
+                s.setCustomName(ChatColor.DARK_PURPLE+"Tainted Sheep");
+                e.setCancelled(true);
+
+            }
+        };
+    }
 }


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Nether Goo now changes an ordinary sheep to **Tainted Sheep**.
- When applied to a Sheep without a CustomName, it renames that Sheep to **Tainted Sheep**.
- Changes wool color to **PURPLE**.
- Gets poisoned for 3 seconds with _Poison PotionEffect II_.

## Changes
<!-- Please list all the changes you have made. -->
Added `addItemHandler(onRightClickEntity())`

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #2414

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
