### PR TITLE
Add Rainbow beds

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/RainbowTickHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/RainbowTickHandler.java
@@ -180,11 +180,11 @@ public class RainbowTickHandler extends BlockTicker {
     }
 
     private void setBedBlock(Block b, Material material, BlockFace facing, Part part, boolean doPhysics) {
-		b.setType(material, false);
+        b.setType(material, false);
         BlockData data = b.getBlockData();
         
 		if (data instanceof Bed) {
-			((Bed) data).setFacing(facing);
+            ((Bed) data).setFacing(facing);
             ((Bed) data).setPart(part);
         }
         

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -420,6 +420,7 @@ public final class SlimefunItems {
     public static final SlimefunItemStack RAINBOW_GLASS_PANE = new SlimefunItemStack("RAINBOW_GLASS_PANE", Material.WHITE_STAINED_GLASS_PANE, "&5Rainbow Glass Pane", "", RAINBOW);
     public static final SlimefunItemStack RAINBOW_CONCRETE = new SlimefunItemStack("RAINBOW_CONCRETE", Material.WHITE_CONCRETE, "&5Rainbow Concrete", "", RAINBOW);
     public static final SlimefunItemStack RAINBOW_GLAZED_TERRACOTTA = new SlimefunItemStack("RAINBOW_GLAZED_TERRACOTTA", Material.WHITE_GLAZED_TERRACOTTA, "&5Rainbow Glazed Terracotta", "", RAINBOW);
+    public static final SlimefunItemStack RAINBOW_BED = new SlimefunItemStack("RAINBOW_BED", Material.WHITE_BED, "&5Rainbow Bed", "", RAINBOW);
 
     /* Seasonal */
     private static final String CHRISTMAS = ChatUtils.christmas("[Christmas Edition]");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/ResearchSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/ResearchSetup.java
@@ -166,7 +166,7 @@ public final class ResearchSetup {
         register("ancient_runes", 155, "Elemental Runes", 15, SlimefunItems.BLANK_RUNE, SlimefunItems.EARTH_RUNE, SlimefunItems.WATER_RUNE, SlimefunItems.AIR_RUNE, SlimefunItems.FIRE_RUNE);
         register("special_runes", 156, "Purple Runes", 18, SlimefunItems.ENDER_RUNE, SlimefunItems.RAINBOW_RUNE);
         register("infernal_bonemeal", 157, "Infernal Bonemeal", 12, SlimefunItems.INFERNAL_BONEMEAL);
-        register("rainbow_blocks", 158, "Rainbow Blocks", 24, SlimefunItems.RAINBOW_CLAY, SlimefunItems.RAINBOW_GLASS, SlimefunItems.RAINBOW_GLASS_PANE, SlimefunItems.RAINBOW_WOOL, SlimefunItems.RAINBOW_CONCRETE, SlimefunItems.RAINBOW_GLAZED_TERRACOTTA);
+        register("rainbow_blocks", 158, "Rainbow Blocks", 24, SlimefunItems.RAINBOW_CLAY, SlimefunItems.RAINBOW_GLASS, SlimefunItems.RAINBOW_GLASS_PANE, SlimefunItems.RAINBOW_WOOL, SlimefunItems.RAINBOW_CONCRETE, SlimefunItems.RAINBOW_GLAZED_TERRACOTTA, SlimefunItems.RAINBOW_BED);
         register("infused_hopper", 159, "Infused Hopper", 22, SlimefunItems.INFUSED_HOPPER);
         register("wither_proof_glass", 160, "Wither-Proof Glass", 20, SlimefunItems.WITHER_PROOF_GLASS);
         register("duct_tape", 161, "Duct Tape", 14, SlimefunItems.DUCT_TAPE);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1979,6 +1979,8 @@ public final class SlimefunItemSetup {
         new ItemStack[] {SlimefunItems.ESSENCE_OF_AFTERLIFE, new ItemStack(Material.EMERALD_BLOCK), SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_3, SlimefunItems.COMMON_TALISMAN, SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, new ItemStack(Material.EMERALD_BLOCK), SlimefunItems.ESSENCE_OF_AFTERLIFE})
         .register(plugin);
 
+        // Rainbow Blocks
+
         new RainbowBlock(categories.magicalGadgets, SlimefunItems.RAINBOW_WOOL, RecipeType.ANCIENT_ALTAR,
         new ItemStack[] {new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL), SlimefunItems.RAINBOW_RUNE, new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL)}, 
         new SlimefunItemStack(SlimefunItems.RAINBOW_WOOL, 8), new RainbowTickHandler(ColoredMaterial.WOOL))

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -2009,6 +2009,11 @@ public final class SlimefunItemSetup {
         new SlimefunItemStack(SlimefunItems.RAINBOW_GLAZED_TERRACOTTA, 8), new RainbowTickHandler(ColoredMaterial.GLAZED_TERRACOTTA))
         .register(plugin);
 
+        new RainbowBlock(categories.magicalGadgets, SlimefunItems.RAINBOW_BED, RecipeType.ANCIENT_ALTAR,
+        new ItemStack[] {new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.WHITE_WOOL), null, SlimefunItems.RAINBOW_RUNE, null, new ItemStack(Material.OAK_PLANKS), new ItemStack(Material.OAK_PLANKS), new ItemStack(Material.OAK_PLANKS)},
+        new SlimefunItemStack(SlimefunItems.RAINBOW_BED, 8), new RainbowTickHandler(ColoredMaterial.BED))
+        .register(plugin);
+
         // Christmas
 
         new RainbowBlock(categories.christmas, SlimefunItems.RAINBOW_WOOL_XMAS, RecipeType.ANCIENT_ALTAR,

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
@@ -155,6 +155,28 @@ public enum ColoredMaterial {
             Material.GREEN_CONCRETE,
             Material.RED_CONCRETE,
             Material.BLACK_CONCRETE
+    }),
+
+    /**
+     * This {@link List} contains all bed colors ordered by their appearance ingame.
+     */
+    BED(new Material[] {
+            Material.WHITE_BED,
+            Material.ORANGE_BED,
+            Material.MAGENTA_BED,
+            Material.LIGHT_BLUE_BED,
+            Material.YELLOW_BED,
+            Material.LIME_BED,
+            Material.PINK_BED,
+            Material.GRAY_BED,
+            Material.LIGHT_GRAY_BED,
+            Material.CYAN_BED,
+            Material.PURPLE_BED,
+            Material.BLUE_BED,
+            Material.BROWN_BED,
+            Material.GREEN_BED,
+            Material.RED_BED,
+            Material.BLACK_BED
     });
     
     // @formatter:on

