### PR TITLE
Adding slimefun item recipe uses to guide

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -13,6 +13,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nonnull;
 
+import me.mrCookieSlime.Slimefun.api.Slimefun;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Server;
 import org.bukkit.entity.Entity;
@@ -53,6 +55,8 @@ public final class SlimefunRegistry {
     private final Map<String, SlimefunItem> slimefunIds = new HashMap<>();
     private final List<SlimefunItem> slimefunItems = new ArrayList<>();
     private final List<SlimefunItem> enabledItems = new ArrayList<>();
+
+    private Map<SlimefunItem, List<SlimefunItem>> slimefunItemUses = null;
 
     private final List<Category> categories = new ArrayList<>();
     private final List<MultiBlock> multiblocks = new LinkedList<>();
@@ -102,6 +106,24 @@ public final class SlimefunRegistry {
         freeCreativeResearches = cfg.getBoolean("researches.free-in-creative-mode");
         researchFireworks = cfg.getBoolean("researches.enable-fireworks");
         logDuplicateBlockEntries = cfg.getBoolean("options.log-duplicate-block-entries");
+    }
+
+    public void loadRecipeUses() {
+        Map<SlimefunItem, List<SlimefunItem>> recipeUses = new HashMap<>();
+
+        for (SlimefunItem item : enabledItems) {
+            List<SlimefunItem> uses = new ArrayList<>();
+
+            for (SlimefunItem checkingItem : enabledItems) {
+                if (ArrayUtils.contains(checkingItem.getRecipe(), item.getItem())) {
+                    uses.add(checkingItem);
+                }
+
+                //add display item stuff
+            }
+
+            recipeUses.put(item, uses);
+        }
     }
 
     /**
@@ -155,6 +177,15 @@ public final class SlimefunRegistry {
      */
     public List<SlimefunItem> getEnabledSlimefunItems() {
         return enabledItems;
+    }
+
+    /**
+     * This {@link Map} contains the recipe uses for each {@link SlimefunItem} in other {@link SlimefunItem}s
+     *
+     * @return A {@link Map} containing the recipe uses for each {@link SlimefunItem} in other {@link SlimefunItem}s
+     */
+    public Map<SlimefunItem, List<SlimefunItem>> getSlimefunItemUses() {
+        return slimefunItemUses;
     }
 
     public List<Research> getResearches() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -57,7 +57,7 @@ public final class SlimefunRegistry {
     private final List<SlimefunItem> slimefunItems = new ArrayList<>();
     private final List<SlimefunItem> enabledItems = new ArrayList<>();
 
-    private Map<SlimefunItem, List<Pair<SlimefunItem, Integer>>> slimefunItemUses = null;
+    private final Map<SlimefunItem, List<Pair<SlimefunItem, Integer>>> slimefunItemUses = new HashMap<>();
 
     private final List<Category> categories = new ArrayList<>();
     private final List<MultiBlock> multiblocks = new LinkedList<>();
@@ -107,38 +107,6 @@ public final class SlimefunRegistry {
         freeCreativeResearches = cfg.getBoolean("researches.free-in-creative-mode");
         researchFireworks = cfg.getBoolean("researches.enable-fireworks");
         logDuplicateBlockEntries = cfg.getBoolean("options.log-duplicate-block-entries");
-    }
-
-    public void loadRecipeUses() {
-        Map<SlimefunItem, List<Pair<SlimefunItem, Integer>>> recipeUses = new HashMap<>();
-
-        for (SlimefunItem item : enabledItems) {
-            List<Pair<SlimefunItem, Integer>> uses = new ArrayList<>();
-
-            for (SlimefunItem checkingItem : enabledItems) {
-                if (ArrayUtils.contains(checkingItem.getRecipe(), item.getItem())) {
-                    uses.add(new Pair<>(checkingItem, -1));
-                }
-
-                if (checkingItem instanceof RecipeDisplayItem) {
-                   List<ItemStack> displayRecipes = ((RecipeDisplayItem) checkingItem).getDisplayRecipes();
-
-                    for (ItemStack display : displayRecipes) { //checks for duplicate display item/normal recipes
-                        if (item.getItem() == display) {
-
-                            int index = displayRecipes.indexOf(item.getItem());
-                            if (index % 2 == 0 && displayRecipes.size() > index + 1) {
-                               uses.add(new Pair<>(checkingItem, displayRecipes.indexOf(item.getItem())));
-                            }
-                        }
-                    }
-                }
-            }
-
-            recipeUses.put(item, uses);
-        }
-
-        slimefunItemUses = recipeUses;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -15,7 +15,6 @@ import javax.annotation.Nonnull;
 
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import me.mrCookieSlime.CSCoreLibPlugin.cscorelib2.collections.Pair;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Server;
 import org.bukkit.entity.Entity;
@@ -114,7 +113,7 @@ public final class SlimefunRegistry {
      * Auto-Loading will automatically call {@link SlimefunItem#load()} when the item is registered.
      * Normally that method is called after the {@link Server} finished starting up.
      * But in the unusual scenario if a {@link SlimefunItem} is registered after that, this is gonna cover that.
-     *
+     * 
      * @return Whether auto-loading is enabled
      */
     public boolean isAutoLoadingEnabled() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -46,7 +46,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.UniversalBlockMenu;
 /**
  * This class houses a lot of instances of {@link Map} and {@link List} that hold
  * various mappings and collections related to {@link SlimefunItem}.
- *
+ * 
  * @author TheBusyBiscuit
  *
  */
@@ -124,7 +124,7 @@ public final class SlimefunRegistry {
      * This method returns whether backwards-compatibility is enabled.
      * Backwards compatibility allows Slimefun to recognize items from older versions but comes
      * at a huge performance cost.
-     *
+     * 
      * @return Whether backwards compatibility is enabled
      */
     public boolean isBackwardsCompatible() {
@@ -145,7 +145,7 @@ public final class SlimefunRegistry {
 
     /**
      * This {@link List} contains every {@link SlimefunItem}, even disabled items.
-     *
+     * 
      * @return A {@link List} containing every {@link SlimefunItem}
      */
     public List<SlimefunItem> getAllSlimefunItems() {
@@ -154,7 +154,7 @@ public final class SlimefunRegistry {
 
     /**
      * This {@link List} contains every <strong>enabled</strong> {@link SlimefunItem}.
-     *
+     * 
      * @return A {@link List} containing every enabled {@link SlimefunItem}
      */
     public List<SlimefunItem> getEnabledSlimefunItems() {
@@ -165,7 +165,7 @@ public final class SlimefunRegistry {
      * This {@link Map} contains the recipe uses for each {@link SlimefunItem} in other {@link SlimefunItem}s
      * The boolean part of the pair represents whether the {@link SlimefunItem} is part of the main recipe
      * or the {@link RecipeDisplayItem} slots
-     *
+     * 
      * @return A {@link Map} containing the recipe uses for each {@link SlimefunItem} in other {@link SlimefunItem}s
      */
     public Map<SlimefunItem, List<Pair<SlimefunItem, Integer>>> getSlimefunItemUses() {
@@ -215,7 +215,7 @@ public final class SlimefunRegistry {
     /**
      * This returns a {@link Map} connecting the {@link EntityType} with a {@link Set}
      * of {@link ItemStack ItemStacks} which would be dropped when an {@link Entity} of that type was killed.
-     *
+     * 
      * @return The {@link Map} of custom mob drops
      */
     public Map<EntityType, Set<ItemStack>> getMobDrops() {
@@ -225,7 +225,7 @@ public final class SlimefunRegistry {
     /**
      * This returns a {@link Set} of {@link ItemStack ItemStacks} which can be obtained by bartering
      * with {@link Piglin Piglins}.
-     *
+     * 
      * @return A {@link Set} of bartering drops
      */
     public Set<ItemStack> getBarteringDrops() {
@@ -278,9 +278,9 @@ public final class SlimefunRegistry {
 
     /**
      * This method returns a list of recipes for the {@link AutomatedCraftingChamber}
-     *
+     * 
      * @deprecated This just a really bad way to do this. Someone needs to rewrite this.
-     *
+     * 
      * @return A list of recipes for the {@link AutomatedCraftingChamber}
      */
     @Deprecated

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -108,6 +108,20 @@ public class GuideHistory {
         queue.add(new GuideEntry<>(searchTerm, 0));
     }
 
+    /**
+     * This method replaces the last entry in this {@link GuideHistory}.
+     *
+     * @param item entry to add in place of old
+     */
+    public void replaceLastEntry(Object item) {
+        queue.removeLast();
+        if (item instanceof SlimefunItemRecipeUses) {
+            add((SlimefunItemRecipeUses) item);
+        } else if (item instanceof SlimefunItem) {
+            add((SlimefunItem) item);
+        }
+    }
+
     private <T> void refresh(@Nonnull T object, int page) {
         Validate.notNull(object, "Cannot add a null Entry to the GuideHistory!");
         Validate.isTrue(page >= 0, "page must not be negative!");
@@ -133,7 +147,7 @@ public class GuideHistory {
     /**
      * Retrieves the last page in the {@link SlimefunGuide} that was visited by a {@link Player}.
      * Optionally also rewinds the history back to that entry.
-     * 
+     *
      * @param remove
      *            Whether to remove the current entry so it moves back to the entry returned.
      * @return The last Guide Entry that was saved to the given Players guide history.
@@ -145,6 +159,20 @@ public class GuideHistory {
         }
 
         return queue.isEmpty() ? null : queue.getLast();
+    }
+
+    /**
+     * This method gets the last object in the {@link Player}s history.
+     *
+     * @return the last object in the {@link Player}s history.
+     */
+    @Nullable
+    public Object getLastObject() {
+        GuideEntry<?> lastEntry = getLastEntry(false);
+        if (lastEntry != null) {
+            return lastEntry.getIndexedObject();
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.core.guide;
 
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -87,13 +88,13 @@ public class GuideHistory {
     }
 
     /**
-     * This method stores the given {@link SlimefunItemRecipeUses} in this {@link GuideHistory}.
+     * This method stores the given {@link SlimefunItemRecipeUse} in this {@link GuideHistory}.
      *
      * @param item
-     *            The {@link SlimefunItemRecipeUses} that should be added to this {@link GuideHistory}
+     *            The {@link SlimefunItemRecipeUse} that should be added to this {@link GuideHistory}
      */
-    public void add(@Nonnull SlimefunItemRecipeUses item) {
-        Validate.notNull(item, "Cannot add a non-existing SlimefunItemRecipeUses to the GuideHistory!");
+    public void add(@Nonnull SlimefunItemRecipeUse item) {
+        Validate.notNull(item, "Cannot add a non-existing SlimefunItemRecipeUse to the GuideHistory!");
         queue.add(new GuideEntry<>(item, 0));
     }
 
@@ -115,8 +116,8 @@ public class GuideHistory {
      */
     public void replaceLastEntry(Object item) {
         queue.removeLast();
-        if (item instanceof SlimefunItemRecipeUses) {
-            add((SlimefunItemRecipeUses) item);
+        if (item instanceof SlimefunItemRecipeUse) {
+            add((SlimefunItemRecipeUse) item);
         } else if (item instanceof SlimefunItem) {
             add((SlimefunItem) item);
         }
@@ -176,6 +177,36 @@ public class GuideHistory {
     }
 
     /**
+     * This method checks if a {@link Player}s history contains a certain {@link SlimefunItem}
+     *
+     * @param item {@link SlimefunItem} to check for
+     * @return whether the history contains that {@link SlimefunItem}
+     */
+    public boolean containsSlimefunItem(SlimefunItem item) {
+        for (GuideEntry<?> entry : queue) {
+            if (Objects.equals(entry.getIndexedObject(), item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This method checks if a {@link Player}s history contains a certain {@link SlimefunItem}'s recipe uses
+     *
+     * @param item {@link SlimefunItem} recipe uses to check for
+     * @return whether the history contains that {@link SlimefunItem}'s recipe uses
+     */
+    public boolean containsRecipeUses(SlimefunItem item) {
+        for (GuideEntry<?> entry : queue) {
+            if (entry.getIndexedObject() instanceof SlimefunItemRecipeUse && ((SlimefunItemRecipeUse) entry.getIndexedObject()).getItem().equals(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * This method opens the last opened entry to the associated {@link PlayerProfile}
      * of this {@link GuideHistory}.
      * 
@@ -207,8 +238,8 @@ public class GuideHistory {
             guide.openMainMenu(profile, 1);
         } else if (entry.getIndexedObject() instanceof Category) {
             guide.openCategory(profile, (Category) entry.getIndexedObject(), entry.getPage());
-        } else if (entry.getIndexedObject() instanceof SlimefunItemRecipeUses) {
-            guide.displayRecipeUses(profile, (SlimefunItemRecipeUses) entry.getIndexedObject(), false);
+        } else if (entry.getIndexedObject() instanceof SlimefunItemRecipeUse) {
+            guide.displayRecipeUses(profile, (SlimefunItemRecipeUse) entry.getIndexedObject(), false);
         } else if (entry.getIndexedObject() instanceof SlimefunItem) {
             guide.displayItem(profile, (SlimefunItem) entry.getIndexedObject(), false);
         } else if (entry.getIndexedObject() instanceof ItemStack) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -87,6 +87,17 @@ public class GuideHistory {
     }
 
     /**
+     * This method stores the given {@link SlimefunItemRecipeUses} in this {@link GuideHistory}.
+     *
+     * @param item
+     *            The {@link SlimefunItemRecipeUses} that should be added to this {@link GuideHistory}
+     */
+    public void add(@Nonnull SlimefunItemRecipeUses item) {
+        Validate.notNull(item, "Cannot add a non-existing SlimefunItemRecipeUses to the GuideHistory!");
+        queue.add(new GuideEntry<>(item, 0));
+    }
+
+    /**
      * This method stores the given search term in this {@link GuideHistory}.
      * 
      * @param searchTerm
@@ -168,6 +179,8 @@ public class GuideHistory {
             guide.openMainMenu(profile, 1);
         } else if (entry.getIndexedObject() instanceof Category) {
             guide.openCategory(profile, (Category) entry.getIndexedObject(), entry.getPage());
+        } else if (entry.getIndexedObject() instanceof SlimefunItemRecipeUses) {
+            guide.displayRecipeUses(profile, (SlimefunItemRecipeUses) entry.getIndexedObject(), false);
         } else if (entry.getIndexedObject() instanceof SlimefunItem) {
             guide.displayItem(profile, (SlimefunItem) entry.getIndexedObject(), false);
         } else if (entry.getIndexedObject() instanceof ItemStack) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -1,7 +1,9 @@
 package io.github.thebusybiscuit.slimefun4.core.guide;
 
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -177,31 +179,18 @@ public class GuideHistory {
     }
 
     /**
-     * This method checks if a {@link Player}s history contains a certain {@link SlimefunItem}
+     * This method checks if a {@link Player}s history contains a certain {@link SlimefunItemRecipeUse} regardless of page, excluding the last
      *
-     * @param item {@link SlimefunItem} to check for
-     * @return whether the history contains that {@link SlimefunItem}
-     */
-    public boolean containsSlimefunItem(SlimefunItem item) {
-        for (GuideEntry<?> entry : queue) {
-            if (Objects.equals(entry.getIndexedObject(), item)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * This method checks if a {@link Player}s history contains a certain {@link SlimefunItem}'s recipe uses
-     *
-     * @param item {@link SlimefunItem} recipe uses to check for
-     * @return whether the history contains that {@link SlimefunItem}'s recipe uses
+     * @param item {@link SlimefunItem} recipe use item to check for
+     * @return whether the history contains that {@link SlimefunItemRecipeUse}
      */
     public boolean containsRecipeUses(SlimefunItem item) {
+        int spot = 0;
         for (GuideEntry<?> entry : queue) {
-            if (entry.getIndexedObject() instanceof SlimefunItemRecipeUse && ((SlimefunItemRecipeUse) entry.getIndexedObject()).getItem().equals(item)) {
+            if (spot < queue.size() - 1 && entry.getIndexedObject() instanceof SlimefunItemRecipeUse && ((SlimefunItemRecipeUse) entry.getIndexedObject()).getItem().equals(item)) {
                 return true;
             }
+             spot++;
         }
         return false;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
@@ -103,7 +103,7 @@ public final class SlimefunGuide {
         SlimefunPlugin.getRegistry().getGuideLayout(SlimefunGuideLayout.CHEST).displayItem(profile, item, addToHistory);
     }
 
-    public static void displayItemRecipeUses(PlayerProfile profile, SlimefunItemRecipeUses itemUses, boolean addToHistory) {
+    public static void displayItemRecipeUses(PlayerProfile profile, SlimefunItemRecipeUse itemUses, boolean addToHistory) {
         SlimefunPlugin.getRegistry().getGuideLayout(SlimefunGuideLayout.CHEST).displayRecipeUses(profile, itemUses, addToHistory);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
@@ -103,6 +103,10 @@ public final class SlimefunGuide {
         SlimefunPlugin.getRegistry().getGuideLayout(SlimefunGuideLayout.CHEST).displayItem(profile, item, addToHistory);
     }
 
+    public static void displayItemRecipeUses(PlayerProfile profile, SlimefunItemRecipeUses itemUses, boolean addToHistory) {
+        SlimefunPlugin.getRegistry().getGuideLayout(SlimefunGuideLayout.CHEST).displayRecipeUses(profile, itemUses, addToHistory);
+    }
+
     public static boolean isGuideItem(ItemStack item) {
         return SlimefunUtils.isItemSimilar(item, getItem(SlimefunGuideLayout.CHEST), true) || SlimefunUtils.isItemSimilar(item, getItem(SlimefunGuideLayout.BOOK), true) || SlimefunUtils.isItemSimilar(item, getItem(SlimefunGuideLayout.CHEAT_SHEET), true);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
@@ -66,6 +66,8 @@ public interface SlimefunGuideImplementation {
 
     void displayItem(PlayerProfile profile, SlimefunItem item, boolean addToHistory);
 
+    void displayRecipeUses(PlayerProfile profile, SlimefunItemRecipeUses itemUses, boolean addToHistory);
+
     default void unlockItem(Player p, SlimefunItem sfitem, Consumer<Player> callback) {
         Research research = sfitem.getResearch();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
@@ -66,7 +66,7 @@ public interface SlimefunGuideImplementation {
 
     void displayItem(PlayerProfile profile, SlimefunItem item, boolean addToHistory);
 
-    void displayRecipeUses(PlayerProfile profile, SlimefunItemRecipeUses itemUses, boolean addToHistory);
+    void displayRecipeUses(PlayerProfile profile, SlimefunItemRecipeUse itemUses, boolean addToHistory);
 
     default void unlockItem(Player p, SlimefunItem sfitem, Consumer<Player> callback) {
         Research research = sfitem.getResearch();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUse.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUse.java
@@ -10,21 +10,15 @@ import java.util.List;
  * This object holds a {@link SlimefunItem} for use in the {@link GuideHistory}
  * when opening the recipe uses for that {@link SlimefunItem} as well as the page of those uses
  */
-public class SlimefunItemRecipeUses {
+public class SlimefunItemRecipeUse {
 
     private final SlimefunItem item;
     private final int page;
     private final List<Pair<SlimefunItem, Integer>> uses;
 
-    public SlimefunItemRecipeUses(SlimefunItem item, int page) {
+    public SlimefunItemRecipeUse(SlimefunItem item, int page) {
         this.item = item;
         this.page = page;
-
-        //first time a player uses this it loads all recipe uses
-        if (SlimefunPlugin.getRegistry().getSlimefunItemUses() == null) {
-            SlimefunPlugin.getRegistry().loadRecipeUses(); //move this to first time opening guide
-        }
-
         this.uses = SlimefunPlugin.getRegistry().getSlimefunItemUses().get(item);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUse.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUse.java
@@ -4,6 +4,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.CSCoreLibPlugin.cscorelib2.collections.Pair;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -16,12 +18,13 @@ public class SlimefunItemRecipeUse {
     private final int page;
     private final List<Pair<SlimefunItem, Integer>> uses;
 
-    public SlimefunItemRecipeUse(SlimefunItem item, int page) {
+    public SlimefunItemRecipeUse(@Nonnull SlimefunItem item, int page) {
         this.item = item;
         this.page = page;
         this.uses = SlimefunPlugin.getRegistry().getSlimefunItemUses().get(item);
     }
-
+    
+    @Nonnull
     public SlimefunItem getItem() {
         return this.item;
     }
@@ -30,6 +33,7 @@ public class SlimefunItemRecipeUse {
         return this.page;
     }
 
+    @Nullable
     public List<Pair<SlimefunItem, Integer>> getUses() {
         return this.uses;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUses.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUses.java
@@ -1,0 +1,40 @@
+package io.github.thebusybiscuit.slimefun4.core.guide;
+
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+
+import java.util.List;
+
+/**
+ * This object holds a {@link SlimefunItem} for use in the {@link GuideHistory}
+ * when opening the recipe uses for that {@link SlimefunItem} as well as the page of those uses
+ */
+public class SlimefunItemRecipeUses {
+
+    private final SlimefunItem item;
+    private final int page;
+    private final List<SlimefunItem> uses;
+
+    public SlimefunItemRecipeUses(SlimefunItem item, int page) {
+        this.item = item;
+        this.page = page;
+
+        if (SlimefunPlugin.getRegistry().getSlimefunItemUses() == null) {
+            SlimefunPlugin.getRegistry().loadRecipeUses();
+        }
+
+        this.uses = SlimefunPlugin.getRegistry().getSlimefunItemUses().get(item);
+    }
+
+    public SlimefunItem getItem() {
+        return this.item;
+    }
+
+    public int getPage() {
+        return this.page;
+    }
+
+    public List<SlimefunItem> getUses() {
+        return this.uses;
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUses.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunItemRecipeUses.java
@@ -1,6 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.core.guide;
 
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import me.mrCookieSlime.CSCoreLibPlugin.cscorelib2.collections.Pair;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
 import java.util.List;
@@ -13,14 +14,15 @@ public class SlimefunItemRecipeUses {
 
     private final SlimefunItem item;
     private final int page;
-    private final List<SlimefunItem> uses;
+    private final List<Pair<SlimefunItem, Integer>> uses;
 
     public SlimefunItemRecipeUses(SlimefunItem item, int page) {
         this.item = item;
         this.page = page;
 
+        //first time a player uses this it loads all recipe uses
         if (SlimefunPlugin.getRegistry().getSlimefunItemUses() == null) {
-            SlimefunPlugin.getRegistry().loadRecipeUses();
+            SlimefunPlugin.getRegistry().loadRecipeUses(); //move this to first time opening guide
         }
 
         this.uses = SlimefunPlugin.getRegistry().getSlimefunItemUses().get(item);
@@ -34,7 +36,7 @@ public class SlimefunItemRecipeUses {
         return this.page;
     }
 
-    public List<SlimefunItem> getUses() {
+    public List<Pair<SlimefunItem, Integer>> getUses() {
         return this.uses;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
+import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunItemRecipeUses;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -254,4 +255,8 @@ public class BookSlimefunGuide implements SlimefunGuideImplementation {
         SlimefunGuide.displayItem(profile, item, addToHistory);
     }
 
+    @Override
+    public void displayRecipeUses(PlayerProfile profile, SlimefunItemRecipeUses itemUses, boolean addToHistory) {
+        SlimefunGuide.displayItemRecipeUses(profile, itemUses, addToHistory);
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/BookSlimefunGuide.java
@@ -5,7 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
-import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunItemRecipeUses;
+import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunItemRecipeUse;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -256,7 +256,7 @@ public class BookSlimefunGuide implements SlimefunGuideImplementation {
     }
 
     @Override
-    public void displayRecipeUses(PlayerProfile profile, SlimefunItemRecipeUses itemUses, boolean addToHistory) {
+    public void displayRecipeUses(PlayerProfile profile, SlimefunItemRecipeUse itemUses, boolean addToHistory) {
         SlimefunGuide.displayItemRecipeUses(profile, itemUses, addToHistory);
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -582,7 +582,7 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         List<Pair<SlimefunItem, Integer>> uses = recipeUse.getUses();
 
         //no uses
-        if (uses.size() == 0) {
+        if (uses == null || uses.size() == 0) {
             return;
         }
 
@@ -614,7 +614,7 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         int displayItemSpot = uses.get(page).getSecondValue();
         boolean useRecipeDisplayItems = displayItemSpot >= 0;
 
-        ChestMenu menu = new ChestMenu(ChatColor.stripColor(item.getItemName()) + "Uses");
+        ChestMenu menu = new ChestMenu(ChatColor.stripColor(item.getItemName()) + " Uses");
 
         addWiki(item, menu, p);
 
@@ -650,7 +650,11 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
         };
 
         if (useRecipeDisplayItems && use instanceof RecipeDisplayItem) { //RecipeDisplayItem recipe
-            List<ItemStack> displayRecipes = ((RecipeDisplayItem) use).getDisplayRecipes();
+
+            List<ItemStack> displayRecipes = new ArrayList<>(((RecipeDisplayItem) use).getDisplayRecipes());
+            if (displayRecipes.size() % 2 == 1) {
+                displayRecipes.add(null);
+            }
 
             menu.addItem(10, use.getItem(), normalClickHandler);
             menu.addItem(13, displayRecipes.get(displayItemSpot), normalClickHandler);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -268,12 +268,15 @@ public final class PostSetup {
     }
 
     private static void loadRecipeUses() {
+        Slimefun.getLogger().log(Level.INFO, "Loading item usages...");
+
         for (SlimefunItem item : SlimefunPlugin.getRegistry().getEnabledSlimefunItems()) {
             List<Pair<SlimefunItem, Integer>> uses = new ArrayList<>();
 
             //add the items uses in other recipes
             for (SlimefunItem checkingItem : SlimefunPlugin.getRegistry().getEnabledSlimefunItems()) {
-                if (ArrayUtils.contains(checkingItem.getRecipe(), item.getItem())) {
+                //add normal recipe usage and RecipeType usage
+                if (ArrayUtils.contains(checkingItem.getRecipe(), item.getItem()) || checkingItem.getRecipeType().getMachine() == item) {
                     uses.add(new Pair<>(checkingItem, -1)); //-1 means not a recipeDisplayItem
                 }
 
@@ -281,7 +284,7 @@ public final class PostSetup {
                 if (checkingItem instanceof RecipeDisplayItem) {
                     List<ItemStack> displayRecipes = ((RecipeDisplayItem) checkingItem).getDisplayRecipes();
 
-                    for (ItemStack display : displayRecipes) { //checks for duplicate display item/normal recipes
+                    for (ItemStack display : displayRecipes) {
                         if (item.getItem() == display) {
 
                             int index = displayRecipes.indexOf(item.getItem());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -284,8 +284,8 @@ public final class PostSetup {
                 if (checkingItem instanceof RecipeDisplayItem) {
                     List<ItemStack> displayRecipes = ((RecipeDisplayItem) checkingItem).getDisplayRecipes();
 
-                    for (int i = 0; i + 1 < displayRecipes.size() ; i+=2) {
-                        if (item.getItem() == displayRecipes.get(i)) {
+                    for (int i = 0; i < displayRecipes.size() ; i+=2) {
+                        if (item.equals(SlimefunItem.getByItem(displayRecipes.get(i)))) {
                             uses.add(new Pair<>(checkingItem, i));
                         }
                     }
@@ -302,7 +302,13 @@ public final class PostSetup {
                     continue;
                 }
                 
-                SlimefunItem slot = SlimefunItem.getByItem(((RecipeDisplayItem) use.getFirstValue()).getDisplayRecipes().get(use.getSecondValue() + 1));
+                List<ItemStack> displayRecipes = ((RecipeDisplayItem) use.getFirstValue()).getDisplayRecipes();
+                
+                if (use.getSecondValue() + 1 >= displayRecipes.size()) {
+                    continue;
+                }
+                
+                SlimefunItem slot = SlimefunItem.getByItem(displayRecipes.get(use.getSecondValue() + 1));
                 if (slot != null && uses.contains(new Pair<>(slot, -1))) {
                     iterator.remove();
                 }


### PR DESCRIPTION
## Description
Right click a Slimefun item in the guide to see it's uses in other recipes. 

## Changes
Added new map in registry that keeps a list of recipe uses for each SlimefunItem, filled in PostSetup.
Added new class SlimefunItemRecipeUse which holds a slimefunItem, the uses of it, and the page of use.
Added that class to history which will open the correct menu.
Added right click handlers to many spots that will open the recipe uses if its a SliemfunItem.
Added recipe uses menu to ChestSlimefunGuide implementation.
Added some methods to history which can replace the last object in history and check for an object in history.

## Related Issues
none

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
