### PR TITLE
Soulbound items adhere to the world settings

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.ItemStack;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Soulbound;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 /**
  * This {@link Listener} is responsible for handling any {@link Soulbound} items.
@@ -43,11 +44,10 @@ public class SoulboundListener implements Listener {
             ItemStack item = p.getInventory().getItem(slot);
 
             // Store soulbound items for later retrieval
-            if (SlimefunUtils.isSoulbound(item)) {
+            if (SlimefunUtils.isSoulbound(item) && Slimefun.isEnabled(p, item, false)) {
                 items.put(slot, item);
             }
         }
-
         // There shouldn't even be any items in there, but let's be extra safe!
         Map<Integer, ItemStack> existingItems = soulbound.get(p.getUniqueId());
 
@@ -62,7 +62,7 @@ public class SoulboundListener implements Listener {
         while (drops.hasNext()) {
             ItemStack item = drops.next();
 
-            if (SlimefunUtils.isSoulbound(item)) {
+            if (SlimefunUtils.isSoulbound(item) && Slimefun.isEnabled(p, item, false)) {
                 drops.remove();
             }
         }


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
- Added checks `Slimefun.isEnabled(p, item, false)` while soulbound items being added for retrieval and again before removing soulbound items from dropped items.

## Changes
<!-- Please list all the changes you have made. -->
- Imported `me.mrCookieSlime.Slimefun.api.Slimefun` package.
- Added `Slimefun.isEnabled(p, item, false)` checks.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #2650

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
