### PR TITLE
Added script length checking

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -474,7 +474,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                 openScript(pl, b, getScript(b.getLocation()));
             } else {
                 pl.closeInventory();
-                pl.sendMessage("&cThe script is too large to edit!");
+                pl.sendMessage(ChatColor.RED + "The script is too large to edit!");
             }
             return false;
         });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -556,6 +556,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         Validate.notNull(script, "No script given");
         Validate.isTrue(script.startsWith(Instruction.START.name() + '-'), "A script must begin with a 'START' token.");
         Validate.isTrue(script.endsWith('-' + Instruction.REPEAT.name()), "A script must end with a 'REPEAT' token.");
+        Validate.isTrue(PatternUtils.DASH.split(script).length <= MAX_SCRIPT_LENGTH, "Scripts may not have more than " + MAX_SCRIPT_LENGTH + " segments");
 
         BlockStorage.addBlockInfo(l, "script", script);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -470,7 +470,12 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
         menu.addItem(1, new CustomItem(HeadTexture.SCRIPT_FORWARD.getAsItemStack(), "&2> Edit Script", "", "&aEdits your current Script"));
         menu.addMenuClickHandler(1, (pl, slot, item, action) -> {
-            openScript(pl, b, getScript(b.getLocation()));
+            if (PatternUtils.DASH.split(BlockStorage.getLocationInfo(b.getLocation()).getString("script")).length <= MAX_SCRIPT_LENGTH) {
+                openScript(pl, b, getScript(b.getLocation()));
+            } else {
+                pl.closeInventory();
+                pl.sendMessage("&cThe script is too large to edit!");
+            }
             return false;
         });
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -474,7 +474,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                 openScript(pl, b, getScript(b.getLocation()));
             } else {
                 pl.closeInventory();
-                pl.sendMessage(ChatColor.RED + "The script is too large to edit!");
+                SlimefunPlugin.getLocalization().sendMessage(pl, "android.scripts.too-long");
             }
             return false;
         });
@@ -556,7 +556,6 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         Validate.notNull(script, "No script given");
         Validate.isTrue(script.startsWith(Instruction.START.name() + '-'), "A script must begin with a 'START' token.");
         Validate.isTrue(script.endsWith('-' + Instruction.REPEAT.name()), "A script must end with a 'REPEAT' token.");
-        Validate.isTrue(PatternUtils.DASH.split(script).length <= MAX_SCRIPT_LENGTH, "Scripts may not have more than " + MAX_SCRIPT_LENGTH + " segments");
 
         BlockStorage.addBlockInfo(l, "script", script);
     }

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -314,6 +314,7 @@ android:
   scripts:
     already-uploaded: '&4This script has already been uploaded.'
     editor: 'Script Editor'
+    too-long: '&cThe script is too long to edit!'
     
     instructions:
       START: '&2Start Script'


### PR DESCRIPTION
## Description
I added a script length check right before opening the edit script page. The reason for this is that in an addon I'm making, I can set much longer scripts than 54 instructions.

## Changes
Added a script length check

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos. (I don't think this needs testing)
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I added sufficient Unit Tests to cover my code.
