### PR TITLE
Fix the infused hopper picking up items with pickup delay Short.MAX_VALUE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Fixed a threading issue related to BlockStates and persistent data
 * Fixed an error when the server was shutting down
 * Fixed #2721
+* Fixed Infused Hopper picking up items with a max pickup delay
 
 ## Release Candidate 19 (11 Jan 2021)
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunCommand.java
@@ -83,7 +83,7 @@ public class SlimefunCommand implements CommandExecutor, Listener {
 
         sendHelp(sender);
 
-        /**
+        /*
          * We could just return true here, but if there's no subcommands,
          * then something went horribly wrong anyway.
          * This will also stop sonarcloud from nagging about

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
@@ -28,13 +28,11 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 /**
  * The {@link InfusedHopper} is a special kind of {@link Hopper} which teleports any
- * neaby {@link Item} to itself.
+ * nearby {@link Item} to itself.
  * The radius can be configured in the config.
- * 
- * @author TheBusyBiscuit
- * 
- * @see InfusedMagnet
  *
+ * @author TheBusyBiscuit
+ * @see InfusedMagnet
  */
 public class InfusedHopper extends SimpleSlimefunItem<BlockTicker> {
 
@@ -65,7 +63,7 @@ public class InfusedHopper extends SimpleSlimefunItem<BlockTicker> {
                 if (toggleable.getValue()) {
                     Hopper hopper = (Hopper) b.getBlockData();
 
-                    /**
+                    /*
                      * If the Hopper was disabled by a redstone signal,
                      * we just don't do anything.
                      */
@@ -85,7 +83,7 @@ public class InfusedHopper extends SimpleSlimefunItem<BlockTicker> {
                     playSound = true;
                 }
 
-                /**
+                /*
                  * Play a sound if at least one item was teleported and
                  * the "silent" setting is set to false.
                  */
@@ -104,7 +102,10 @@ public class InfusedHopper extends SimpleSlimefunItem<BlockTicker> {
     private boolean isValidItem(@Nonnull Location l, @Nonnull Entity entity) {
         if (entity instanceof Item && entity.isValid()) {
             Item item = (Item) entity;
-            return !SlimefunUtils.hasNoPickupFlag(item) && item.getLocation().distanceSquared(l) > 0.25;
+            // Check if the item cannot be picked up or has the "no pickup" metadata
+            return item.getPickupDelay() != Short.MAX_VALUE
+                && !SlimefunUtils.hasNoPickupFlag(item)
+                && item.getLocation().distanceSquared(l) > 0.25;
         }
 
         return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
@@ -32,6 +32,7 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * The radius can be configured in the config.
  *
  * @author TheBusyBiscuit
+ * @author Walshy
  * @see InfusedMagnet
  */
 public class InfusedHopper extends SimpleSlimefunItem<BlockTicker> {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
@@ -104,7 +104,7 @@ public class InfusedHopper extends SimpleSlimefunItem<BlockTicker> {
         if (entity instanceof Item && entity.isValid()) {
             Item item = (Item) entity;
             // Check if the item cannot be picked up or has the "no pickup" metadata
-            return item.getPickupDelay() != Short.MAX_VALUE
+            return item.getPickupDelay() <= 0
                 && !SlimefunUtils.hasNoPickupFlag(item)
                 && item.getLocation().distanceSquared(l) > 0.25;
         }


### PR DESCRIPTION
## Description
The Infused Hopper would think that an item with pickup delay of 32,767 is valid. Items with a delay of 32,767 are marked as non-pickupable by the MC client and server. We should treat them the same, there are many plugins which use this in order to say their items shouldn't be picked up.

MC Wiki Ref: https://minecraft.gamepedia.com/Item_(entity)#Entity_data

## Changes
* Added a pickup delay check to InfusedHopper#isValidItem
* Fixed a typo in the class Javadoc

## Related Issues
Skizzles on Discord: https://discord.com/channels/565557184348422174/565569196218384385/799931483635580959

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