--- a/src/main/resources/wiki.json
+++ b/src/main/resources/wiki.json
@@ -217,6 +217,7 @@
 	"RAINBOW_GLASS_PANE" : "Rainbow-Blocks",
 	"RAINBOW_CONCRETE" : "Rainbow-Blocks",
 	"RAINBOW_GLAZED_TERRACOTTA" : "Rainbow-Blocks",
+	"RAINBOW_BED" : "Rainbow-Blocks",
 	"REDSTONE_ALLOY" : "Redstone-Alloy-Ingot",
 	"REINFORCED_ALLOY_INGOT" : "Reinforced-Alloy-Ingot",
 	"SILVER_DUST" : "Silver-Dust",


### PR DESCRIPTION
## Description
Added Rainbow Beds to the Rainbow Blocks collection.
The beds are still spazzing out right now but I havent found the issue with it, though I wanted to push the code already.
![Spazzing bed](https://user-images.githubusercontent.com/35664724/99884427-7ea82a80-2c2e-11eb-8d93-a023d4d2238c.gif)


## Changes
- Create Rainbow Bed SlimefunItem
- Add Rainbow Bed to SlimefunItemSetup
- Add Rainbow Bed to `wiki.json`
- Add Rainbow Bed to Rainbow Blocks Research Setup
- Add BED Material array in `ColoredMaterial.java`
- Add logic so both bed blocks update in `RainbowTickHandler.java`

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
