### PR TITLE
Readd drops from ghost blocks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -63,18 +63,16 @@ public class BlockListener implements Listener {
          */
         Block block = e.getBlock();
 
-        if (e.getBlockReplacedState().getType().isAir()) {
+        if (e.getBlockReplacedState().getType().isAir() && !SlimefunPlugin.getTickerTask().isPendingDeletion(block.getLocation())) {
             SlimefunItem sfItem = BlockStorage.check(block);
-
             if (sfItem != null) {
-                /* Temp fix for #2636
                 for (ItemStack item : sfItem.getDrops()) {
                     if (item != null && !item.getType().isAir()) {
                         block.getWorld().dropItemNaturally(block.getLocation(), item);
                     }
                 }
-                 */
                 BlockStorage.clearBlockInfo(block);
+                e.setCancelled(true);
             }
         } else if (BlockStorage.hasBlockInfo(e.getBlock())) {
             e.setCancelled(true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -258,6 +258,21 @@ public class TickerTask implements Runnable {
     }
 
     /**
+     * This method checks if the given {@link Location} is pending deletion
+     * by this {@link TickerTask}.
+     * A reserved {@link Location} does hold data but will be deleted
+     * upon the next tick.
+     *
+     * @param l
+     *            The {@link Location} to check
+     *
+     * @return Whether this {@link Location} is pending deletion.
+     */
+    public boolean isPendingDeletion(@Nonnull Location l) {
+        return deletionQueue.containsKey(l);
+    }
+
+    /**
      * This returns the delay between ticks
      * 
      * @return The tick delay


### PR DESCRIPTION
## Description
This PR readds drops with ghost blocks (with additional checks, so it doesn't cause duplication)
## Changes
- Added `isPendingDeletion` to `TickerTask`
- Enabled drops from ghost blocks
- Event is now canceled after ghost block is removed (so data of new block isn't deleted)

## Related Issues
Replaces tempfix for #2636 (#2637)

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
