### PR TITLE
Fixes #2677

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -296,7 +296,7 @@ public final class SlimefunUtils {
             return false;
         } else if (itemMeta instanceof PotionMeta && sfitemMeta instanceof PotionMeta) {
             return ((PotionMeta) itemMeta).getBasePotionData().equals(((PotionMeta) sfitemMeta).getBasePotionData());
-        }else if (!checkLore) {
+        } else if (!checkLore) {
             return true;
         } else if (itemMeta.hasLore() && sfitemMeta.hasLore()) {
             return equalsLore(itemMeta.getLore(), sfitemMeta.getLore());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -295,7 +295,7 @@ public final class SlimefunUtils {
         } else if (itemMeta.hasDisplayName() && sfitemMeta.hasDisplayName() && !itemMeta.getDisplayName().equals(sfitemMeta.getDisplayName())) {
             return false;
         } else if (itemMeta instanceof PotionMeta && sfitemMeta instanceof PotionMeta) {
-            return ((PotionMeta) itemMeta).getBasePotionData().equals(((PotionMeta) sfitemMeta).getBasePotionData());
+            return ((PotionMeta) itemMeta).getBasePotionData().hashCode() == ((PotionMeta) sfitemMeta).getBasePotionData().hashCode();
         } else if (!checkLore) {
             return true;
         } else if (itemMeta.hasLore() && sfitemMeta.hasLore()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -19,6 +19,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
@@ -293,7 +294,9 @@ public final class SlimefunUtils {
             return false;
         } else if (itemMeta.hasDisplayName() && sfitemMeta.hasDisplayName() && !itemMeta.getDisplayName().equals(sfitemMeta.getDisplayName())) {
             return false;
-        } else if (!checkLore) {
+        } else if (itemMeta instanceof PotionMeta && sfitemMeta instanceof PotionMeta) {
+            return ((PotionMeta) itemMeta).getBasePotionData().equals(((PotionMeta) sfitemMeta).getBasePotionData());
+        }else if (!checkLore) {
             return true;
         } else if (itemMeta.hasLore() && sfitemMeta.hasLore()) {
             return equalsLore(itemMeta.getLore(), sfitemMeta.getLore());


### PR DESCRIPTION
## Description
Fixes #2677 

## Changes
Added judgment on potion for SlimefunUtils#isItemSimilar()

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
