### PR TITLE
Fix ghost blocks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -66,14 +66,14 @@ public class BlockListener implements Listener {
 
             if (sfItem != null) {
                 for (ItemStack item : sfItem.getDrops()) {
-                    if (!item.getType().isAir()) {
+                    if (item != null && !item.getType().isAir()) {
                         block.getWorld().dropItemNaturally(block.getLocation(), item);
                     }
                 }
                 BlockStorage.clearBlockInfo(block);
-            } else {
-                e.setCancelled(true);
             }
+        } else if (BlockStorage.hasBlockInfo(e.getBlock())) {
+            e.setCancelled(true);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -4,16 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.enchantments.Enchantment;
@@ -41,10 +38,10 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
 /**
  * The {@link BlockListener} is responsible for listening to the {@link BlockPlaceEvent}
  * and {@link BlockBreakEvent}.
- * 
+ *
  * @author TheBusyBiscuit
  * @author Linox
- * 
+ *
  * @see BlockPlaceHandler
  * @see BlockBreakHandler
  * @see ToolUseHandler
@@ -62,18 +59,17 @@ public class BlockListener implements Listener {
         // While this can cause ghost blocks it also prevents them from replacing grass
         // or saplings etc...
         Block block = e.getBlock();
-        if (BlockStorage.hasBlockInfo(block)) {
+        SlimefunItem sfItem = BlockStorage.check(block);
+
+        if (sfItem != null) {
             if (e.getBlockReplacedState().getType().isAir()) {
-                Iterator<ItemStack> item = BlockStorage.check(block).getDrops().iterator();
-                World world = block.getWorld();
-                Location loc = block.getLocation();
-                while (item.hasNext()) {
-                    world.dropItem(loc, item.next());
+                for (ItemStack item : sfItem.getDrops()) {
+                    if (item != null && !item.getType().isAir()) { block.getWorld().dropItemNaturally(block.getLocation(), item); }
                 }
                 BlockStorage.clearBlockInfo(block);
-                return;
+            } else {
+                e.setCancelled(true);
             }
-            e.setCancelled(true);
         }
     }
 
@@ -184,7 +180,7 @@ public class BlockListener implements Listener {
      * This method checks for a sensitive {@link Block}.
      * Sensitive {@link Block Blocks} are pressure plates or saplings, which should be broken
      * when the block beneath is broken as well.
-     * 
+     *
      * @param p
      *            The {@link Player} who broke this {@link Block}
      * @param b

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -41,6 +41,7 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
  *
  * @author TheBusyBiscuit
  * @author Linox
+ * @author Patbox
  *
  * @see BlockPlaceHandler
  * @see BlockBreakHandler
@@ -59,12 +60,15 @@ public class BlockListener implements Listener {
         // While this can cause ghost blocks it also prevents them from replacing grass
         // or saplings etc...
         Block block = e.getBlock();
-        SlimefunItem sfItem = BlockStorage.check(block);
 
-        if (sfItem != null) {
-            if (e.getBlockReplacedState().getType().isAir()) {
+        if (e.getBlockReplacedState().getType().isAir()) {
+            SlimefunItem sfItem = BlockStorage.check(block);
+
+            if (sfItem != null) {
                 for (ItemStack item : sfItem.getDrops()) {
-                    if (item != null && !item.getType().isAir()) { block.getWorld().dropItemNaturally(block.getLocation(), item); }
+                    if (!item.getType().isAir()) {
+                        block.getWorld().dropItemNaturally(block.getLocation(), item);
+                    }
                 }
                 BlockStorage.clearBlockInfo(block);
             } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -4,13 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.enchantments.Enchantment;
@@ -58,7 +61,18 @@ public class BlockListener implements Listener {
         // This prevents Players from placing a block where another block already exists
         // While this can cause ghost blocks it also prevents them from replacing grass
         // or saplings etc...
-        if (BlockStorage.hasBlockInfo(e.getBlock())) {
+        Block block = e.getBlock();
+        if (BlockStorage.hasBlockInfo(block)) {
+            if (e.getBlockReplacedState().getType().isAir()) {
+                Iterator<ItemStack> item = BlockStorage.check(block).getDrops().iterator();
+                World world = block.getWorld();
+                Location loc = block.getLocation();
+                while (item.hasNext()) {
+                    world.dropItem(loc, item.next());
+                }
+                BlockStorage.clearBlockInfo(block);
+                return;
+            }
             e.setCancelled(true);
         }
     }


### PR DESCRIPTION
## Description
Fixes instances of ghost blocks (places where you can't place blocks, because for SF it exist and for server not).
As for now I did quick test of it and it looks like everything worked. I also plan to test in on working server soon.
## Changes
Added some logic to BlockListener.onBlockPlaceExisting for checking if targeted block is air (and if it is, removing it and dropping item).

## Related Issues
https://github.com/Slimefun/Slimefun4/wiki/Common-Issues#unplaceable-blocks
https://youtu.be/HYlNRKud5kI

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

^ Leaving this empty, as I prefer someone else to rate it (1st and 2nd one I will check after tests).