### PR TITLE
Fix duplicating woods when unable to replant

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
@@ -159,6 +159,7 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
             } else {
                 // Simply drop the sapling if the soil does not fit
                 block.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(saplingType));
+                block.setType(Material.AIR);
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Fixed wood cutter is able to duplicate wood when unable to replant.

## Changes
<!-- Please list all the changes you have made. -->

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
