### PR TITLE
Fixed a bug of Duplicate items with BlockPlacer

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -145,10 +145,9 @@ public class BlockPlacer extends SlimefunItem {
 
     private void placeSlimefunBlock(SlimefunItem sfItem, ItemStack item, Block block, Dispenser dispenser) {
         BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, block);
-        Bukkit.getPluginManager().callEvent(e);
         
-        if(!dispenser.getInventory().getViewers().isEmpty()){
-        	e.setCancelled(true);
+        if(dispenser.getInventory().getViewers().isEmpty()) {
+        	Bukkit.getPluginManager().callEvent(e);
         }
 
         if (!e.isCancelled()) {
@@ -185,10 +184,9 @@ public class BlockPlacer extends SlimefunItem {
 
     private void placeBlock(ItemStack item, Block facedBlock, Dispenser dispenser) {
         BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, facedBlock);
-        Bukkit.getPluginManager().callEvent(e);
         
-        if(!dispenser.getInventory().getViewers().isEmpty()){
-        	e.setCancelled(true);
+        if(dispenser.getInventory().getViewers().isEmpty()) {
+        	Bukkit.getPluginManager().callEvent(e);
         }
 
         if (!e.isCancelled()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -93,10 +93,10 @@ public class BlockPlacer extends SlimefunItem {
                 return;
             }
 
-            if (facedBlock.isEmpty() && !isBlacklisted(material)) {
+            if (facedBlock.isEmpty() && !isBlacklisted(material) && dispenser.getInventory().getViewers().isEmpty()) {
                 SlimefunItem item = SlimefunItem.getByItem(e.getItem());
 
-                if (item != null && dispenser.getInventory().getViewers().isEmpty()) {
+                if (item != null) {
                     // Check if this Item can even be placed down
                     if (!(item instanceof NotPlaceable)) {
                         placeSlimefunBlock(item, e.getItem(), facedBlock, dispenser);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -96,7 +96,7 @@ public class BlockPlacer extends SlimefunItem {
             if (facedBlock.isEmpty() && !isBlacklisted(material)) {
                 SlimefunItem item = SlimefunItem.getByItem(e.getItem());
 
-                if (item != null) {
+                if (item != null && dispenser.getInventory().getViewers().isEmpty()) {
                     // Check if this Item can even be placed down
                     if (!(item instanceof NotPlaceable)) {
                         placeSlimefunBlock(item, e.getItem(), facedBlock, dispenser);
@@ -145,10 +145,7 @@ public class BlockPlacer extends SlimefunItem {
 
     private void placeSlimefunBlock(SlimefunItem sfItem, ItemStack item, Block block, Dispenser dispenser) {
         BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, block);
-        
-        if(dispenser.getInventory().getViewers().isEmpty()) {
-        	Bukkit.getPluginManager().callEvent(e);
-        }
+        Bukkit.getPluginManager().callEvent(e);
 
         if (!e.isCancelled()) {
             boolean hasItemHandler = sfItem.callItemHandler(BlockPlaceHandler.class, handler -> {
@@ -184,10 +181,7 @@ public class BlockPlacer extends SlimefunItem {
 
     private void placeBlock(ItemStack item, Block facedBlock, Dispenser dispenser) {
         BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, facedBlock);
-        
-        if(dispenser.getInventory().getViewers().isEmpty()) {
-        	Bukkit.getPluginManager().callEvent(e);
-        }
+        Bukkit.getPluginManager().callEvent(e);
 
         if (!e.isCancelled()) {
             facedBlock.setType(item.getType());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -146,6 +146,10 @@ public class BlockPlacer extends SlimefunItem {
     private void placeSlimefunBlock(SlimefunItem sfItem, ItemStack item, Block block, Dispenser dispenser) {
         BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, block);
         Bukkit.getPluginManager().callEvent(e);
+        
+        if(!dispenser.getInventory().getViewers().isEmpty()){
+        	e.setCancelled(true);
+        }
 
         if (!e.isCancelled()) {
             boolean hasItemHandler = sfItem.callItemHandler(BlockPlaceHandler.class, handler -> {
@@ -182,6 +186,10 @@ public class BlockPlacer extends SlimefunItem {
     private void placeBlock(ItemStack item, Block facedBlock, Dispenser dispenser) {
         BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, facedBlock);
         Bukkit.getPluginManager().callEvent(e);
+        
+        if(!dispenser.getInventory().getViewers().isEmpty()){
+        	e.setCancelled(true);
+        }
 
         if (!e.isCancelled()) {
             facedBlock.setType(item.getType());


### PR DESCRIPTION
Fixed a bug of Duplicate items with BlockPlacer's delay

## Description
on BlockPlacer place an item, just take out the item when it place,then one in hand and 
another is placed.
## Changes
when BlockPlacer place,there shouldn't be someone viewing it.
I have no better way to fix it.

## Related Issues
With BlockPlacer's Place delay,it can Duplicate almost any block,just take out the item in BlockPlacer on BlockPlacer place.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
