### PR TITLE
Fixes #2509

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -281,6 +282,8 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
      * @return Whether charge was taken if its chargeable
      */
     protected boolean takeCharge(@Nonnull Location l) {
+        Validate.notNull(l, "Can't attempt to take charge from a null location!");
+
         if (isChargeable()) {
             if (getCharge(l) < getEnergyConsumption()) {
                 return false;

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -243,15 +244,16 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
             if (timeleft > 0) {
                 ChestMenuUtils.updateProgressbar(inv, 22, timeleft, processing.get(b).getTicks(), getProgressBar());
 
-                if (isChargeable()) {
-                    if (getCharge(b.getLocation()) < getEnergyConsumption()) {
-                        return;
-                    }
-
-                    removeCharge(b.getLocation(), getEnergyConsumption());
+                if (!takeCharge(b.getLocation())) {
+                    return;
                 }
+
                 progress.put(b, timeleft - 1);
             } else {
+                if (!takeCharge(b.getLocation())) {
+                    return;
+                }
+
                 inv.replaceExistingItem(22, new CustomItem(Material.BLACK_STAINED_GLASS_PANE, " "));
 
                 for (ItemStack output : processing.get(b).getOutput()) {
@@ -271,6 +273,17 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
                 progress.put(b, next.getTicks());
             }
         }
+    }
+
+    protected boolean takeCharge(Location l) {
+        if (isChargeable()) {
+            if (getCharge(l) < getEnergyConsumption()) {
+                return false;
+            }
+
+            removeCharge(l, getEnergyConsumption());
+        }
+        return true;
     }
 
     protected MachineRecipe findNextRecipe(BlockMenu inv) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -249,10 +249,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
                 }
 
                 progress.put(b, timeleft - 1);
-            } else {
-                if (!takeCharge(b.getLocation())) {
-                    return;
-                }
+            } else if (takeCharge(b.getLocation())) {
 
                 inv.replaceExistingItem(22, new CustomItem(Material.BLACK_STAINED_GLASS_PANE, " "));
 


### PR DESCRIPTION
## Description
AContainers will now check and take charge when they are outputting, not just when progressing.

## Changes
Added a method to check and take the charge ,called it before outputting

## Related Issues
Resolves #2509 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
