### PR TITLE
Added verbose flag to /sf timings

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
@@ -29,6 +29,11 @@ class TimingsCommand extends SubCommand {
     }
 
     @Override
+    protected String getDescription() {
+        return "commands.timings.description";
+    }
+
+    @Override
     public void onExecute(CommandSender sender, String[] args) {
         if (sender.hasPermission("slimefun.command.timings") || sender instanceof ConsoleCommandSender) {
             if (hasInvalidFlags(sender, args)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
@@ -64,7 +64,7 @@ class TimingsCommand extends SubCommand {
         for (int i = 1; i < args.length; i++) {
             String argument = args[i].toLowerCase(Locale.ROOT);
 
-            if (!argument.startsWith(FLAG_PREFIX) || !flags.contains(argument.substring(2))) {
+            if (argument.startsWith(FLAG_PREFIX) && !flags.contains(argument.substring(2))) {
                 hasInvalidFlags = true;
                 SlimefunPlugin.getLocalization().sendMessage(sender, "commands.timings.unknown-flag", true, msg -> msg.replace("%flag%", argument));
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
@@ -1,6 +1,12 @@
 package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
@@ -15,6 +21,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 
 class TimingsCommand extends SubCommand {
 
+    private static final String FLAG_PREFIX = "--";
+    private final Set<String> flags = new HashSet<>(Arrays.asList("verbose"));
+
     TimingsCommand(SlimefunPlugin plugin, SlimefunCommand cmd) {
         super(plugin, cmd, "timings", false);
     }
@@ -22,20 +31,61 @@ class TimingsCommand extends SubCommand {
     @Override
     public void onExecute(CommandSender sender, String[] args) {
         if (sender.hasPermission("slimefun.command.timings") || sender instanceof ConsoleCommandSender) {
-            sender.sendMessage("Please wait a second... The results are coming in!");
-            PerformanceInspector inspector = inspectorOf(sender);
+            if (hasInvalidFlags(sender, args)) {
+                return;
+            }
+
+            boolean verbose = hasFlag(args, "verbose");
+
+            if (verbose && sender instanceof Player) {
+                SlimefunPlugin.getLocalization().sendMessage(sender, "commands.timings.verbose-player", true);
+                return;
+            }
+
+            SlimefunPlugin.getLocalization().sendMessage(sender, "commands.timings.please-wait", true);
+
+            PerformanceInspector inspector = inspectorOf(sender, verbose);
             SlimefunPlugin.getProfiler().requestSummary(inspector);
         } else {
             SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);
         }
     }
 
+    @ParametersAreNonnullByDefault
+    private boolean hasInvalidFlags(CommandSender sender, String[] args) {
+        boolean hasInvalidFlags = false;
+
+        // We start at 1 because args[0] will be "timings".
+        for (int i = 1; i < args.length; i++) {
+            String argument = args[i].toLowerCase(Locale.ROOT);
+
+            if (!argument.startsWith(FLAG_PREFIX) || !flags.contains(argument.substring(2))) {
+                hasInvalidFlags = true;
+                SlimefunPlugin.getLocalization().sendMessage(sender, "commands.timings.unknown-flag", true, msg -> msg.replace("%flag%", argument));
+            }
+        }
+
+        return hasInvalidFlags;
+    }
+
+    @ParametersAreNonnullByDefault
+    private boolean hasFlag(String[] args, String flag) {
+        // We start at 1 because args[0] will be "timings".
+        for (int i = 1; i < args.length; i++) {
+            if (args[i].equalsIgnoreCase(FLAG_PREFIX + flag)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     @Nonnull
-    private PerformanceInspector inspectorOf(@Nonnull CommandSender sender) {
+    private PerformanceInspector inspectorOf(@Nonnull CommandSender sender, boolean verbose) {
         if (sender instanceof Player) {
             return new PlayerPerformanceInspector((Player) sender);
         } else {
-            return new ConsolePerformanceInspector(sender);
+            return new ConsolePerformanceInspector(sender, verbose);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceInspector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceInspector.java
@@ -36,6 +36,6 @@ public interface PerformanceInspector {
      * 
      * @return Whether to send the full {@link PerformanceSummary} or a trimmed version
      */
-    boolean hasFullView();
+    boolean isVerbose();
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceSummary.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceSummary.java
@@ -152,7 +152,7 @@ class PerformanceSummary {
             builder.append(ChatColor.YELLOW);
 
             for (Map.Entry<String, Long> entry : results) {
-                if (!inspector.hasFullView() || (shownEntries < MAX_ITEMS && (shownEntries < MIN_ITEMS || entry.getValue() > VISIBILITY_THRESHOLD))) {
+                if (!inspector.isVerbose() || (shownEntries < MAX_ITEMS && (shownEntries < MIN_ITEMS || entry.getValue() > VISIBILITY_THRESHOLD))) {
                     builder.append("\n  ");
                     builder.append(ChatColor.stripColor(formatter.apply(entry)));
                     shownEntries++;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/ConsolePerformanceInspector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/ConsolePerformanceInspector.java
@@ -24,15 +24,21 @@ public class ConsolePerformanceInspector implements PerformanceInspector {
     private final CommandSender console;
 
     /**
+     * Whether a summary will be verbose or trimmed of.
+     */
+    private final boolean verbose;
+
+    /**
      * This creates a new {@link ConsolePerformanceInspector} for the given {@link CommandSender}.
      * 
      * @param console
      *            The {@link CommandSender}, preferabbly a {@link ConsoleCommandSender}
      */
-    public ConsolePerformanceInspector(@Nonnull CommandSender console) {
+    public ConsolePerformanceInspector(@Nonnull CommandSender console, boolean verbose) {
         Validate.notNull(console, "CommandSender cannot be null");
 
         this.console = console;
+        this.verbose = verbose;
     }
 
     @Override
@@ -42,8 +48,8 @@ public class ConsolePerformanceInspector implements PerformanceInspector {
     }
 
     @Override
-    public boolean hasFullView() {
-        return false;
+    public boolean isVerbose() {
+        return verbose;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/PlayerPerformanceInspector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/PlayerPerformanceInspector.java
@@ -50,7 +50,7 @@ public class PlayerPerformanceInspector implements PerformanceInspector {
     }
 
     @Override
-    public boolean hasFullView() {
+    public boolean isVerbose() {
         return false;
     }
 

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -27,7 +27,7 @@ commands:
     not-rechargeable: This item can not be charged!
 
   timings:
-    description: Lag-Info about your Server
+    description: Timings for Slimefun and its addon
     please-wait: '&ePlease wait a second... The results are coming in!'
     verbose-player: '&4The verbose flag cannot by used by a Player!'
     unknown-flag: '&4Unknown flag: &c%flag%'

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -26,7 +26,7 @@ commands:
     description: Charges the item you are holding
     charge-success: Item has been charged!
     not-rechargeable: This item can not be charged!
-  
+
   timings:
     please-wait: '&ePlease wait a second... The results are coming in!'
     verbose-player: '&4The verbose flag cannot by used by a Player!'

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -3,7 +3,6 @@ commands:
   cheat: Allows you to cheat Items
   give: Give somebody some Slimefun Items
   guide: Gives yourself a Slimefun Guide
-  timings: Lag-Info about your Server
   teleporter: See other Player's Waypoints
   versions: Lists all installed Addons
   search: Searches your Guide for the given term
@@ -28,6 +27,7 @@ commands:
     not-rechargeable: This item can not be charged!
 
   timings:
+    description: Lag-Info about your Server
     please-wait: '&ePlease wait a second... The results are coming in!'
     verbose-player: '&4The verbose flag cannot by used by a Player!'
     unknown-flag: '&4Unknown flag: &c%flag%'

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -26,6 +26,11 @@ commands:
     description: Charges the item you are holding
     charge-success: Item has been charged!
     not-rechargeable: This item can not be charged!
+  
+  timings:
+    please-wait: '&ePlease wait a second... The results are coming in!'
+    verbose-player: '&4The verbose flag cannot by used by a Player!'
+    unknown-flag: '&4Unknown flag: &c%flag%'
 
 guide:
   locked: 'LOCKED'


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
@WalshyDev wanted this.
Also finally added locale to the /sf timings command. Added an abstract framework to allow for future flags too.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
