### PR TITLE
Fix broken enchant plugins stalling plugin start

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -6,6 +6,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.settings.TalismanEnchan
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -40,12 +41,17 @@ public class MagicianTalisman extends Talisman {
         addItemSetting(allowEnchantmentBooks);
 
         for (Enchantment enchantment : Enchantment.values()) {
-            try {
-                for (int i = 1; i <= enchantment.getMaxLevel(); i++) {
-                    enchantments.add(new TalismanEnchantment(enchantment, i));
+            // Stop custom enchant plugins appearing
+            // We also want to stop some stupid plugins which register as Minecraft enchants
+            // but also go above the max enchant level.
+            if (enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT) && enchantment.getMaxLevel() < Short.MAX_VALUE) {
+                try {
+                    for (int i = 1; i <= enchantment.getMaxLevel(); i++) {
+                        enchantments.add(new TalismanEnchantment(enchantment, i));
+                    }
+                } catch (Exception x) {
+                    SlimefunPlugin.logger().log(Level.SEVERE, x, () -> "The following Exception occurred while trying to register the following Enchantment: " + enchantment);
                 }
-            } catch (Exception x) {
-                SlimefunPlugin.logger().log(Level.SEVERE, x, () -> "The following Exception occurred while trying to register the following Enchantment: " + enchantment);
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -124,7 +124,7 @@ public class MagicianTalisman extends Talisman {
         if (enchantment.getMaxLevel() > Short.MAX_VALUE) {
             // Enchantment levels are shorts, even if Bukkit allows integers.
             return false;
-        } else if (!SlimefunPlugin.getCfg().getBoolean("allow-custom-enchants") {
+        } else if (!SlimefunPlugin.getCfg().getBoolean("allow-custom-enchants")) {
             // Only allow Enchantments from the "minecraft:" namespace.
             return enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT);
         } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -41,9 +41,11 @@ public class MagicianTalisman extends Talisman {
         addItemSetting(allowEnchantmentBooks);
 
         for (Enchantment enchantment : Enchantment.values()) {
-            // Stop custom enchant plugins appearing
-            // We also want to stop some stupid plugins which register as Minecraft enchants
-            // but also go above the max enchant level.
+            /* 
+            * Stop custom enchant plugins appearing
+            * We also want to stop some stupid plugins which register as Minecraft enchants
+            * but also go above the max enchant level.
+            */
             if (enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT) && enchantment.getMaxLevel() < Short.MAX_VALUE) {
                 try {
                     for (int i = 1; i <= enchantment.getMaxLevel(); i++) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 public class MagicianTalisman extends Talisman {
 
     private final ItemSetting<Boolean> allowEnchantmentBooks = new ItemSetting<>("allow-enchantment-books", false);
-    private final ItemSetting<Boolean> allowCustomEnchantments = new ItemSetting<>("allow-custom-enchants", false);
 
     private final Set<TalismanEnchantment> enchantments = new HashSet<>();
 
@@ -39,7 +38,7 @@ public class MagicianTalisman extends Talisman {
     public MagicianTalisman(SlimefunItemStack item, ItemStack[] recipe) {
         super(item, recipe, false, false, "magician", 80);
 
-        addItemSetting(allowEnchantmentBooks, allowCustomEnchantments);
+        addItemSetting(allowEnchantmentBooks);
 
         for (Enchantment enchantment : Enchantment.values()) {
             /* 
@@ -47,7 +46,9 @@ public class MagicianTalisman extends Talisman {
              * We also want to stop some stupid plugins which register as Minecraft enchants
              * but also go above the max enchant level.
              */
-            if ((allowCustomEnchantments.getValue() || enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT))) {
+            if ((SlimefunPlugin.getCfg().getBoolean("allow-custom-enchants")
+                || enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT))
+            ) {
                 try {
                     // Make sure we cap this at max level or if set it incorrectly, use Short.MAX_VALUE
                     for (int i = 1; i <= Math.min(enchantment.getMaxLevel(), Short.MAX_VALUE); i++) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -50,7 +50,7 @@ public class MagicianTalisman extends Talisman {
             if ((allowCustomEnchantments.getValue() || enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT))) {
                 try {
                     // Make sure we cap this at max level or if set it incorrectly, use Short.MAX_VALUE
-                    for (int i = 1; i <= Math.max(enchantment.getMaxLevel(), Short.MAX_VALUE); i++) {
+                    for (int i = 1; i <= Math.min(enchantment.getMaxLevel(), Short.MAX_VALUE); i++) {
                         enchantments.add(new TalismanEnchantment(enchantment, i));
                     }
                 } catch (Exception x) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -115,6 +115,9 @@ public class MagicianTalisman extends Talisman {
      * This method checks if a given {@link Enchantment} is valid
      * or whether an enchantment was set up incorrectly.
      *
+     * @param enchantment
+     *            The enchantment to validate
+     *
      * @return Whether this enchantment is valid or not
      */
     protected boolean isValidEnchantment(@Nonnull Enchantment enchantment) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 public class MagicianTalisman extends Talisman {
 
     private final ItemSetting<Boolean> allowEnchantmentBooks = new ItemSetting<>("allow-enchantment-books", false);
-
     private final Set<TalismanEnchantment> enchantments = new HashSet<>();
 
     @ParametersAreNonnullByDefault
@@ -46,12 +45,10 @@ public class MagicianTalisman extends Talisman {
              * We also want to stop some stupid plugins which register as Minecraft enchants
              * but also go above the max enchant level.
              */
-            if ((SlimefunPlugin.getCfg().getBoolean("allow-custom-enchants")
-                || enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT))
-            ) {
+            if (isValidEnchantment(enchantment)) {
                 try {
                     // Make sure we cap this at max level or if set it incorrectly, use Short.MAX_VALUE
-                    for (int i = 1; i <= Math.min(enchantment.getMaxLevel(), Short.MAX_VALUE); i++) {
+                    for (int i = 1; i <= enchantment.getMaxLevel(); i++) {
                         enchantments.add(new TalismanEnchantment(enchantment, i));
                     }
                 } catch (Exception x) {
@@ -112,5 +109,24 @@ public class MagicianTalisman extends Talisman {
      */
     public boolean isEnchantmentBookAllowed() {
         return allowEnchantmentBooks.getValue();
+    }
+
+    /**
+     * This method checks if a given {@link Enchantment} is valid
+     * or whether an enchantment was set up incorrectly.
+     *
+     * @return Whether this enchantment is valid or not
+     */
+    protected boolean isValidEnchantment(@Nonnull Enchantment enchantment) {
+        if (enchantment.getMaxLevel() > Short.MAX_VALUE) {
+            // Enchantment levels are shorts, even if Bukkit allows integers.
+            return false;
+        } else if (!SlimefunPlugin.getCfg().getBoolean("allow-custom-enchants") {
+            // Only allow Enchantments from the "minecraft:" namespace.
+            return enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT);
+        } else {
+            // Custom Enchantments are allowed
+            return true;
+        }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -39,7 +39,7 @@ public class MagicianTalisman extends Talisman {
     public MagicianTalisman(SlimefunItemStack item, ItemStack[] recipe) {
         super(item, recipe, false, false, "magician", 80);
 
-        addItemSetting(allowEnchantmentBooks);
+        addItemSetting(allowEnchantmentBooks, allowCustomEnchantments);
 
         for (Enchantment enchantment : Enchantment.values()) {
             /* 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 public class MagicianTalisman extends Talisman {
 
     private final ItemSetting<Boolean> allowEnchantmentBooks = new ItemSetting<>("allow-enchantment-books", false);
+    private final ItemSetting<Boolean> allowCustomEnchantments = new ItemSetting<>("allow-custom-enchants", false);
 
     private final Set<TalismanEnchantment> enchantments = new HashSet<>();
 
@@ -42,13 +43,14 @@ public class MagicianTalisman extends Talisman {
 
         for (Enchantment enchantment : Enchantment.values()) {
             /* 
-            * Stop custom enchant plugins appearing
-            * We also want to stop some stupid plugins which register as Minecraft enchants
-            * but also go above the max enchant level.
-            */
-            if (enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT) && enchantment.getMaxLevel() < Short.MAX_VALUE) {
+             * Stop custom enchant plugins appearing
+             * We also want to stop some stupid plugins which register as Minecraft enchants
+             * but also go above the max enchant level.
+             */
+            if ((allowCustomEnchantments.getValue() || enchantment.getKey().getNamespace().equals(NamespacedKey.MINECRAFT))) {
                 try {
-                    for (int i = 1; i <= enchantment.getMaxLevel(); i++) {
+                    // Make sure we cap this at max level or if set it incorrectly, use Short.MAX_VALUE
+                    for (int i = 1; i <= Math.max(enchantment.getMaxLevel(), Short.MAX_VALUE); i++) {
                         enchantments.add(new TalismanEnchantment(enchantment, i));
                     }
                 } catch (Exception x) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/settings/TalismanEnchantment.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/settings/TalismanEnchantment.java
@@ -2,6 +2,8 @@ package io.github.thebusybiscuit.slimefun4.implementation.settings;
 
 import javax.annotation.Nonnull;
 
+import java.util.Objects;
+
 import org.bukkit.enchantments.Enchantment;
 
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
@@ -46,4 +48,20 @@ public class TalismanEnchantment extends ItemSetting<Boolean> {
         return level;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(enchantment.getKey(), level);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof TalismanEnchantment) {
+            TalismanEnchantment instance = (TalismanEnchantment) obj;
+
+            return instance.getEnchantment().getKey().equals(this.enchantment.getKey())
+                && instance.getLevel() == this.level;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,6 +40,7 @@ networks:
 
 talismans:
   use-actionbar: true
+  allow-custom-enchants: false
 
 metrics:
   auto-update: true


### PR DESCRIPTION
## Description
There have been a few reports of servers locking up after `loadItems()` is called. Today I managed to get one of the person's servers and reproduce the issue. Thanks to `Cahsew#8395` for providing his server.

Custom enchantments... *sigh* there was a plugin (Enchantments+-) which was adding enchants which were: 1. Prefixed with `minecraft:` in their namespace... and 2: Above the MC max enchant value

This plugin was basically creating about 12 enchants all from what I can tell using Integer.MAX_VALUE as the max level. This means creating 14,400,000,000 item settings.... yeah, this caused issues...
So, this removes custom enchants in general showing up (which is good) and also fixes really stupid ones using an above Short.MAX_VALUE max level.

## Changes
* Fix broken custom enchant plugins freezing up the server.

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
