### PR TITLE
Add a way to retrieve the raw storage

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -22,6 +22,7 @@ jobs:
           fix: '✨ Fix'
           chore: '🧹 Chores'
           performance: '💡 Performance Optimization'
+          api: '🔧 API'
 
       - uses: thollander/actions-comment-pull-request@1.0.1
         name: Comment the applied label
@@ -45,6 +46,7 @@ jobs:
             `feature/**`             | 🎈 Feature
             `fix/**`                 | ✨ Fix
             `chore/**`               | 🧹 Chores
+            `api/**`                 | 🔧 API
             `performance/**`         | 💡 Performance Optimization
             <hr>
             If your changes do not fall into any of these categories, don't worry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Fixed machines not respecting max size from inventories
 * Fixed #2761
 * Fixed #2460
+* Fixed #2760
 
 ## Release Candidate 19 (11 Jan 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Fixed #2754
 * Fixed machines not respecting max size from inventories
 * Fixed #2761
+* Fixed #2460
 
 ## Release Candidate 19 (11 Jan 2021)
 

--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
         <dependency>
             <groupId>com.gmail.nossr50.mcMMO</groupId>
             <artifactId>mcMMO</artifactId>
-            <version>2.1.172</version>
+            <version>2.1.173</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/BookBinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/BookBinder.java
@@ -106,7 +106,7 @@ public class BookBinder extends AContainer {
         Map<Enchantment, Integer> enchantments = new HashMap<>();
         boolean conflicts = false;
         enchantments.putAll(ech1);
-        
+
         for (Map.Entry<Enchantment, Integer> entry : ech2.entrySet()) {
             for (Map.Entry<Enchantment, Integer> conflictsWith : enchantments.entrySet()) {
                 if (entry.getKey().conflictsWith(conflictsWith.getKey())) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -8,6 +8,7 @@ import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.inventory.ItemStack;
@@ -138,12 +139,17 @@ class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements NotPla
         } else if (material == Material.PLAYER_HEAD || SlimefunTag.SHULKER_BOXES.isTagged(material)) {
             b.breakNaturally(item);
         } else {
-            boolean applyFortune = SlimefunTag.FORTUNE_COMPATIBLE_ORES.isTagged(material);
+            // Check if the block was mined using Silk Touch
+            if (item.containsEnchantment(Enchantment.SILK_TOUCH)) {
+                b.getWorld().dropItemNaturally(b.getLocation(), new ItemStack(b.getType()));
+            } else {
+                boolean applyFortune = SlimefunTag.FORTUNE_COMPATIBLE_ORES.isTagged(material);
 
-            for (ItemStack drop : b.getDrops(getItem())) {
-                // For some reason this check is necessary with Paper
-                if (drop != null && drop.getType() != Material.AIR) {
-                    b.getWorld().dropItemNaturally(b.getLocation(), applyFortune ? new CustomItem(drop, fortune) : drop);
+                for (ItemStack drop : b.getDrops(getItem())) {
+                    // For some reason this check is necessary with Paper
+                    if (drop != null && drop.getType() != Material.AIR) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), applyFortune ? new CustomItem(drop, fortune) : drop);
+                    }
                 }
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -246,13 +246,14 @@ public class TalismanListener implements Listener {
 
         // Wizard Talisman
         if (!enchantments.containsKey(Enchantment.SILK_TOUCH) && Enchantment.LOOT_BONUS_BLOCKS.canEnchantItem(e.getItem()) && Talisman.checkFor(e, SlimefunItems.TALISMAN_WIZARD)) {
-
-            for (Enchantment enchantment : enchantments.keySet()) {
-                if (random.nextInt(100) < 40) {
-                    e.getEnchantsToAdd().put(enchantment, random.nextInt(3) + 1);
+            // Randomly lower some enchantments
+            for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
+                if (entry.getValue() > 1 && random.nextInt(100) < 40) {
+                    enchantments.put(entry.getKey(), entry.getValue() - 1);
                 }
             }
 
+            // Give an extra Fortune boost (Lvl 3 - 5)
             enchantments.put(Enchantment.LOOT_BONUS_BLOCKS, random.nextInt(3) + 3);
         }
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -387,7 +387,7 @@ public class BlockStorage {
 
         BlockStorage storage = getStorage(world);
         if (storage != null) {
-            return (storage.getRawStorage();
+            return storage.getRawStorage();
         } else {
             return null;
         }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -27,6 +27,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.ItemStack;
 
+import org.apache.commons.lang.Validate;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -357,6 +359,23 @@ public class BlockStorage {
             cfg.save(chunks);
 
             chunkChanges = 0;
+        }
+    }
+
+    @Nonnull
+    public Map<Location, Config> getRawStorage() {
+        return this.storage;
+    }
+
+    @Nullable
+    public static Map<Location, Config> getRawStorage(@Nonnull World world) {
+        Validate.notNull(world, "World cannot be null!");
+
+        BlockStorage storage = getStorage(world);
+        if (storage != null) {
+            return storage.getRawStorage();
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -371,7 +371,7 @@ public class BlockStorage {
      */
     @Nonnull
     public Map<Location, Config> getRawStorage() {
-        return this.storage;
+        return ImmutableMap.copyOf(this.storage);
     }
 
     /**
@@ -387,7 +387,7 @@ public class BlockStorage {
 
         BlockStorage storage = getStorage(world);
         if (storage != null) {
-            return ImmutableMap.copyOf(storage.getRawStorage());
+            return (storage.getRawStorage();
         } else {
             return null;
         }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.google.common.collect.ImmutableMap;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -362,18 +363,31 @@ public class BlockStorage {
         }
     }
 
+    /**
+     * This will return an {@link ImmutableMap} of the underline {@code Map<String, Config>} of
+     * this worlds {@link BlockStorage}.
+     *
+     * @return An {@link ImmutableMap} of the raw data.
+     */
     @Nonnull
     public Map<Location, Config> getRawStorage() {
         return this.storage;
     }
 
+    /**
+     * This will return an {@link ImmutableMap} of the underline {@code Map<String, Config>} of
+     * this worlds {@link BlockStorage}. If there is no registered world then this will return null.
+     *
+     * @param world The world of which to fetch the data from.
+     * @return An {@link ImmutableMap} of the raw data or null if the world isn't registered.
+     */
     @Nullable
     public static Map<Location, Config> getRawStorage(@Nonnull World world) {
         Validate.notNull(world, "World cannot be null!");
 
         BlockStorage storage = getStorage(world);
         if (storage != null) {
-            return storage.getRawStorage();
+            return ImmutableMap.copyOf(storage.getRawStorage());
         } else {
             return null;
         }

--- a/src/main/resources/languages/researches_ja.yml
+++ b/src/main/resources/languages/researches_ja.yml
@@ -249,3 +249,4 @@ slimefun:
   energy_connectors: 有線接続
   bee_armor: 蜂アーマー
   wise_talisman: 知恵のタリスマン
+  book_binder: エンチャントの本の製本


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Provide a way to access BlockStorage's `storage`. This adds a way to access all the blocks loaded in the server. It may be worth making this return an immutable map so that people don't modify this. Let me know your opinion.

This is currently untested (though if it compiles, can't see why it wouldn't work) and I made this on my phone sooo compilation may fail. Not added tests or docs either due to phone (also this class really needs to be redone anyway)

## Changes
<!-- Please list all the changes you have made. -->
* Added BlockStorage#getStorage
* Added BlockStorage.getStorage(World)

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
