### PR TITLE
Enable batch mode and disable transfer progress for Maven

### DIFF
--- a/.github/workflows/maven-compiler.yml
+++ b/.github/workflows/maven-compiler.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn package --file pom.xml
+      run: mvn package -B --no-transfer-progress

--- a/.github/workflows/maven-compiler.yml
+++ b/.github/workflows/maven-compiler.yml
@@ -13,6 +13,7 @@ on:
     paths:
     - 'src/**'
     - 'pom.xml'
+    - '.github/workflows/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Description
Enable batch mode (If any prompts come up just use default value) and disable transfer progress (since this spams lots of lines). This will make the log cleaner and prevent any issue where a stall could happen.

Will slightly increase build time but mainly just shorten the log.

## Changes
* Change maven command to `-B --no-transfer-progress`

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those checkboxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
