### PR TITLE
Allow Talismans to use the Actionbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Added Talisman of the Wise
 * Added Book Binder
 * Added Tier 3 Electric Ore Grinder
+* Added an option to allow Talismans to send their notifications via the Actionbar
 
 #### Changes
 * Massive performance improvements to holograms/armorstands

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -64,12 +64,14 @@ public final class SlimefunRegistry {
     private final List<String> researchRanks = new ArrayList<>();
     private final Set<UUID> researchingPlayers = Collections.synchronizedSet(new HashSet<>());
 
+    // TODO: Move this all into a proper "config cache" class
     private boolean backwardsCompatibility;
     private boolean automaticallyLoadItems;
     private boolean enableResearches;
     private boolean freeCreativeResearches;
     private boolean researchFireworks;
     private boolean logDuplicateBlockEntries;
+    private boolean talismanActionBarMessages;
 
     private final Set<String> tickers = new HashSet<>();
     private final Set<SlimefunItem> radioactive = new HashSet<>();
@@ -110,6 +112,7 @@ public final class SlimefunRegistry {
         freeCreativeResearches = cfg.getBoolean("researches.free-in-creative-mode");
         researchFireworks = cfg.getBoolean("researches.enable-fireworks");
         logDuplicateBlockEntries = cfg.getBoolean("options.log-duplicate-block-entries");
+        talismanActionBarMessages = cfg.getBoolean("talismans.use-actionbar");
     }
 
     /**
@@ -352,6 +355,10 @@ public final class SlimefunRegistry {
 
     public boolean logDuplicateBlockEntries() {
         return logDuplicateBlockEntries;
+    }
+    
+    public boolean useActionbarForTalismans() {
+        return talismanActionBarMessages;
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -26,6 +26,9 @@ import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.core.services.LocalizationService;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
 
 /**
  * This is an abstract parent class of {@link LocalizationService}.
@@ -223,6 +226,14 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
         } else {
             sender.sendMessage(ChatColor.stripColor(ChatColors.color(prefix + getMessage(key))));
         }
+    }
+
+    public void sendActionbarMessage(@Nonnull Player player, @Nonnull String key, boolean addPrefix) {
+        String prefix = addPrefix ? getPrefix() : "";
+        String message = ChatColors.color(prefix + getMessage(player, key));
+
+        BaseComponent[] components = TextComponent.fromLegacyText(message);
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, components);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -619,6 +619,8 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         new ButcherAndroidListener(this);
         new NetworkListener(this, networkManager);
         new HopperListener(this);
+        new TalismanListener(this);
+        new SoulboundListener(this);
 
         // Bees were added in 1.15
         if (minecraftVersion.isAtLeast(MinecraftVersion.MINECRAFT_1_15)) {
@@ -639,15 +641,6 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         grapplingHookListener.register(this, (GrapplingHook) SlimefunItems.GRAPPLING_HOOK.getItem());
         bowListener.register(this);
         backpackListener.register(this);
-
-        // Toggleable Listeners for performance reasons
-        if (config.getBoolean("items.talismans")) {
-            new TalismanListener(this);
-        }
-
-        if (config.getBoolean("items.soulbound")) {
-            new SoulboundListener(this);
-        }
 
         // Handle Slimefun Guide being given on Join
         new SlimefunGuideListener(this, config.getBoolean("guide.receive-on-first-join"));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,9 +38,8 @@ networks:
   enable-visualizer: true
   delete-excess-items: false
 
-items:
-  talismans: true
-  soulbound: true
+talismans:
+  use-actionbar: true
 
 metrics:
   auto-update: true


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Long-requested feature; Talismans can now send their messages using the actionbar.
This is configurable but reduces spam :)

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
