### PR TITLE
Experimental: Slimefun but without CS-CoreLib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,12 +302,6 @@
             <version>${spigot.version}-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.TheBusyBiscuit</groupId>
-            <artifactId>CS-CoreLib</artifactId>
-            <version>1.7</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Development dependencies -->
         <dependency>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
@@ -149,7 +149,6 @@ public class ErrorReport<T extends Throwable> {
             stream.println();
 
             stream.println("Slimefun Environment:");
-            stream.println("  CS-CoreLib v" + SlimefunPlugin.getCSCoreLibVersion());
             stream.println("  Slimefun v" + SlimefunPlugin.getVersion());
             stream.println("  Caused by: " + addon.getName() + " v" + addon.getPluginVersion());
             stream.println();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -30,7 +30,6 @@ class VersionsCommand extends SubCommand {
 
             sender.sendMessage(ChatColor.GRAY + "This Server uses the following setup of Slimefun:");
             sender.sendMessage(ChatColors.color("&a" + serverSoftware + " &2" + Bukkit.getVersion()));
-            sender.sendMessage(ChatColors.color("&aCS-CoreLib &2v" + SlimefunPlugin.getCSCoreLibVersion()));
             sender.sendMessage(ChatColors.color("&aSlimefun &2v" + SlimefunPlugin.getVersion()));
 
             if (SlimefunPlugin.getMetricsService().getVersion() != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/SlimefunGuideSettings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/SlimefunGuideSettings.java
@@ -81,7 +81,7 @@ public final class SlimefunGuideSettings {
             return false;
         });
 
-        menu.addItem(4, new CustomItem(Material.WRITABLE_BOOK, ChatColor.GREEN + SlimefunPlugin.getLocalization().getMessage(p, "guide.title.versions"), "&7&o" + SlimefunPlugin.getLocalization().getMessage(p, "guide.tooltips.versions-notice"), "", "&fMinecraft: &a" + Bukkit.getBukkitVersion(), "&fSlimefun: &a" + SlimefunPlugin.getVersion(), "&fCS-CoreLib: &a" + SlimefunPlugin.getCSCoreLibVersion()), ChestMenuUtils.getEmptyClickHandler());
+        menu.addItem(4, new CustomItem(Material.WRITABLE_BOOK, ChatColor.GREEN + SlimefunPlugin.getLocalization().getMessage(p, "guide.title.versions"), "&7&o" + SlimefunPlugin.getLocalization().getMessage(p, "guide.tooltips.versions-notice"), "", "&fMinecraft: &a" + Bukkit.getBukkitVersion(), "&fSlimefun: &a" + SlimefunPlugin.getVersion()), ChestMenuUtils.getEmptyClickHandler());
 
         menu.addItem(6,
                 new CustomItem(Material.COMPARATOR, "&e" + SlimefunPlugin.getLocalization().getMessage(p, "guide.title.source"), "", "&7Last Activity: &a" + NumberUtils.getElapsedTime(SlimefunPlugin.getGitHubService().getLastUpdate()) + " ago", "&7Forks: &e" + SlimefunPlugin.getGitHubService().getForks(), "&7Stars: &e" + SlimefunPlugin.getGitHubService().getStars(), "", "&7&oSlimefun 4 is a community project,", "&7&othe source code is available on GitHub", "&7&oand if you want to keep this Plugin alive,", "&7&othen please consider contributing to it", "", "&7\u21E8 &eClick to go to GitHub"));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -115,6 +115,7 @@ import io.github.thebusybiscuit.slimefun4.integrations.IntegrationsManager;
 import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import io.papermc.lib.PaperLib;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.MenuListener;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AGenerator;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -208,29 +209,10 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
             setInstance(this);
             getLogger().log(Level.WARNING, "Slimefun was not installed properly! Disabling...");
             getServer().getPluginManager().disablePlugin(this);
-        } else if (getServer().getPluginManager().isPluginEnabled("CS-CoreLib")) {
-            // The Environment and dependencies have been validated.
-            setInstance(this);
-            getLogger().log(Level.INFO, "CS-CoreLib was detected!");
-            onPluginStart();
         } else {
-            // Terminate our Plugin instance
-            setInstance(null);
-
-            // CS-CoreLib has not been installed!
-            getLogger().log(Level.INFO, "#################### - INFO - ####################");
-            getLogger().log(Level.INFO, " ");
-            getLogger().log(Level.INFO, "Slimefun could not be loaded (yet).");
-            getLogger().log(Level.INFO, "It appears that you have not installed CS-CoreLib.");
-            getLogger().log(Level.INFO, "Please download and install CS-CoreLib manually:");
-            getLogger().log(Level.INFO, "https://thebusybiscuit.github.io/builds/TheBusyBiscuit/CS-CoreLib/master/");
-
-            // Send a message upon doing /slimefun
-            getCommand("slimefun").setExecutor((sender, cmd, label, args) -> {
-                sender.sendMessage("You have forgotten to install CS-CoreLib! Slimefun is disabled.");
-                sender.sendMessage("https://thebusybiscuit.github.io/builds/TheBusyBiscuit/CS-CoreLib/master/");
-                return true;
-            });
+            // The Environment has been validated.
+            setInstance(this);
+            onPluginStart();
         }
     }
 
