### PR TITLE
Add java ver and hover to versions subcommand

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -5,13 +5,11 @@ import java.util.Collection;
 import javax.annotation.Nonnull;
 
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.hover.content.Text;
-import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
@@ -104,13 +102,13 @@ class VersionsCommand extends SubCommand {
                 ClickEvent clickEvent = null;
                 if (plugin instanceof SlimefunAddon) {
                     hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
-                        "Author: " + String.join(", ", plugin.getDescription().getAuthors())
+                        "Author(s): " + String.join(", ", plugin.getDescription().getAuthors())
                         + "\nClick to open the Bug Tracker"
                     ));
                     clickEvent = new ClickEvent(ClickEvent.Action.OPEN_URL, ((SlimefunAddon) plugin).getBugTrackerURL());
                 } else {
                     hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
-                        "Author: " + String.join(", ", plugin.getDescription().getAuthors())
+                        "Author(s): " + String.join(", ", plugin.getDescription().getAuthors())
                     ));
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -48,7 +48,7 @@ class VersionsCommand extends SubCommand {
             if (SlimefunPlugin.getRegistry().isBackwardsCompatible()) {
                 HoverEvent hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
                     "Backwards compatibility has a negative impact on performance!\n"
-                        + "We recommend you to disable this setting unless your server still"
+                        + "We recommend you to disable this setting unless your server still "
                         + "has legacy Slimefun items (from before summer 2019) in circulation."
                 ));
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -4,7 +4,10 @@ import java.util.Collection;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import me.mrCookieSlime.Slimefun.api.Slimefun;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.hover.content.Text;
@@ -45,14 +48,19 @@ class VersionsCommand extends SubCommand {
             addJavaVersion(builder);
 
             if (SlimefunPlugin.getRegistry().isBackwardsCompatible()) {
-                builder.append("Backwards compatibility enabled!\n").color(ChatColor.RED);
+                HoverEvent hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
+                    "Backwards compatibility has a negative impact on performance!\n"
+                        + "We recommend you to disable this setting unless your server still"
+                        + "has legacy Slimefun items (from before summer 2019) in circulation."
+                ));
+
+                builder.append("Backwards compatibility enabled!\n").color(ChatColor.RED).event(hoverEvent);
             }
 
-            builder.append("\n");
+            builder.append("\n").event((HoverEvent) null);
 
             addPluginVersions(builder);
 
-            System.out.println(ComponentSerializer.toString(builder.create()));
             sender.spigot().sendMessage(builder.create());
         } else {
             SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);
@@ -64,7 +72,9 @@ class VersionsCommand extends SubCommand {
         if (javaVer.startsWith("1.")) {
             javaVer = javaVer.substring(2);
         }
-        if (javaVer.indexOf('.') != -1) { // If it's like 11.0.1.3 or 8.0_275
+
+        // If it's like 11.0.1.3 or 8.0_275
+        if (javaVer.indexOf('.') != -1) {
             javaVer = javaVer.substring(0, javaVer.indexOf('.'));
         }
         int ver = Integer.parseInt(javaVer);
@@ -90,16 +100,41 @@ class VersionsCommand extends SubCommand {
             String version = plugin.getDescription().getVersion();
 
             if (Bukkit.getPluginManager().isPluginEnabled(plugin)) {
-                builder.append("\n  " + plugin.getName()).color(ChatColor.GREEN)
-                    .append(" v" + version).color(ChatColor.DARK_GREEN);
+                HoverEvent hoverEvent;
+                ClickEvent clickEvent = null;
+                if (plugin instanceof SlimefunAddon) {
+                    hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
+                        "Author: " + String.join(", ", plugin.getDescription().getAuthors())
+                        + "\nClick to open the Bug Tracker"
+                    ));
+                    clickEvent = new ClickEvent(ClickEvent.Action.OPEN_URL, ((SlimefunAddon) plugin).getBugTrackerURL());
+                } else {
+                    hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
+                        "Author: " + String.join(", ", plugin.getDescription().getAuthors())
+                    ));
+                }
+
+                builder.append("\n  " + plugin.getName()).color(ChatColor.GREEN).event(hoverEvent).event(clickEvent)
+                    .append(" v" + version).color(ChatColor.DARK_GREEN)
+                .append("").event((ClickEvent) null).event((HoverEvent) null);
             } else {
-                HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                    new Text("Plugin is disabled. Check the console for an error and report on their issue tracker."));
+                HoverEvent hoverEvent;
+                ClickEvent clickEvent = null;
+                if (plugin instanceof SlimefunAddon) {
+                    hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                        new Text("Plugin is disabled. Check the console for an error. Click here to report on their issue tracker"));
+                    if (((SlimefunAddon) plugin).getBugTrackerURL() != null) {
+                        clickEvent = new ClickEvent(ClickEvent.Action.OPEN_URL, ((SlimefunAddon) plugin).getBugTrackerURL());
+                    }
+                } else {
+                    hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                        new Text("Plugin is disabled. Check the console for an error and report on their issue tracker."));
+                }
 
                 // We need to reset the hover event or it's added to all components
-                builder.append("\n  " + plugin.getName()).color(ChatColor.RED).event(hover)
+                builder.append("\n  " + plugin.getName()).color(ChatColor.RED).event(hoverEvent).event(clickEvent)
                     .append(" v" + version).color(ChatColor.DARK_RED)
-                    .append("").event((HoverEvent) null);
+                    .append("").event((ClickEvent) null).event((HoverEvent) null);
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -3,13 +3,17 @@ package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
 import java.util.Collection;
 
 import javax.annotation.Nonnull;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.plugin.Plugin;
 
