### PR TITLE
Smallest documentation fix ever

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/AnvilListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/AnvilListener.java
@@ -15,8 +15,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
 /**
- * This {@link Listener} prevents any {@link SlimefunItem} from being used in a
- * {@link BrewingStand}.
+ * This {@link Listener} prevents any {@link SlimefunItem} from being used in an
+ * anvil.
  * 
  * @author TheBusyBiscuit
  *

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/BrewingStandListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/BrewingStandListener.java
@@ -17,7 +17,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
 /**
  * This {@link Listener} prevents any {@link SlimefunItem} from being used in a
- * {@link BrewingStand}.
+ * brewing stand.
  * 
  * @author VoidAngel
  * @author SoSeDiK


### PR DESCRIPTION
## Description
Anvil Listener had doc comment copied from Brewing Stand.

## Changes
Changed one link

## Related Issues
N/A

## Checklist
N/A:
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