@@ -595,6 +577,9 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
      * This method registers all of our {@link Listener Listeners}.
      */
     private void registerListeners() {
+        // Old deprecated CS-CoreLib Listener
+        new MenuListener(this);
+
         new SlimefunBootsListener(this);
         new SlimefunItemInteractListener(this);
         new SlimefunItemConsumeListener(this);
@@ -973,18 +958,6 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
     public static boolean isNewlyInstalled() {
         validateInstance();
         return instance.isNewlyInstalled;
-    }
-
-    @Nonnull
-    public static String getCSCoreLibVersion() {
-        validateInstance();
-        Plugin cscorelib = instance.getServer().getPluginManager().getPlugin("CS-CoreLib");
-
-        if (cscorelib == null) {
-            throw new IllegalStateException("CS-CoreLib is not installed.");
-        } else {
-            return cscorelib.getDescription().getVersion();
-        }
     }
 
     /**

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/Configuration/Config.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/Configuration/Config.java
@@ -2,22 +2,10 @@ package me.mrCookieSlime.CSCoreLibPlugin.Configuration;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.Sound;
-import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.Plugin;
 
 /**
  * An old remnant of CS-CoreLib.
@@ -31,26 +19,13 @@ public class Config {
     private FileConfiguration config;
 
     /**
-     * Creates a new Config Object for the config.yml File of
-     * the specified Plugin
-     *
-     * @param plugin
-     *            The Instance of the Plugin, the config.yml is referring to
-     */
-    public Config(Plugin plugin) {
-        this.file = new File("plugins/" + plugin.getDescription().getName().replace(" ", "_") + "/config.yml");
-        this.config = YamlConfiguration.loadConfiguration(this.file);
-    }
-
-    /**
      * Creates a new Config Object for the specified File
      *
      * @param file
      *            The File for which the Config object is created for
      */
     public Config(File file) {
-        this.file = file;
-        this.config = YamlConfiguration.loadConfiguration(this.file);
+        this(file, YamlConfiguration.loadConfiguration(file));
     }
 
     /**
@@ -96,10 +71,6 @@ public class Config {
         return this.config;
     }
 
-    protected void store(String path, Object value) {
-        this.config.set(path, value);
-    }
-
     /**
      * Sets the Value for the specified Path
      *
@@ -109,38 +80,7 @@ public class Config {
      *            The Value for that Path
      */
     public void setValue(String path, Object value) {
-        if (value == null) {
-            this.store(path, value);
-            this.store(path + "_extra", null);
-        } else if (value instanceof Inventory) {
-            for (int i = 0; i < ((Inventory) value).getSize(); i++) {
-                setValue(path + "." + i, ((Inventory) value).getItem(i));
-            }
-        } else if (value instanceof Date) {
-            this.store(path, String.valueOf(((Date) value).getTime()));
-        } else if (value instanceof Long) {
-            this.store(path, String.valueOf(value));
-        } else if (value instanceof UUID) {
-            this.store(path, value.toString());
-        } else if (value instanceof Sound) {
-            this.store(path, String.valueOf(value));
-        } else if (value instanceof ItemStack) {
-            this.store(path, new ItemStack((ItemStack) value));
-        } else if (value instanceof Location) {
-            setValue(path + ".x", ((Location) value).getX());
-            setValue(path + ".y", ((Location) value).getY());
-            setValue(path + ".z", ((Location) value).getZ());
-            setValue(path + ".pitch", ((Location) value).getPitch());
-            setValue(path + ".yaw", ((Location) value).getYaw());
-            setValue(path + ".world", ((Location) value).getWorld().getName());
-        } else if (value instanceof Chunk) {
-            setValue(path + ".x", ((Chunk) value).getX());
-            setValue(path + ".z", ((Chunk) value).getZ());
-            setValue(path + ".world", ((Chunk) value).getWorld().getName());
-        } else if (value instanceof World) {
-            this.store(path, ((World) value).getName());
-        } else
-            this.store(path, value);
+        this.config.set(path, value);
     }
 
     /**
@@ -174,8 +114,9 @@ public class Config {
      *            The Value for that Path
      */
     public void setDefaultValue(String path, Object value) {
-        if (!contains(path))
+        if (!contains(path)) {
             setValue(path, value);
+        }
     }
 
     /**
@@ -201,17 +142,6 @@ public class Config {
     }
 
     /**
-     * Returns the ItemStack at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The ItemStack at that Path
-     */
-    public ItemStack getItem(String path) {
-        return config.getItemStack(path);
-    }
-
-    /**
      * Returns the String at the specified Path
      *
      * @param path
@@ -223,209 +153,12 @@ public class Config {
     }
 
     /**
-     * Returns the Integer at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Integer at that Path
-     */
-    public int getInt(String path) {
-        return config.getInt(path);
-    }
-
-    /**
-     * Returns the Boolean at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Boolean at that Path
-     */
-    public boolean getBoolean(String path) {
-        return config.getBoolean(path);
-    }
-
-    /**
-     * Returns the StringList at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The StringList at that Path
-     */
-    public List<String> getStringList(String path) {
-        return config.getStringList(path);
-    }
-
-    /**
-     * Returns the ItemList at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The ItemList at that Path
-     */
-    public List<ItemStack> getItemList(String path) {
-        List<ItemStack> list = new ArrayList<ItemStack>();
-        for (String key : getKeys(path)) {
-            if (!key.endsWith("_extra"))
-                list.add(getItem(path + "." + key));
-        }
-        return list;
-    }
-
-    /**
-     * Returns the IntegerList at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The IntegerList at that Path
-     */
-    public List<Integer> getIntList(String path) {
-        return config.getIntegerList(path);
-    }
-
-    /**
      * Recreates the File of this Config
      */
     public void createFile() {
         try {
             this.file.createNewFile();
         } catch (IOException e) {}
-    }
-
-    /**
-     * Returns the Float at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Float at that Path
-     */
-    public Float getFloat(String path) {
-        return Float.valueOf(String.valueOf(getValue(path)));
-    }
-
-    /**
-     * Returns the Long at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Long at that Path
-     */
-    public Long getLong(String path) {
-        return Long.valueOf(String.valueOf(getValue(path)));
-    }
-
-    /**
-     * Returns the Sound at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Sound at that Path
-     */
-    public Sound getSound(String path) {
-        return Sound.valueOf(getString(path));
-    }
-
-    /**
-     * Returns the Date at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Date at that Path
-     */
-    public Date getDate(String path) {
-        return new Date(getLong(path));
-    }
-
-    /**
-     * Returns the Chunk at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Chunk at that Path
-     */
-    public Chunk getChunk(String path) {
-        return Bukkit.getWorld(getString(path + ".world")).getChunkAt(getInt(path + ".x"), getInt(path + ".z"));
-    }
-
-    /**
-     * Returns the UUID at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The UUID at that Path
-     */
-    public UUID getUUID(String path) {
-        return UUID.fromString(getString(path));
-    }
-
-    /**
-     * Returns the World at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The World at that Path
-     */
-    public World getWorld(String path) {
-        return Bukkit.getWorld(getString(path));
-    }
-
-    /**
-     * Returns the Double at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Double at that Path
-     */
-    public Double getDouble(String path) {
-        return config.getDouble(path);
-    }
-
-    /**
-     * Returns the Location at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @return The Location at that Path
-     */
-    public Location getLocation(String path) {
-        if (this.contains(path + ".pitch")) {
-            return new Location(Bukkit.getWorld(getString(path + ".world")), getDouble(path + ".x"), getDouble(path + ".y"), getDouble(path + ".z"), getFloat(path + ".yaw"), getFloat(path + ".pitch"));
-        } else {
-            return new Location(Bukkit.getWorld(this.getString(path + ".world")), this.getDouble(path + ".x"), this.getDouble(path + ".y"), this.getDouble(path + ".z"));
-        }
-    }
-
-    @Deprecated
-    public void setLocation(String path, Location location) {
-        setValue(path + ".x", location.getX());
-        setValue(path + ".y", location.getY());
-        setValue(path + ".z", location.getZ());
-        setValue(path + ".world", location.getWorld().getName());
-    }
-
-    @Deprecated
-    public void setInventory(String path, Inventory inventory) {
-        for (int i = 0; i < inventory.getSize(); i++) {
-            setValue(path + "." + i, inventory.getItem(i));
-        }
-    }
-
-    /**
-     * Gets the Contents of an Inventory at the specified Path
-     *
-     * @param path
-     *            The path in the Config File
-     * @param size
-     *            The Size of the Inventory
-     * @param title
-     *            The Title of the Inventory
-     * @return The generated Inventory
-     */
-    public Inventory getInventory(String path, int size, String title) {
-        Inventory inventory = Bukkit.createInventory(null, size, title);
-        for (int i = 0; i < size; i++) {
-            inventory.setItem(i, getItem(path + "." + i));
-        }
-        return inventory;
     }
 
     /**

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/Configuration/Config.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/Configuration/Config.java
@@ -1,0 +1,457 @@
+package me.mrCookieSlime.CSCoreLibPlugin.Configuration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * An old remnant of CS-CoreLib.
+ * This will be removed once we updated everything.
+ * Don't look at the code, it will be gone soon, don't worry.
+ *
+ */
+public class Config {
+
+    private final File file;
+    private FileConfiguration config;
+
+    /**
+     * Creates a new Config Object for the config.yml File of
+     * the specified Plugin
+     *
+     * @param plugin
+     *            The Instance of the Plugin, the config.yml is referring to
+     */
+    public Config(Plugin plugin) {
+        this.file = new File("plugins/" + plugin.getDescription().getName().replace(" ", "_") + "/config.yml");
+        this.config = YamlConfiguration.loadConfiguration(this.file);
+    }
+
+    /**
+     * Creates a new Config Object for the specified File
+     *
+     * @param file
+     *            The File for which the Config object is created for
+     */
+    public Config(File file) {
+        this.file = file;
+        this.config = YamlConfiguration.loadConfiguration(this.file);
+    }
+
+    /**
+     * Creates a new Config Object for the specified File and FileConfiguration
+     *
+     * @param file
+     *            The File to save to
+     * @param config
+     *            The FileConfiguration
+     */
+    public Config(File file, FileConfiguration config) {
+        this.file = file;
+        this.config = config;
+    }
+
+    /**
+     * Creates a new Config Object for the File with in
+     * the specified Location
+     *
+     * @param path
+     *            The Path of the File which the Config object is created for
+     */
+    public Config(String path) {
+        this.file = new File(path);
+        this.config = YamlConfiguration.loadConfiguration(this.file);
+    }
+
+    /**
+     * Returns the File the Config is handling
+     *
+     * @return The File this Config is handling
+     */
+    public File getFile() {
+        return this.file;
+    }
+
+    /**
+     * Converts this Config Object into a plain FileConfiguration Object
+     *
+     * @return The converted FileConfiguration Object
+     */
+    public FileConfiguration getConfiguration() {
+        return this.config;
+    }
+
+    protected void store(String path, Object value) {
+        this.config.set(path, value);
+    }
+
+    /**
+     * Sets the Value for the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @param value
+     *            The Value for that Path
+     */
+    public void setValue(String path, Object value) {
+        if (value == null) {
+            this.store(path, value);
+            this.store(path + "_extra", null);
+        } else if (value instanceof Inventory) {
+            for (int i = 0; i < ((Inventory) value).getSize(); i++) {
+                setValue(path + "." + i, ((Inventory) value).getItem(i));
+            }
+        } else if (value instanceof Date) {
+            this.store(path, String.valueOf(((Date) value).getTime()));
+        } else if (value instanceof Long) {
+            this.store(path, String.valueOf(value));
+        } else if (value instanceof UUID) {
+            this.store(path, value.toString());
+        } else if (value instanceof Sound) {
+            this.store(path, String.valueOf(value));
+        } else if (value instanceof ItemStack) {
+            this.store(path, new ItemStack((ItemStack) value));
+        } else if (value instanceof Location) {
+            setValue(path + ".x", ((Location) value).getX());
+            setValue(path + ".y", ((Location) value).getY());
+            setValue(path + ".z", ((Location) value).getZ());
+            setValue(path + ".pitch", ((Location) value).getPitch());
+            setValue(path + ".yaw", ((Location) value).getYaw());
+            setValue(path + ".world", ((Location) value).getWorld().getName());
+        } else if (value instanceof Chunk) {
+            setValue(path + ".x", ((Chunk) value).getX());
+            setValue(path + ".z", ((Chunk) value).getZ());
+            setValue(path + ".world", ((Chunk) value).getWorld().getName());
+        } else if (value instanceof World) {
+            this.store(path, ((World) value).getName());
+        } else
+            this.store(path, value);
+    }
+
+    /**
+     * Saves the Config Object to its File
+     */
+    public void save() {
+        try {
+            config.save(file);
+        } catch (IOException e) {}
+    }
+
+    /**
+     * Saves the Config Object to a File
+     * 
+     * @param file
+     *            The File you are saving this Config to
+     */
+    public void save(File file) {
+        try {
+            config.save(file);
+        } catch (IOException e) {}
+    }
+
+    /**
+     * Sets the Value for the specified Path
+     * (IF the Path does not yet exist)
+     *
+     * @param path
+     *            The path in the Config File
+     * @param value
+     *            The Value for that Path
+     */
+    public void setDefaultValue(String path, Object value) {
+        if (!contains(path))
+            setValue(path, value);
+    }
+
+    /**
+     * Checks whether the Config contains the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return True/false
+     */
+    public boolean contains(String path) {
+        return config.contains(path);
+    }
+
+    /**
+     * Returns the Object at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Value at that Path
+     */
+    public Object getValue(String path) {
+        return config.get(path);
+    }
+
+    /**
+     * Returns the ItemStack at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The ItemStack at that Path
+     */
+    public ItemStack getItem(String path) {
+        return config.getItemStack(path);
+    }
+
+    /**
+     * Returns the String at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The String at that Path
+     */
+    public String getString(String path) {
+        return config.getString(path);
+    }
+
+    /**
+     * Returns the Integer at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Integer at that Path
+     */
+    public int getInt(String path) {
+        return config.getInt(path);
+    }
+
+    /**
+     * Returns the Boolean at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Boolean at that Path
+     */
+    public boolean getBoolean(String path) {
+        return config.getBoolean(path);
+    }
+
+    /**
+     * Returns the StringList at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The StringList at that Path
+     */
+    public List<String> getStringList(String path) {
+        return config.getStringList(path);
+    }
+
+    /**
+     * Returns the ItemList at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The ItemList at that Path
+     */
+    public List<ItemStack> getItemList(String path) {
+        List<ItemStack> list = new ArrayList<ItemStack>();
+        for (String key : getKeys(path)) {
+            if (!key.endsWith("_extra"))
+                list.add(getItem(path + "." + key));
+        }
+        return list;
+    }
+
+    /**
+     * Returns the IntegerList at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The IntegerList at that Path
+     */
+    public List<Integer> getIntList(String path) {
+        return config.getIntegerList(path);
+    }
+
+    /**
+     * Recreates the File of this Config
+     */
+    public void createFile() {
+        try {
+            this.file.createNewFile();
+        } catch (IOException e) {}
+    }
+
+    /**
+     * Returns the Float at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Float at that Path
+     */
+    public Float getFloat(String path) {
+        return Float.valueOf(String.valueOf(getValue(path)));
+    }
+
+    /**
+     * Returns the Long at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Long at that Path
+     */
+    public Long getLong(String path) {
+        return Long.valueOf(String.valueOf(getValue(path)));
+    }
+
+    /**
+     * Returns the Sound at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Sound at that Path
+     */
+    public Sound getSound(String path) {
+        return Sound.valueOf(getString(path));
+    }
+
+    /**
+     * Returns the Date at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Date at that Path
+     */
+    public Date getDate(String path) {
+        return new Date(getLong(path));
+    }
+
+    /**
+     * Returns the Chunk at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Chunk at that Path
+     */
+    public Chunk getChunk(String path) {
+        return Bukkit.getWorld(getString(path + ".world")).getChunkAt(getInt(path + ".x"), getInt(path + ".z"));
+    }
+
+    /**
+     * Returns the UUID at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The UUID at that Path
+     */
+    public UUID getUUID(String path) {
+        return UUID.fromString(getString(path));
+    }
+
+    /**
+     * Returns the World at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The World at that Path
+     */
+    public World getWorld(String path) {
+        return Bukkit.getWorld(getString(path));
+    }
+
+    /**
+     * Returns the Double at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Double at that Path
+     */
+    public Double getDouble(String path) {
+        return config.getDouble(path);
+    }
+
+    /**
+     * Returns the Location at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @return The Location at that Path
+     */
+    public Location getLocation(String path) {
+        if (this.contains(path + ".pitch")) {
+            return new Location(Bukkit.getWorld(getString(path + ".world")), getDouble(path + ".x"), getDouble(path + ".y"), getDouble(path + ".z"), getFloat(path + ".yaw"), getFloat(path + ".pitch"));
+        } else {
+            return new Location(Bukkit.getWorld(this.getString(path + ".world")), this.getDouble(path + ".x"), this.getDouble(path + ".y"), this.getDouble(path + ".z"));
+        }
+    }
+
+    @Deprecated
+    public void setLocation(String path, Location location) {
+        setValue(path + ".x", location.getX());
+        setValue(path + ".y", location.getY());
+        setValue(path + ".z", location.getZ());
+        setValue(path + ".world", location.getWorld().getName());
+    }
+
+    @Deprecated
+    public void setInventory(String path, Inventory inventory) {
+        for (int i = 0; i < inventory.getSize(); i++) {
+            setValue(path + "." + i, inventory.getItem(i));
+        }
+    }
+
+    /**
+     * Gets the Contents of an Inventory at the specified Path
+     *
+     * @param path
+     *            The path in the Config File
+     * @param size
+     *            The Size of the Inventory
+     * @param title
+     *            The Title of the Inventory
+     * @return The generated Inventory
+     */
+    public Inventory getInventory(String path, int size, String title) {
+        Inventory inventory = Bukkit.createInventory(null, size, title);
+        for (int i = 0; i < size; i++) {
+            inventory.setItem(i, getItem(path + "." + i));
+        }
+        return inventory;
+    }
+
+    /**
+     * Returns all Paths in this Config
+     *
+     * @return All Paths in this Config
+     */
+    public Set<String> getKeys() {
+        return config.getKeys(false);
+    }
+
+    /**
+     * Returns all Sub-Paths in this Config
+     *
+     * @param path
+     *            The path in the Config File
+     * @return All Sub-Paths of the specified Path
+     */
+    public Set<String> getKeys(String path) {
+        return config.getConfigurationSection(path).getKeys(false);
+    }
+
+    /**
+     * Reloads the Configuration File
+     */
+    public void reload() {
+        this.config = YamlConfiguration.loadConfiguration(this.file);
+    }
+}

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
@@ -1,0 +1,347 @@
+package me.mrCookieSlime.CSCoreLibPlugin.general.Inventory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * An old remnant of CS-CoreLib.
+ * This will be removed once we updated everything.
+ * Don't look at the code, it will be gone soon, don't worry.
+ *
+ */
+public class ChestMenu {
+
+    private boolean clickable;
+    private boolean emptyClickable;
+    private String title;
+    private Inventory inv;
+    private List<ItemStack> items;
+    private Map<Integer, MenuClickHandler> handlers;
+    private MenuOpeningHandler open;
+    private MenuCloseHandler close;
+    private MenuClickHandler playerclick;
+
+    /**
+     * Creates a new ChestMenu with the specified
+     * Title
+     *
+     * @param title
+     *            The title of the Menu
+     */
+    public ChestMenu(String title) {
+        this.title = ChatColor.translateAlternateColorCodes('&', title);
+        this.clickable = false;
+        this.emptyClickable = true;
+        this.items = new ArrayList<>();
+        this.handlers = new HashMap<>();
+
+        this.open = p -> {};
+        this.close = p -> {};
+        this.playerclick = (p, slot, item, action) -> isPlayerInventoryClickable();
+    }
+
+    /**
+     * Toggles whether Players can access there
+     * Inventory while viewing this Menu
+     *
+     * @param clickable
+     *            Whether the Player can access his Inventory
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu setPlayerInventoryClickable(boolean clickable) {
+        this.clickable = clickable;
+        return this;
+    }
+
+    /**
+     * Returns whether the Player's Inventory is
+     * accessible while viewing this Menu
+     *
+     * @return Whether the Player Inventory is clickable
+     */
+    public boolean isPlayerInventoryClickable() {
+        return clickable;
+    }
+
+    /**
+     * Toggles whether Players can click the
+     * empty menu slots while viewing this Menu
+     *
+     * @param emptyClickable
+     *            Whether the Player can click empty slots
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu setEmptySlotsClickable(boolean emptyClickable) {
+        this.emptyClickable = emptyClickable;
+        return this;
+    }
+
+    /**
+     * Returns whether the empty menu slots are
+     * clickable while viewing this Menu
+     *
+     * @return Whether the empty menu slots are clickable
+     */
+    public boolean isEmptySlotsClickable() {
+        return emptyClickable;
+    }
+
+    /**
+     * Adds a ClickHandler to ALL Slots of the
+     * Player's Inventory
+     *
+     * @param handler
+     *            The MenuClickHandler
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu addPlayerInventoryClickHandler(MenuClickHandler handler) {
+        this.playerclick = handler;
+        return this;
+    }
+
+    /**
+     * Adds an Item to the Inventory in that Slot
+     *
+     * @param slot
+     *            The Slot in the Inventory
+     * @param item
+     *            The Item for that Slot
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu addItem(int slot, ItemStack item) {
+        final int size = this.items.size();
+        if (size > slot)
+            this.items.set(slot, item);
+        else {
+            for (int i = 0; i < slot - size; i++) {
+                this.items.add(null);
+            }
+            this.items.add(item);
+        }
+        return this;
+    }
+
+    /**
+     * Adds an Item to the Inventory in that Slot
+     * as well as a Click Handler
+     *
+     * @param slot
+     *            The Slot in the Inventory
+     * @param item
+     *            The Item for that Slot
+     * @param handler
+     *            The MenuClickHandler for that Slot
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu addItem(int slot, ItemStack item, MenuClickHandler clickHandler) {
+        addItem(slot, item);
+        addMenuClickHandler(slot, clickHandler);
+        return this;
+    }
+
+    /**
+     * Returns the ItemStack in that Slot
+     *
+     * @param slot
+     *            The Slot in the Inventory
+     * @return The ItemStack in that Slot
+     */
+    public ItemStack getItemInSlot(int slot) {
+        setup();
+        return this.inv.getItem(slot);
+    }
+
+    /**
+     * Executes a certain Action upon clicking an
+     * Item in the Menu
+     *
+     * @param slot
+     *            The Slot in the Inventory
+     * @param handler
+     *            The MenuClickHandler
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu addMenuClickHandler(int slot, MenuClickHandler handler) {
+        this.handlers.put(slot, handler);
+        return this;
+    }
+
+    /**
+     * Executes a certain Action upon opening
+     * this Menu
+     *
+     * @param handler
+     *            The MenuOpeningHandler
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu addMenuOpeningHandler(MenuOpeningHandler handler) {
+        this.open = handler;
+        return this;
+    }
+
+    /**
+     * Executes a certain Action upon closing
+     * this Menu
+     *
+     * @param handler
+     *            The MenuCloseHandler
+     * @return The ChestMenu Instance
+     */
+    public ChestMenu addMenuCloseHandler(MenuCloseHandler handler) {
+        this.close = handler;
+        return this;
+    }
+
+    /**
+     * Finishes the Creation of the Menu
+     *
+     * @return The ChestMenu Instance
+     */
+    @Deprecated
+    public ChestMenu build() {
+        return this;
+    }
+
+    /**
+     * Returns an Array containing the Contents
+     * of this Inventory
+     *
+     * @return The Contents of this Inventory
+     */
+    public ItemStack[] getContents() {
+        setup();
+        return this.inv.getContents();
+    }
+
+    private void setup() {
+        if (this.inv != null)
+            return;
+        this.inv = Bukkit.createInventory(null, ((int) Math.ceil(this.items.size() / 9F)) * 9, title);
+        for (int i = 0; i < this.items.size(); i++) {
+            this.inv.setItem(i, this.items.get(i));
+        }
+    }
+
+    /**
+     * Resets this ChestMenu to a Point BEFORE the User interacted with it
+     */
+    public void reset(boolean update) {
+        if (update)
+            this.inv.clear();
+        else
+            this.inv = Bukkit.createInventory(null, ((int) Math.ceil(this.items.size() / 9F)) * 9, title);
+        for (int i = 0; i < this.items.size(); i++) {
+            this.inv.setItem(i, this.items.get(i));
+        }
+    }
+
+    /**
+     * Modifies an ItemStack in an ALREADY OPENED ChestMenu
+     *
+     * @param slot
+     *            The Slot of the Item which will be replaced
+     * @param item
+     *            The new Item
+     */
+    public void replaceExistingItem(int slot, ItemStack item) {
+        setup();
+        this.inv.setItem(slot, item);
+    }
+
+    /**
+     * Opens this Menu for the specified Player/s
+     * 
+     * @param players
+     *            The Players who will see this Menu
+     */
+    public void open(Player... players) {
+        setup();
+        for (Player p : players) {
+            p.openInventory(this.inv);
+            MenuListener.menus.put(p.getUniqueId(), this);
+            if (open != null)
+                open.onOpen(p);
+        }
+    }
+
+    /**
+     * Returns the MenuClickHandler which was registered for the specified Slot
+     *
+     * @param slot
+     *            The Slot in the Inventory
+     * @return The MenuClickHandler registered for the specified Slot
+     */
+    public MenuClickHandler getMenuClickHandler(int slot) {
+        return handlers.get(slot);
+    }
+
+    /**
+     * Returns the registered MenuCloseHandler
+     *
+     * @return The registered MenuCloseHandler
+     */
+    public MenuCloseHandler getMenuCloseHandler() {
+        return close;
+    }
+
+    /**
+     * Returns the registered MenuOpeningHandler
+     *
+     * @return The registered MenuOpeningHandler
+     */
+    public MenuOpeningHandler getMenuOpeningHandler() {
+        return open;
+    }
+
+    /**
+     * Returns the registered MenuClickHandler
+     * for Player Inventories
+     *
+     * @return The registered MenuClickHandler
+     */
+    public MenuClickHandler getPlayerInventoryClickHandler() {
+        return playerclick;
+    }
+
+    /**
+     * Converts this ChestMenu Instance into a
+     * normal Inventory
+     *
+     * @return The converted Inventory
+     */
+    public Inventory toInventory() {
+        return this.inv;
+    }
+
+    @FunctionalInterface
+    public interface MenuClickHandler {
+
+        public boolean onClick(Player p, int slot, ItemStack item, ClickAction action);
+    }
+
+    public interface AdvancedMenuClickHandler extends MenuClickHandler {
+
+        public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action);
+    }
+
+    @FunctionalInterface
+    public interface MenuOpeningHandler {
+
+        public void onOpen(Player p);
+    }
+
+    @FunctionalInterface
+    public interface MenuCloseHandler {
+
+        public void onClose(Player p);
+    }
+}

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ClickAction.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ClickAction.java
@@ -1,0 +1,27 @@
+package me.mrCookieSlime.CSCoreLibPlugin.general.Inventory;
+
+/**
+ * An old remnant of CS-CoreLib.
+ * This will be removed once we updated everything.
+ * Don't look at the code, it will be gone soon, don't worry.
+ *
+ */
+public class ClickAction {
+
+    private boolean right;
+    private boolean shift;
+
+    public ClickAction(boolean rightClicked, boolean shiftClicked) {
+        this.right = rightClicked;
+        this.shift = shiftClicked;
+    }
+
+    public boolean isRightClicked() {
+        return right;
+    }
+
+    public boolean isShiftClicked() {
+        return shift;
+    }
+
+}

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/Item/CustomItemSerializer.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/Item/CustomItemSerializer.java
@@ -1,0 +1,117 @@
+package me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item;
+
+import java.util.Arrays;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * An old remnant of CS-CoreLib.
+ * This will be removed once we updated everything.
+ * Don't look at the code, it will be gone soon, don't worry.
+ * 
+ * @deprecated This was a horrible idea. Don't use it.
+ *
+ */
+@Deprecated
+public class CustomItemSerializer {
+
+    public enum ItemFlag {
+
+        MATERIAL(0),
+        DATA(1),
+        AMOUNT(2),
+        DURABILITY(3),
+        ENCHANTMENTS(4),
+        ITEMMETA_DISPLAY_NAME(5),
+        ITEMMETA_LORE(6);
+
+        private int weight;
+
+        ItemFlag(int weight) {
+            this.weight = weight;
+        }
+
+        public int getWeight() {
+            return this.weight;
+        }
+
+    }
+
+    private static ItemFlagComparator comparator = new ItemFlagComparator();
+
+    public static String serialize(ItemStack item, ItemFlag... flags) {
+        if (item == null)
+            return "NULL";
+        List<ItemFlag> flaglist = Arrays.asList(flags);
+
+        Collections.sort(flaglist, comparator);
+
+        StringBuilder builder = new StringBuilder();
+
+        int i = 0;
+        for (ItemFlag flag : flags) {
+            if (i > 0)
+                builder.append(" </sep> ");
+            builder.append(flag.toString() + "=");
+
+            switch (flag) {
+            case AMOUNT: {
+                builder.append(item.getAmount());
+                break;
+            }
+            case DATA: {
+                builder.append((int) item.getData().getData());
+                break;
+            }
+            case DURABILITY: {
+                builder.append((int) item.getDurability());
+                break;
+            }
+            case ENCHANTMENTS:
+                for (Enchantment enchantment : Enchantment.values()) {
+                    if (item.getEnchantments().containsKey(enchantment)) {
+                        builder.append(enchantment.getName() + ":" + item.getEnchantmentLevel(enchantment));
+                    } else {
+                        builder.append(enchantment.getName() + ":0");
+                    }
+                }
+                break;
+            case ITEMMETA_DISPLAY_NAME: {
+                if (item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
+                    builder.append(item.getItemMeta().getDisplayName().replaceAll("\\u00a7", "&"));
+                } else {
+                    builder.append("NONE");
+                }
+                break;
+            }
+            case ITEMMETA_LORE: {
+                if (item.hasItemMeta() && item.getItemMeta().hasLore()) {
+                    builder.append(item.getItemMeta().getLore().toString().replaceAll("\\u00a7", "&"));
+                } else {
+                    builder.append("NONE");
+                }
+                break;
+            }
+            case MATERIAL: {
+                builder.append(item.getType().toString());
+                break;
+            }
+            default:
+                break;
+            }
+
+            i++;
+        }
+
+        return builder.toString();
+    }
+
+    public static boolean equals(ItemStack stack1, ItemStack stack2, ItemFlag... flags) {
+        return serialize(stack1, flags).equals(serialize(stack2, flags));
+    }
+
+}

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/Item/ItemFlagComparator.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/Item/ItemFlagComparator.java
@@ -1,0 +1,23 @@
+package me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item;
+
+import java.util.Comparator;
+
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItemSerializer.ItemFlag;
+
+/**
+ * An old remnant of CS-CoreLib.
+ * This will be removed once we updated everything.
+ * Don't look at the code, it will be gone soon, don't worry.
+ * 
+ * @deprecated This was a horrible idea. Don't use it.
+ *
+ */
+@Deprecated
+public class ItemFlagComparator implements Comparator<ItemFlag> {
+
+    @Override
+    public int compare(ItemFlag flag1, ItemFlag flag2) {
+        return flag1.getWeight() - flag2.getWeight();
+    }
+
+}

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
@@ -1,0 +1,65 @@
+package me.mrCookieSlime.CSCoreLibPlugin.general.Inventory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.plugin.Plugin;
+
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu.AdvancedMenuClickHandler;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu.MenuClickHandler;
+
+/**
+ * An old {@link Listener} for CS-CoreLib
+ * 
+ * @deprecated This is an old remnant of CS-CoreLib, the last bits of the past. They will be removed once everything is
+ *             updated.
+ *
+ */
+@Deprecated
+public class MenuListener implements Listener {
+
+    static final Map<UUID, ChestMenu> menus = new HashMap<>();
+
+    public MenuListener(Plugin plugin) {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent e) {
+        ChestMenu menu = menus.get(e.getPlayer().getUniqueId());
+
+        if (menu != null) {
+            menu.getMenuCloseHandler().onClose((Player) e.getPlayer());
+            menus.remove(e.getPlayer().getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        ChestMenu menu = menus.get(e.getWhoClicked().getUniqueId());
+
+        if (menu != null) {
+            if (e.getRawSlot() < e.getInventory().getSize()) {
+                MenuClickHandler handler = menu.getMenuClickHandler(e.getSlot());
+
+                if (handler == null) {
+                    e.setCancelled(!menu.isEmptySlotsClickable() && (e.getCurrentItem() == null || e.getCurrentItem().getType() == Material.AIR));
+                } else if (handler instanceof AdvancedMenuClickHandler) {
+                    e.setCancelled(!((AdvancedMenuClickHandler) handler).onClick(e, (Player) e.getWhoClicked(), e.getSlot(), e.getCursor(), new ClickAction(e.isRightClick(), e.isShiftClick())));
+                } else {
+                    e.setCancelled(!handler.onClick((Player) e.getWhoClicked(), e.getSlot(), e.getCurrentItem(), new ClickAction(e.isRightClick(), e.isShiftClick())));
+                }
+            } else {
+                e.setCancelled(!menu.getPlayerInventoryClickHandler().onClick((Player) e.getWhoClicked(), e.getSlot(), e.getCurrentItem(), new ClickAction(e.isRightClick(), e.isShiftClick())));
+            }
+        }
+    }
+
+}

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
@@ -33,11 +33,10 @@ public class MenuListener implements Listener {
 
     @EventHandler
     public void onClose(InventoryCloseEvent e) {
-        ChestMenu menu = menus.get(e.getPlayer().getUniqueId());
+        ChestMenu menu = menus.remove(e.getPlayer().getUniqueId());
 
         if (menu != null) {
             menu.getMenuCloseHandler().onClose((Player) e.getPlayer());
-            menus.remove(e.getPlayer().getUniqueId());
         }
     }
 

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/package-info.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Old CS-CoreLib 1.X code.
+ */
+@java.lang.Deprecated
+package me.mrCookieSlime.CSCoreLibPlugin;

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockInfoConfig.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockInfoConfig.java
@@ -2,9 +2,10 @@ package me.mrCookieSlime.Slimefun.api;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.annotation.Nonnull;
 
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -39,12 +40,13 @@ public class BlockInfoConfig extends Config {
         this.data = data;
     }
 
+    @Nonnull
     public Map<String, String> getMap() {
         return data;
     }
 
     @Override
-    protected void store(String path, Object value) {
+    public void setValue(String path, Object value) {
         if (value != null && !(value instanceof String)) {
             throw new UnsupportedOperationException("Can't set \"" + path + "\" to \"" + value + "\" (type: " + value.getClass().getSimpleName() + ") because BlockInfoConfig only supports Strings");
         }
@@ -77,69 +79,41 @@ public class BlockInfoConfig extends Config {
     }
 
     @Override
-    public int getInt(String path) {
-        throw invalidType(path);
-    }
-
-    @Override
-    public boolean getBoolean(String path) {
-        throw invalidType(path);
-    }
-
-    @Override
-    public List<String> getStringList(String path) {
-        throw invalidType(path);
-    }
-
-    @Override
-    public List<Integer> getIntList(String path) {
-        throw invalidType(path);
-    }
-
-    @Override
-    public Double getDouble(String path) {
-        throw invalidType(path);
-    }
-
-    @Override
     public Set<String> getKeys(String path) {
-        throw invalidType(path);
-    }
-
-    private UnsupportedOperationException invalidType(String path) {
-        return new UnsupportedOperationException("Can't get \"" + path + "\" because BlockInfoConfig only supports String values");
+        throw new UnsupportedOperationException("Cannot get keys for BlockInfoConfig");
     }
 
     @Override
     public File getFile() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("BlockInfoConfigs do not have a File");
     }
 
     @Override
     public FileConfiguration getConfiguration() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("BlockInfoConfigs do not have a FileConfiguration");
     }
 
     @Override
     public void save() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("BlockInfoConfigs cannot be saved to a File");
     }
 
     @Override
     public void save(File file) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("BlockInfoConfigs cannot be saved to a File");
     }
 
     @Override
     public void createFile() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("BlockInfoConfigs cannot be created from a File");
     }
 
     @Override
     public void reload() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("BlockInfoConfigs cannot be reloaded");
     }
 