-import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
 import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
 import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
@@ -28,35 +32,75 @@ class VersionsCommand extends SubCommand {
             // so we will just fix this inconsistency for them :)
             String serverSoftware = PaperLib.isSpigot() && !PaperLib.isPaper() ? "Spigot" : Bukkit.getName();
 
-            sender.sendMessage(ChatColor.GRAY + "This Server uses the following setup of Slimefun:");
-            sender.sendMessage(ChatColors.color("&a" + serverSoftware + " &2" + Bukkit.getVersion()));
-            sender.sendMessage(ChatColors.color("&aSlimefun &2v" + SlimefunPlugin.getVersion()));
+            ComponentBuilder builder = new ComponentBuilder();
+            builder.append("This Server uses the following setup of Slimefun:\n").color(ChatColor.GRAY)
+                .append(serverSoftware).color(ChatColor.GREEN).append(" " + Bukkit.getVersion() + '\n').color(ChatColor.DARK_GREEN)
+                .append("Slimefun").color(ChatColor.GREEN).append(" v" + SlimefunPlugin.getVersion() + '\n').color(ChatColor.DARK_GREEN);
 
             if (SlimefunPlugin.getMetricsService().getVersion() != null) {
-                sender.sendMessage(ChatColors.color("&aMetrics build: &2#" + SlimefunPlugin.getMetricsService().getVersion()));
+                builder.append("Metrics build: ").color(ChatColor.GREEN)
+                    .append("#" + SlimefunPlugin.getMetricsService().getVersion() + '\n').color(ChatColor.DARK_GREEN);
             }
+
+            addJavaVersion(builder);
 
             if (SlimefunPlugin.getRegistry().isBackwardsCompatible()) {
-                sender.sendMessage(ChatColor.RED + "Backwards compatibility enabled!");
+                builder.append("Backwards compatibility enabled!\n").color(ChatColor.RED);
             }
 
-            sender.sendMessage("");
+            builder.append("\n");
 
-            Collection<Plugin> addons = SlimefunPlugin.getInstalledAddons();
-            sender.sendMessage(ChatColors.color("&7Installed Addons: &8(" + addons.size() + ")"));
+            addPluginVersions(builder);
 
-            for (Plugin plugin : addons) {
-                String version = plugin.getDescription().getVersion();
-
-                if (Bukkit.getPluginManager().isPluginEnabled(plugin)) {
-                    sender.sendMessage(ChatColor.GREEN + " " + plugin.getName() + ChatColor.DARK_GREEN + " v" + version);
-                } else {
-                    sender.sendMessage(ChatColor.RED + " " + plugin.getName() + ChatColor.DARK_RED + " v" + version);
-                }
-            }
+            System.out.println(ComponentSerializer.toString(builder.create()));
+            sender.spigot().sendMessage(builder.create());
         } else {
             SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);
         }
     }
 
+    private void addJavaVersion(@Nonnull ComponentBuilder builder) {
+        String javaVer = System.getProperty("java.version");
+        if (javaVer.startsWith("1.")) {
+            javaVer = javaVer.substring(2);
+        }
+        if (javaVer.indexOf('.') != -1) { // If it's like 11.0.1.3 or 8.0_275
+            javaVer = javaVer.substring(0, javaVer.indexOf('.'));
+        }
+        int ver = Integer.parseInt(javaVer);
+
+        if (ver < 11) {
+            builder.append("Java " + ver).color(ChatColor.RED)
+                .event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
+                    "You should be using at least Java 11! Paper will be dropping support for before Java 11 starting at MC 1.17"
+                )))
+                .append("\n")
+                .event((HoverEvent) null);
+        } else {
+            builder.append("Java " + ver + "\n").color(ChatColor.GREEN);
+        }
+    }
+
+    private void addPluginVersions(@Nonnull ComponentBuilder builder) {
+        Collection<Plugin> addons = SlimefunPlugin.getInstalledAddons();
+        builder.append("Installed Addons: ").color(ChatColor.GRAY)
+            .append("(" + addons.size() + ")").color(ChatColor.DARK_GRAY);
+
+        for (Plugin plugin : addons) {
+            String version = plugin.getDescription().getVersion();
+
+            if (Bukkit.getPluginManager().isPluginEnabled(plugin)) {
+                builder.append("\n  " + plugin.getName()).color(ChatColor.GREEN)
+                    .append(" v" + version).color(ChatColor.DARK_GREEN);
+            } else {
+                HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                    new Text("Plugin is disabled. Check the console for an error and report on their issue tracker."));
+
+                // We need to reset the hover event or it's added to all components
+                builder.append("\n  " + plugin.getName()).color(ChatColor.RED).event(hover)
+                    .append(" v" + version).color(ChatColor.DARK_RED)
+                    .append("").event((HoverEvent) null);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
Add the Java version to `/sf versions` and add some hover text to it if using a version lower than 11. I also added hover text to disabled plugins.

Image of full versions:
![image](https://user-images.githubusercontent.com/8492901/106485084-22704b00-64a8-11eb-8165-370d9d09d4db.png)

Image of Java hover text (Need suggestions on the text):
![image](https://user-images.githubusercontent.com/8492901/106485132-3156fd80-64a8-11eb-8d69-0a703fc17eb4.png)

Image of disabled plugin hover text:
![image](https://user-images.githubusercontent.com/8492901/106485167-3ae06580-64a8-11eb-9546-ebd27bc001da.png)


## Changes
* Added "Java" to `/sf versions`
* Redone the `/sf versions` message to be a TextComponent
* Added hover text for the Java field
* Added hover text for any disabled plugins

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
