### PR TITLE
Check inv maxStackSize

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -105,15 +105,18 @@ public class DirtyChestMenu extends ChestMenu {
             if (stack == null) {
                 replaceExistingItem(slot, item);
                 return null;
-            } else if (stack.getAmount() < stack.getMaxStackSize()) {
-                if (wrapper == null) {
-                    wrapper = new ItemStackWrapper(item);
-                }
+            } else {
+                int maxStackSize = Math.min(stack.getMaxStackSize(), toInventory().getMaxStackSize());
+                if (stack.getAmount() < maxStackSize) {
+                    if (wrapper == null) {
+                        wrapper = new ItemStackWrapper(item);
+                    }
 
-                if (ItemUtils.canStack(wrapper, stack)) {
-                    amount -= (stack.getMaxStackSize() - stack.getAmount());
-                    stack.setAmount(Math.min(stack.getAmount() + item.getAmount(), stack.getMaxStackSize()));
-                    item.setAmount(amount);
+                    if (ItemUtils.canStack(wrapper, stack)) {
+                        amount -= (maxStackSize - stack.getAmount());
+                        stack.setAmount(Math.min(stack.getAmount() + item.getAmount(), maxStackSize));
+                        item.setAmount(amount);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
As mentioned in CS-CoreLib2's numbers 141 and 142 PR's, previous iterations of Slimefun AContainers would not consider the underlying Inventory's max stack size when determining sizing or pushing items. This commit changes DirtyChestMenus to act similarly by storing a variable defined as the lower of the Inventory's max stack size and the ItemStack's max stack size in a slot.

## Changes
* Changed `else if` statement in line 108 to an `else`
* Defined variable `maxStackSize`
* Resumed original conditional statement
* Changed all references of `stack.getMaxStackSize()` to `maxStackSize`

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
