### PR TITLE
Cargo Net Optimization: Cached Item Filters

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/AbstractItemNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/AbstractItemNetwork.java
@@ -23,6 +23,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -47,12 +48,13 @@ import me.mrCookieSlime.Slimefun.api.inventory.UniversalBlockMenu;
 import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 /**
- * An abstract super class of {@link CargoNet} that handles interactions with ChestTerminal.
+ * An abstract super class of {@link CargoNet} that handles
+ * interactions with ChestTerminal.
  * 
  * @author TheBusyBiscuit
  *
  */
-abstract class ChestTerminalNetwork extends Network {
+abstract class AbstractItemNetwork extends Network {
 
     private static final int[] slots = { 19, 20, 21, 28, 29, 30, 37, 38, 39 };
     private static final int[] TERMINAL_SLOTS = { 0, 1, 2, 3, 4, 5, 6, 9, 10, 11, 12, 13, 14, 15, 18, 19, 20, 21, 22, 23, 24, 27, 28, 29, 30, 31, 32, 33, 36, 37, 38, 39, 40, 41, 42 };
@@ -64,14 +66,23 @@ abstract class ChestTerminalNetwork extends Network {
     protected final Set<Location> imports = new HashSet<>();
     protected final Set<Location> exports = new HashSet<>();
 
-    // This represents a Queue of requests to handle
+    /**
+     * This represents a {@link Queue} of requests to handle
+     */
     private final Queue<ItemRequest> itemRequests = new LinkedList<>();
 
-    // This is a cache for the BlockFace a node is facing, so we don't need to request the
-    // BlockData each time we visit a node
+    /**
+     * This is a cache for the {@link BlockFace} a node is facing, so we don't need to
+     * request the {@link BlockData} each time we visit a node
+     */
     protected Map<Location, BlockFace> connectorCache = new HashMap<>();
 
-    protected ChestTerminalNetwork(Location regulator) {
+    /**
+     * This is our cache for the {@link ItemFilter} for each node.
+     */
+    protected Map<Location, ItemFilter> filterCache = new HashMap<>();
+
+    protected AbstractItemNetwork(Location regulator) {
         super(SlimefunPlugin.getNetworkManager(), regulator);
     }
 
@@ -127,7 +138,7 @@ abstract class ChestTerminalNetwork extends Network {
             Optional<Block> target = getAttachedBlock(l);
 
             if (target.isPresent()) {
-                item = CargoUtils.insert(inventories, l.getBlock(), target.get(), item);
+                item = CargoUtils.insert(this, inventories, l.getBlock(), target.get(), item);
 
                 if (item == null) {
                     terminal.replaceExistingItem(request.getSlot(), null);
@@ -159,7 +170,7 @@ abstract class ChestTerminalNetwork extends Network {
             Optional<Block> target = getAttachedBlock(l);
 
             if (target.isPresent()) {
-                ItemStack is = CargoUtils.withdraw(inventories, l.getBlock(), target.get(), item);
+                ItemStack is = CargoUtils.withdraw(this, inventories, l.getBlock(), target.get(), item);
 
                 if (is != null) {
                     if (stack == null) {
@@ -201,7 +212,7 @@ abstract class ChestTerminalNetwork extends Network {
                 Optional<Block> target = getAttachedBlock(bus);
 
                 if (target.isPresent()) {
-                    ItemStackAndInteger stack = CargoUtils.withdraw(inventories, bus.getBlock(), target.get());
+                    ItemStackAndInteger stack = CargoUtils.withdraw(this, inventories, bus.getBlock(), target.get());
 
                     if (stack != null) {
                         menu.replaceExistingItem(17, stack.getItem());
@@ -227,7 +238,7 @@ abstract class ChestTerminalNetwork extends Network {
             if (menu.getItemInSlot(17) != null) {
                 Optional<Block> target = getAttachedBlock(bus);
 
-                target.ifPresent(block -> menu.replaceExistingItem(17, CargoUtils.insert(inventories, bus.getBlock(), block, menu.getItemInSlot(17))));
+                target.ifPresent(block -> menu.replaceExistingItem(17, CargoUtils.insert(this, inventories, bus.getBlock(), block, menu.getItemInSlot(17))));
             }
 
             if (menu.getItemInSlot(17) == null) {
@@ -274,7 +285,7 @@ abstract class ChestTerminalNetwork extends Network {
      * found in any provider of the network.
      * 
      * @param providers
-     *            A {@link Set} of providers to this {@link ChestTerminalNetwork}
+     *            A {@link Set} of providers to this {@link AbstractItemNetwork}
      * 
      * @return The time it took to compute this operation
      */
@@ -326,8 +337,25 @@ abstract class ChestTerminalNetwork extends Network {
 
     @Override
     public void markDirty(@Nonnull Location l) {
-        connectorCache.remove(l);
+        markCargoNodeConfigurationDirty(l);
         super.markDirty(l);
+    }
+
+    /**
+     * This will markt the {@link ItemFilter} of the given node dirty.
+     * It will also invalidate the cached rotation.
+     * 
+     * @param node
+     *            The {@link Location} of the cargo node
+     */
+    public void markCargoNodeConfigurationDirty(@Nonnull Location node) {
+        ItemFilter filter = filterCache.get(node);
+
+        if (filter != null) {
+            filter.markDirty();
+        }
+
+        connectorCache.remove(node);
     }
 
     @ParametersAreNonnullByDefault
@@ -432,7 +460,7 @@ abstract class ChestTerminalNetwork extends Network {
             for (int slot : blockMenu.getPreset().getSlotsAccessedByItemTransport((DirtyChestMenu) blockMenu, ItemTransportFlow.WITHDRAW, null)) {
                 ItemStack is = blockMenu.getItemInSlot(slot);
 
-                if (is != null && CargoUtils.matchesFilter(l.getBlock(), is)) {
+                if (is != null && CargoUtils.matchesFilter(this, l.getBlock(), is)) {
                     boolean add = true;
 
                     for (ItemStackAndInteger item : items) {
@@ -461,7 +489,7 @@ abstract class ChestTerminalNetwork extends Network {
 
     @ParametersAreNonnullByDefault
     private void filter(@Nullable ItemStack stack, List<ItemStackAndInteger> items, Location node) {
-        if (stack != null && CargoUtils.matchesFilter(node.getBlock(), stack)) {
+        if (stack != null && CargoUtils.matchesFilter(this, node.getBlock(), stack)) {
             boolean add = true;
 
             for (ItemStackAndInteger item : items) {
@@ -474,6 +502,23 @@ abstract class ChestTerminalNetwork extends Network {
             if (add) {
                 items.add(new ItemStackAndInteger(stack, stack.getAmount()));
             }
+        }
+    }
+
+    @Nonnull
+    protected ItemFilter getItemFilter(@Nonnull Block node) {
+        Location loc = node.getLocation();
+        ItemFilter filter = filterCache.get(loc);
+
+        if (filter == null) {
+            ItemFilter newFilter = new ItemFilter(node);
+            filterCache.put(loc, newFilter);
+            return newFilter;
+        } else if (filter.isDirty()) {
+            filter.update(node);
+            return filter;
+        } else {
+            return filter;
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
@@ -24,7 +24,7 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 /**
  * The {@link CargoNet} is a type of {@link Network} which deals with {@link ItemStack} transportation.
- * It is also an extension of {@link ChestTerminalNetwork} which provides methods to deal
+ * It is also an extension of {@link AbstractItemNetwork} which provides methods to deal
  * with the addon ChestTerminal.
  * 
  * @author meiamsome
@@ -37,7 +37,7 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
  * @author DNx5
  *
  */
-public class CargoNet extends ChestTerminalNetwork {
+public class CargoNet extends AbstractItemNetwork {
 
     private static final int RANGE = 5;
     private static final int TICK_DELAY = SlimefunPlugin.getCfg().getInt("networks.cargo-ticker-delay");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNetworkTask.java
@@ -32,7 +32,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.DirtyChestMenu;
  * 
  * @see CargoNet
  * @see CargoUtils
- * @see ChestTerminalNetwork
+ * @see AbstractItemNetwork
  *
  */
 class CargoNetworkTask implements Runnable {
@@ -90,7 +90,7 @@ class CargoNetworkTask implements Runnable {
     }
 
     private void routeItems(Location inputNode, Block inputTarget, int frequency, Map<Integer, List<Location>> outputNodes) {
-        ItemStackAndInteger slot = CargoUtils.withdraw(inventories, inputNode.getBlock(), inputTarget);
+        ItemStackAndInteger slot = CargoUtils.withdraw(network, inventories, inputNode.getBlock(), inputTarget);
 
         if (slot == null) {
             return;
@@ -149,7 +149,7 @@ class CargoNetworkTask implements Runnable {
             Optional<Block> target = network.getAttachedBlock(output);
 
             if (target.isPresent()) {
-                item = CargoUtils.insert(inventories, output.getBlock(), target.get(), item);
+                item = CargoUtils.insert(network, inventories, output.getBlock(), target.get(), item);
 
                 if (item == null) {
                     break;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -1,7 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.core.networks.cargo;
 
 import java.util.Map;
-import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -17,16 +16,12 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import io.papermc.lib.PaperLib;
-import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
-import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.DirtyChestMenu;
 import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
@@ -119,7 +114,7 @@ final class CargoUtils {
         }
     }
 
-    static ItemStack withdraw(Map<Location, Inventory> inventories, Block node, Block target, ItemStack template) {
+    static ItemStack withdraw(AbstractItemNetwork network, Map<Location, Inventory> inventories, Block node, Block target, ItemStack template) {
         DirtyChestMenu menu = getChestMenu(target);
 
         if (menu == null) {
@@ -127,7 +122,7 @@ final class CargoUtils {
                 Inventory inventory = inventories.get(target.getLocation());
 
                 if (inventory != null) {
-                    return withdrawFromVanillaInventory(node, template, inventory);
+                    return withdrawFromVanillaInventory(network, node, template, inventory);
                 }
 
                 BlockState state = PaperLib.getBlockState(target, false).getState();
@@ -135,7 +130,7 @@ final class CargoUtils {
                 if (state instanceof InventoryHolder) {
                     inventory = ((InventoryHolder) state).getInventory();
                     inventories.put(target.getLocation(), inventory);
-                    return withdrawFromVanillaInventory(node, template, inventory);
+                    return withdrawFromVanillaInventory(network, node, template, inventory);
                 }
             }
 
@@ -147,7 +142,7 @@ final class CargoUtils {
         for (int slot : menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.WITHDRAW, null)) {
             ItemStack is = menu.getItemInSlot(slot);
 
-            if (SlimefunUtils.isItemSimilar(is, wrapper, true) && matchesFilter(node, is)) {
+            if (SlimefunUtils.isItemSimilar(is, wrapper, true) && matchesFilter(network, node, is)) {
                 if (is.getAmount() > template.getAmount()) {
                     is.setAmount(is.getAmount() - template.getAmount());
                     menu.replaceExistingItem(slot, is.clone());
@@ -162,7 +157,7 @@ final class CargoUtils {
         return null;
     }
 
-    static ItemStack withdrawFromVanillaInventory(Block node, ItemStack template, Inventory inv) {
+    static ItemStack withdrawFromVanillaInventory(AbstractItemNetwork network, Block node, ItemStack template, Inventory inv) {
         ItemStack[] contents = inv.getContents();
         int[] range = getOutputSlotRange(inv);
         int minSlot = range[0];
@@ -174,7 +169,7 @@ final class CargoUtils {
             // Changes to these ItemStacks are synchronized with the Item in the Inventory
             ItemStack itemInSlot = contents[slot];
 
-            if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false) && matchesFilter(node, itemInSlot)) {
+            if (SlimefunUtils.isItemSimilar(itemInSlot, wrapper, true, false) && matchesFilter(network, node, itemInSlot)) {
                 if (itemInSlot.getAmount() > template.getAmount()) {
                     itemInSlot.setAmount(itemInSlot.getAmount() - template.getAmount());
                     return template;
@@ -189,14 +184,14 @@ final class CargoUtils {
         return null;
     }
 
-    static ItemStackAndInteger withdraw(Map<Location, Inventory> inventories, Block node, Block target) {
+    static ItemStackAndInteger withdraw(AbstractItemNetwork network, Map<Location, Inventory> inventories, Block node, Block target) {
         DirtyChestMenu menu = getChestMenu(target);
 
         if (menu != null) {
             for (int slot : menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.WITHDRAW, null)) {
                 ItemStack is = menu.getItemInSlot(slot);
 
-                if (matchesFilter(node, is)) {
+                if (matchesFilter(network, node, is)) {
                     menu.replaceExistingItem(slot, null);
                     return new ItemStackAndInteger(is, slot);
                 }
@@ -205,7 +200,7 @@ final class CargoUtils {
             Inventory inventory = inventories.get(target.getLocation());
 
             if (inventory != null) {
-                return withdrawFromVanillaInventory(node, inventory);
+                return withdrawFromVanillaInventory(network, node, inventory);
             }
 
             BlockState state = PaperLib.getBlockState(target, false).getState();
@@ -213,14 +208,14 @@ final class CargoUtils {
             if (state instanceof InventoryHolder) {
                 inventory = ((InventoryHolder) state).getInventory();
                 inventories.put(target.getLocation(), inventory);
-                return withdrawFromVanillaInventory(node, inventory);
+                return withdrawFromVanillaInventory(network, node, inventory);
             }
         }
 
         return null;
     }
 
-    private static ItemStackAndInteger withdrawFromVanillaInventory(Block node, Inventory inv) {
+    private static ItemStackAndInteger withdrawFromVanillaInventory(AbstractItemNetwork network, Block node, Inventory inv) {
         ItemStack[] contents = inv.getContents();
         int[] range = getOutputSlotRange(inv);
         int minSlot = range[0];
@@ -229,7 +224,7 @@ final class CargoUtils {
         for (int slot = minSlot; slot < maxSlot; slot++) {
             ItemStack is = contents[slot];
 
-            if (matchesFilter(node, is)) {
+            if (matchesFilter(network, node, is)) {
                 inv.setItem(slot, null);
                 return new ItemStackAndInteger(is, slot);
             }
@@ -238,8 +233,8 @@ final class CargoUtils {
         return null;
     }
 
-    static ItemStack insert(Map<Location, Inventory> inventories, Block node, Block target, ItemStack stack) {
-        if (!matchesFilter(node, stack)) {
+    static ItemStack insert(AbstractItemNetwork network, Map<Location, Inventory> inventories, Block node, Block target, ItemStack stack) {
+        if (!matchesFilter(network, node, stack)) {
             return stack;
         }
 
@@ -340,77 +335,12 @@ final class CargoUtils {
         return BlockStorage.getUniversalInventory(block);
     }
 
-    static boolean matchesFilter(@Nonnull Block block, @Nullable ItemStack item) {
+    static boolean matchesFilter(@Nonnull AbstractItemNetwork network, @Nonnull Block node, @Nullable ItemStack item) {
         if (item == null || item.getType() == Material.AIR) {
             return false;
         }
 
-        // Store the returned Config instance to avoid heavy calls
-        Config blockData = BlockStorage.getLocationInfo(block.getLocation());
-        String id = blockData.getString("id");
-
-        if (id == null) {
-            // This should normally not happen but if it does...
-            // Don't accept any items.
-            return false;
-        } else if (id.equals("CARGO_NODE_OUTPUT")) {
-            // Cargo Output nodes have no filter actually
-            return true;
-        }
-
-        try {
-            BlockMenu menu = BlockStorage.getInventory(block.getLocation());
-
-            if (menu == null) {
-                return false;
-            }
-
-            boolean lore = "true".equals(blockData.getString("filter-lore"));
-            boolean allowByDefault = !"whitelist".equals(blockData.getString("filter-type"));
-            return matchesFilterList(item, menu, lore, allowByDefault);
-        } catch (Exception x) {
-            Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception occurred while trying to filter items for a Cargo Node (" + id + ") at " + new BlockPosition(block));
-            return false;
-        }
-    }
-
-    private static boolean matchesFilterList(ItemStack item, BlockMenu menu, boolean respectLore, boolean defaultValue) {
-        // Little performance optimization:
-        // First check if there is more than one item to compare, if so
-        // then we know we should create an ItemStackWrapper, otherwise it would
-        // be of no benefit to us and just be redundant
-        int itemsToCompare = 0;
-
-        for (int slot : FILTER_SLOTS) {
-            ItemStack stack = menu.getItemInSlot(slot);
-
-            if (stack != null && stack.getType() != Material.AIR) {
-                itemsToCompare++;
-
-                if (itemsToCompare > 1) {
-                    break;
-                }
-            }
-        }
-
-        // Check if there are any non-air items
-        if (itemsToCompare > 0) {
-            // Only create the Wrapper if its worth it
-            if (itemsToCompare > 1) {
-                // Create an itemStackWrapper to save performance
-                item = new ItemStackWrapper(item);
-            }
-
-            for (int slot : FILTER_SLOTS) {
-                ItemStack stack = menu.getItemInSlot(slot);
-
-                if (SlimefunUtils.isItemSimilar(stack, item, respectLore, false)) {
-                    return !defaultValue;
-                }
-            }
-        }
-
-        return defaultValue;
+        return network.getItemFilter(node).test(item);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -32,8 +32,10 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 final class CargoUtils {
 
-    // Whitelist or blacklist slots
-    private static final int[] FILTER_SLOTS = { 19, 20, 21, 28, 29, 30, 37, 38, 39 };
+    /**
+     * These are the slots where our filter items sit.
+     */
+    static final int[] FILTER_SLOTS = { 19, 20, 21, 28, 29, 30, 37, 38, 39 };
 
     private CargoUtils() {}
 
@@ -391,7 +393,7 @@ final class CargoUtils {
             }
         }
 
-        // Check if there are event non-air items
+        // Check if there are any non-air items
         if (itemsToCompare > 0) {
             // Only create the Wrapper if its worth it
             if (itemsToCompare > 1) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
@@ -96,6 +96,8 @@ class ItemFilter implements Predicate<ItemStack> {
                 }
             }
         }
+
+        this.dirty = false;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
@@ -1,0 +1,173 @@
+package io.github.thebusybiscuit.slimefun4.core.networks.cargo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
+import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+
+/**
+ * The {@link ItemFilter} is a performance-optimization for our {@link CargoNet}.
+ * It is a snapshot of a cargo node's configuration.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+class ItemFilter implements Predicate<ItemStack> {
+
+    /**
+     * Our {@link List} of items to check against, might be empty.
+     */
+    private final List<ItemStackWrapper> items = new ArrayList<>();
+
+    /**
+     * Our default value for this {@link ItemFilter}.
+     * A default value of {@literal true} will mean that it returns true if no
+     * match was found. It will deny any items that match.
+     * A default value of {@literal false} means that it will return false if no
+     * match was found. Only items that match will make it past this {@link ItemFilter}.
+     */
+    private boolean defaultValue;
+
+    /**
+     * Whether we should also compare the lore.
+     */
+    private boolean checkLore;
+
+    /**
+     * If an {@link ItemFilter} is marked as dirty / outdated, then it will be updated
+     * on the next tick.
+     */
+    private boolean dirty = false;
+
+    /**
+     * This creates a new {@link ItemFilter} for the given {@link Block}.
+     * This will copy all settings from that {@link Block} to this filter.
+     * 
+     * @param b
+     *            The {@link Block}
+     */
+    public ItemFilter(@Nonnull Block b) {
+        update(b);
+    }
+
+    /**
+     * This updates or refreshes the {@link ItemFilter} to copy the settings
+     * from the given {@link Block}. It takes a new snapshot.
+     * 
+     * @param b
+     *            The {@link Block}
+     */
+    public void update(@Nonnull Block b) {
+        // Store the returned Config instance to avoid heavy calls
+        Config blockData = BlockStorage.getLocationInfo(b.getLocation());
+        String id = blockData.getString("id");
+        SlimefunItem item = SlimefunItem.getByID(id);
+        BlockMenu menu = BlockStorage.getInventory(b.getLocation());
+
+        if (item == null || menu == null) {
+            // Don't filter for a non-existing item (safety check)
+            clear(false);
+        } else if (id.equals("CARGO_NODE_OUTPUT")) {
+            // Output Nodes have no filter, allow everything
+            clear(true);
+        } else {
+            this.items.clear();
+            this.checkLore = Objects.equals(blockData.getString("filter-lore"), "true");
+            this.defaultValue = !Objects.equals(blockData.getString("filter-type"), "whitelist");
+
+            for (int slot : CargoUtils.FILTER_SLOTS) {
+                ItemStack stack = menu.getItemInSlot(slot);
+
+                if (stack != null && stack.getType() != Material.AIR) {
+                    this.items.add(new ItemStackWrapper(stack));
+                }
+            }
+        }
+    }
+
+    /**
+     * This will clear the {@link ItemFilter} and reject <strong>any</strong>
+     * {@link ItemStack}.
+     * 
+     * @param defaultValue
+     *            The new default value.
+     */
+    private void clear(boolean defaultValue) {
+        this.items.clear();
+        this.checkLore = false;
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+     * Whether this {@link ItemFilter} is outdated and needs to be refreshed.
+     * 
+     * @return Whether the filter is outdated.
+     */
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    /**
+     * This marks this {@link ItemFilter} as dirty / outdated.
+     */
+    public void markDirty() {
+        this.dirty = true;
+    }
+
+    @Override
+    public boolean test(@Nonnull ItemStack item) {
+        // An empty Filter does not need to be iterated over.
+        if (items.isEmpty()) {
+            return defaultValue;
+        }
+
+        int potentialMatches = 0;
+
+        // This is a first check for materials to see if we might even have any match.
+        // If there is no potential match then we won't need to perform the quite
+        // intense operation .getItemMeta()
+        for (ItemStackWrapper stack : items) {
+            if (stack.getType() == item.getType()) {
+                // We found a potential match based on the Material
+                potentialMatches++;
+            }
+        }
+
+        if (potentialMatches == 0) {
+            // If there is no match, we can safely assume the default value
+            return defaultValue;
+        } else {
+            // If there is more than one potential match, create a wrapper to save
+            // performance on the Item Meta otherwise just use the item directly.
+            ItemStack subject = potentialMatches == 1 ? item : new ItemStackWrapper(item);
+
+            // If there is only one match, we won't need to create a Wrapper
+            // and thus only perform .getItemMeta() once
+            for (ItemStackWrapper stack : items) {
+                if (SlimefunUtils.isItemSimilar(subject, stack, checkLore, false)) {
+                    // The filter has found a match, we can return the opposite
+                    // of our default value. If we exclude items, this is where we
+                    // would return false. Otherwise we return true.
+                    return !defaultValue;
+                }
+            }
+
+            // If no particular item was matched, we fallback to the default value.
+            return defaultValue;
+        }
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
@@ -1,5 +1,9 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -9,6 +13,7 @@ import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.ColoredMaterials;
@@ -16,7 +21,6 @@ import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
 import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
@@ -29,27 +33,13 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
  * @author TheBusyBiscuit
  *
  */
-abstract class AbstractCargoNode extends SlimefunItem {
+abstract class AbstractCargoNode extends SimpleSlimefunItem<BlockPlaceHandler> {
 
     protected static final String FREQUENCY = "frequency";
 
+    @ParametersAreNonnullByDefault
     public AbstractCargoNode(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
         super(category, item, recipeType, recipe, recipeOutput);
-
-        addItemHandler(new BlockPlaceHandler(false) {
-
-            @Override
-            public void onPlayerPlace(BlockPlaceEvent e) {
-                Block b = e.getBlock();
-
-                // The owner and frequency are required by every node
-                BlockStorage.addBlockInfo(b, "owner", e.getPlayer().getUniqueId().toString());
-                BlockStorage.addBlockInfo(b, FREQUENCY, "0");
-
-                onPlace(e);
-            }
-
-        });
 
         new BlockMenuPreset(getId(), ChatUtils.removeColorCodes(item.getItemMeta().getDisplayName())) {
 
@@ -60,6 +50,7 @@ abstract class AbstractCargoNode extends SlimefunItem {
 
             @Override
             public void newInstance(BlockMenu menu, Block b) {
+                menu.addMenuCloseHandler(p -> markDirty(b.getLocation()));
                 updateBlockMenu(menu, b);
             }
 
@@ -75,6 +66,25 @@ abstract class AbstractCargoNode extends SlimefunItem {
         };
     }
 
+    @Override
+    public BlockPlaceHandler getItemHandler() {
+        return new BlockPlaceHandler(false) {
+
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Block b = e.getBlock();
+
+                // The owner and frequency are required by every node
+                BlockStorage.addBlockInfo(b, "owner", e.getPlayer().getUniqueId().toString());
+                BlockStorage.addBlockInfo(b, FREQUENCY, "0");
+
+                onPlace(e);
+            }
+
+        };
+    }
+
+    @ParametersAreNonnullByDefault
     protected void addChannelSelector(Block b, BlockMenu menu, int slotPrev, int slotCurrent, int slotNext) {
         boolean isChestTerminalInstalled = SlimefunPlugin.getThirdPartySupportService().isChestTerminalInstalled();
         int channel = getSelectedChannel(b);
@@ -122,7 +132,7 @@ abstract class AbstractCargoNode extends SlimefunItem {
         });
     }
 
-    private int getSelectedChannel(Block b) {
+    private int getSelectedChannel(@Nonnull Block b) {
         if (!BlockStorage.hasBlockInfo(b)) {
             return 0;
         } else {
@@ -137,10 +147,12 @@ abstract class AbstractCargoNode extends SlimefunItem {
         }
     }
 
-    protected abstract void onPlace(BlockPlaceEvent e);
+    protected abstract void onPlace(@Nonnull BlockPlaceEvent e);
 
-    protected abstract void createBorder(BlockMenuPreset preset);
+    protected abstract void createBorder(@Nonnull BlockMenuPreset preset);
 
-    protected abstract void updateBlockMenu(BlockMenu menu, Block b);
+    protected abstract void updateBlockMenu(@Nonnull BlockMenu menu, @Nonnull Block b);
+
+    protected abstract void markDirty(@Nonnull Location loc);
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
@@ -1,11 +1,15 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
+import javax.annotation.Nonnull;
+
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
+import io.github.thebusybiscuit.slimefun4.core.networks.cargo.CargoNet;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
@@ -65,7 +69,8 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
 
     @Override
     protected void updateBlockMenu(BlockMenu menu, Block b) {
-        String filterType = BlockStorage.getLocationInfo(b.getLocation(), FILTER_TYPE);
+        Location loc = b.getLocation();
+        String filterType = BlockStorage.getLocationInfo(loc, FILTER_TYPE);
 
         if (!BlockStorage.hasBlockInfo(b) || filterType == null || filterType.equals("whitelist")) {
             menu.replaceExistingItem(15, new CustomItem(Material.WHITE_WOOL, "&7Type: &rWhitelist", "", "&e> Click to change it to Blacklist"));
@@ -102,6 +107,16 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
         }
 
         addChannelSelector(b, menu, 41, 42, 43);
+        markDirty(loc);
+    }
+
+    @Override
+    protected void markDirty(@Nonnull Location loc) {
+        CargoNet network = CargoNet.getNetworkFromLocation(loc);
+
+        if (network != null) {
+            network.markCargoNodeConfigurationDirty(loc);
+        }
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -36,6 +37,11 @@ public class CargoOutputNode extends AbstractCargoNode {
     @Override
     protected void updateBlockMenu(BlockMenu menu, Block b) {
         addChannelSelector(b, menu, 12, 13, 14);
+    }
+
+    @Override
+    protected void markDirty(Location loc) {
+        // No need to mark anything as dirty, there is no item filter.
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
This PR adds a little performance optimization to cargo networks.
Since `ItemStack#getItemMeta()` is a heavy call which creates a cloned instance everytime it is invoked, any way to reduce these calls to a bare minimum is a welcome performance improvement.
Here I have created an `ItemFilter` class, which is a `Predicate<ItemStack>` and it serves the point of representing a cargo node's configuration as a simple object.
This instance is cached in a `HashMap`, it will be updated once marked dirty.
It will be marked dirty when:
* The cargo node's configuration was directly modified
* The cargo node's configuration screen is closed (that way we will know when people modified the filtered items.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