+    @Nonnull
     public String toJSON() {
         return new GsonBuilder().create().toJson(data);
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/EmptyBlockData.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/EmptyBlockData.java
@@ -17,7 +17,7 @@ class EmptyBlockData extends BlockInfoConfig {
     }
 
     @Override
-    protected void store(String path, Object value) {
+    public void setValue(String path, Object value) {
         throw new UnsupportedOperationException("Cannot store values (" + path + ':' + value + " on a read-only data object!");
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/package-info.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Old Slimefun 4.0 code.
+ */
+@java.lang.Deprecated
+package me.mrCookieSlime.Slimefun;

--- a/src/main/java/me/mrCookieSlime/package-info.java
+++ b/src/main/java/me/mrCookieSlime/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * These are the old packages, the remnants of past versions that have not been rewritten yet.
+ * Don't look too close at the code that lays here. It's horrible, believe me.
+ * Once we updated everything, all of these classes will be removed.
+ */
+@java.lang.Deprecated
+package me.mrCookieSlime;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,7 +13,6 @@ api-version: '1.14'
 
 # (Soft) dependencies of Slimefun, we hook into these plugins.
 softdepend:
-- CS-CoreLib
 - PlaceholderAPI
 - WorldEdit
 - ClearLag

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestItemPickupListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestItemPickupListener.java
@@ -20,11 +20,11 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
 import be.seeseemelk.mockbukkit.inventory.HopperInventoryMock;
+import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientPedestal;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.ItemPickupListener;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import me.mrCookieSlime.CSCoreLibPlugin.cscorelib2.item.CustomItem;
 
 class TestItemPickupListener {
 


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
For ~3 years we have been slowly but surely getting rid of the old CS-CoreLib code (CSCL 1 that is).
Sure, a lot of addons may still use methods from CSCL 1 but I made sure to transfer the three main classes that are still in use.

Note here that CSCL 1 has basically remained untouched since 2018 and bStats shows that literally **noone** is running any outdated versions. So the classes should all match, in case someone still uses CSCL1 (though, our classes should take priority when loaded...), the class signatures should still be compatible.

This may need much more testing though before this is ready to be merged.
We may announce this as a public beta.

## Changes
<!-- Please list all the changes you have made. -->
* Removed CS-CoreLib dependency from the `pom.xml`
* Removed CS-CoreLib as a `softDepend` from the `plugin.yml`
* Removed check for CS-CoreLib on startup
* Transferred any "still-in-use" classes from CS-CoreLib to the Slimefun src

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
