### PR TITLE
Changed some things to public (from protected)

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
@@ -102,7 +102,7 @@ public enum Instruction {
     }),
 
     ATTACK_ANIMALS_ADULT(AndroidType.FIGHTER, HeadTexture.SCRIPT_ATTACK, (android, b, inv, face) -> {
-        Predicate<LivingEntity> predicate = e -> e instanceof Animals && e instanceof Ageable && ((Ageable) e).isAdult();
+        Predicate<LivingEntity> predicate = e -> e instanceof Animals && ((Ageable) e).isAdult();
         android.attack(b, face, predicate);
     }),
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
@@ -20,7 +20,7 @@ import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 
-enum Instruction {
+public enum Instruction {
 
     // Start and End Parts
     START(AndroidType.NONE, HeadTexture.SCRIPT_START),

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -534,12 +534,12 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
     }
 
     @Nonnull
-    protected String getScript(@Nonnull Location l) {
+    public String getScript(@Nonnull Location l) {
         String script = BlockStorage.getLocationInfo(l, "script");
         return script != null ? script : DEFAULT_SCRIPT;
     }
 
-    protected void setScript(@Nonnull Location l, @Nonnull String script) {
+    public void setScript(@Nonnull Location l, @Nonnull String script) {
         BlockStorage.addBlockInfo(l, "script", script);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -535,11 +535,14 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
     @Nonnull
     public String getScript(@Nonnull Location l) {
+        Validate.notNull(l, "Location for android not specified");
         String script = BlockStorage.getLocationInfo(l, "script");
         return script != null ? script : DEFAULT_SCRIPT;
     }
 
     public void setScript(@Nonnull Location l, @Nonnull String script) {
+        Validate.notNull(l, "Location for android not specified");
+        Validate.notNull(script, "No script given");
         BlockStorage.addBlockInfo(l, "script", script);
     }
 


### PR DESCRIPTION
## Description
I changed the access modifiers in `ProgrammableAndroid.getScript()` and `ProgrammableAndroid.setScript()` from protected to public so external addons can change android scrips (I need it for precisely that reason). I also changed `Instruction` enum to public

## Changes
<!-- Please list all the changes you have made. -->
`ProgrammableAndroid.getScript()` and `ProgrammableAndroid.setScript()` are now public
`Instruction` is now public

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
None

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
