### PR TITLE
Added ExplosiveToolBreakBlockEvent 

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This {@link Event} is called when a {@link Block} is destroyed by an {@link ExplosiveTool}.
@@ -25,11 +25,11 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
 
     private final ItemStack tool;
     private final ExplosiveTool explosiveTool;
-    private final ArrayList<Block> blocks;
+    private final List<Block> blocks;
     private boolean cancelled;
 
     @ParametersAreNonnullByDefault
-    public ExplosiveToolBreakBlockEvent(Player player, ArrayList<Block> blocks, ItemStack item, ExplosiveTool explosiveTool) {
+    public ExplosiveToolBreakBlockEvent(Player player, List<Block> blocks, ItemStack item, ExplosiveTool explosiveTool) {
         super(player);
         this.blocks = blocks;
         this.tool = item;
@@ -38,16 +38,14 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
 
     /**
      * Gets the {@link Block} ArrayList of blocks destroyed in the event
-     *
      */
     @Nonnull
-    public ArrayList<Block> getBlocks() {
+    public List<Block> getBlocks() {
         return this.blocks;
     }
 
     /**
      * Gets the {@link ExplosiveTool} which triggered this event
-     *
      */
     @Nonnull
     public ExplosiveTool getExplosiveTool() {
@@ -56,14 +54,11 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
 
     /**
      * Gets the {@link ItemStack} of the tool used to destroy this block
-     *
      */
     @Nonnull
     public ItemStack getTool() {
         return this.tool;
     }
-
-
 
     @Override
     public boolean isCancelled() {
@@ -72,7 +67,7 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
 
     @Override
     public void setCancelled(boolean b) {
-        this.cancelled = true;
+        this.cancelled = b;
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
 
 /**
  * This {@link Event} is called when a {@link Block} is destroyed by an {@link ExplosiveTool}.
@@ -23,13 +24,13 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
     private static final HandlerList handlers = new HandlerList();
 
     private final ItemStack tool;
-    private final Block block;
+    private final ArrayList<Block> blocks;
     private boolean cancelled;
 
     @ParametersAreNonnullByDefault
-    public ExplosiveToolBreakBlockEvent(Player player, Block block, ItemStack item) {
+    public ExplosiveToolBreakBlockEvent(Player player, ArrayList<Block> blocks, ItemStack item) {
         super(player);
-        this.block = block;
+        this.blocks = blocks;
         this.tool = item;
     }
 
@@ -43,12 +44,12 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
     }
 
     /**
-     * Gets the {@link Block} destroyed in the event
+     * Gets the {@link Block} ArrayList of blocks destroyed in the event
      *
      */
     @Nonnull
-    public Block getBlock() {
-        return this.block;
+    public ArrayList<Block> getBlocks() {
+        return this.blocks;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
@@ -1,0 +1,74 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.tools.ExplosiveTool;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * This {@link Event} is called when a {@link Block} is destroyed by an {@link ExplosiveTool}.
+ *
+ * @author GallowsDove
+ *
+ */
+public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final ItemStack tool;
+    private final Block block;
+    private boolean cancelled;
+
+    @ParametersAreNonnullByDefault
+    public ExplosiveToolBreakBlockEvent(Player player, Block block, ItemStack item) {
+        super(player);
+        this.block = block;
+        this.tool = item;
+    }
+
+    /**
+     * Gets the {@link ItemStack} of the tool used to destroy this block
+     *
+     */
+    @Nonnull
+    public ItemStack getTool() {
+        return this.tool;
+    }
+
+    /**
+     * Gets the {@link Block} destroyed in the event
+     *
+     */
+    @Nonnull
+    public Block getBlock() {
+        return this.block;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = true;
+    }
+
+    @Nonnull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlockEvent.java
@@ -24,14 +24,34 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
     private static final HandlerList handlers = new HandlerList();
 
     private final ItemStack tool;
+    private final ExplosiveTool explosiveTool;
     private final ArrayList<Block> blocks;
     private boolean cancelled;
 
     @ParametersAreNonnullByDefault
-    public ExplosiveToolBreakBlockEvent(Player player, ArrayList<Block> blocks, ItemStack item) {
+    public ExplosiveToolBreakBlockEvent(Player player, ArrayList<Block> blocks, ItemStack item, ExplosiveTool explosiveTool) {
         super(player);
         this.blocks = blocks;
         this.tool = item;
+        this.explosiveTool = explosiveTool;
+    }
+
+    /**
+     * Gets the {@link Block} ArrayList of blocks destroyed in the event
+     *
+     */
+    @Nonnull
+    public ArrayList<Block> getBlocks() {
+        return this.blocks;
+    }
+
+    /**
+     * Gets the {@link ExplosiveTool} which triggered this event
+     *
+     */
+    @Nonnull
+    public ExplosiveTool getExplosiveTool() {
+        return this.explosiveTool;
     }
 
     /**
@@ -43,14 +63,7 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
         return this.tool;
     }
 
-    /**
-     * Gets the {@link Block} ArrayList of blocks destroyed in the event
-     *
-     */
-    @Nonnull
-    public ArrayList<Block> getBlocks() {
-        return this.blocks;
-    }
+
 
     @Override
     public boolean isCancelled() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlocksEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlocksEvent.java
@@ -1,6 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.tools.ExplosiveTool;
+import org.apache.commons.lang.Validate;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -19,20 +20,25 @@ import java.util.List;
  * @author GallowsDove
  *
  */
-public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancellable {
+public class ExplosiveToolBreakBlocksEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
 
-    private final ItemStack tool;
+    private final ItemStack itemInHand;
     private final ExplosiveTool explosiveTool;
     private final List<Block> blocks;
     private boolean cancelled;
 
     @ParametersAreNonnullByDefault
-    public ExplosiveToolBreakBlockEvent(Player player, List<Block> blocks, ItemStack item, ExplosiveTool explosiveTool) {
+    public ExplosiveToolBreakBlocksEvent(Player player, List<Block> blocks, ItemStack item, ExplosiveTool explosiveTool) {
         super(player);
+
+        Validate.notNull(blocks, "Blocks cannot be null");
+        Validate.notNull(item, "Item cannot be null");
+        Validate.notNull(explosiveTool, "ExplosiveTool cannot be null");
+
         this.blocks = blocks;
-        this.tool = item;
+        this.itemInHand = item;
         this.explosiveTool = explosiveTool;
     }
 
@@ -56,8 +62,8 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
      * Gets the {@link ItemStack} of the tool used to destroy this block
      */
     @Nonnull
-    public ItemStack getTool() {
-        return this.tool;
+    public ItemStack getItemInHand() {
+        return this.itemInHand;
     }
 
     @Override
@@ -66,8 +72,8 @@ public class ExplosiveToolBreakBlockEvent extends PlayerEvent implements Cancell
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        this.cancelled = b;
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -94,7 +94,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, blocksToDestroy, item, this);
         Bukkit.getServer().getPluginManager().callEvent(event);
 
-        if (!event.isCancelled()){
+        if (!event.isCancelled()) {
             for (Block block : blocksToDestroy) {
                 breakBlock(p, item, block, drops);
            }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.events.ExplosiveToolBreakBlockEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.ExplosiveToolBreakBlocksEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -91,7 +91,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             }
         }
 
-        ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, blocksToDestroy, item, this);
+        ExplosiveToolBreakBlocksEvent event = new ExplosiveToolBreakBlocksEvent(p, blocksToDestroy, item, this);
         Bukkit.getServer().getPluginManager().callEvent(event);
 
         if (!event.isCancelled()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -70,7 +70,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
 
     @ParametersAreNonnullByDefault
     private void breakBlocks(Player p, ItemStack item, Block b, List<Block> blocks, List<ItemStack> drops) {
-        ArrayList<Block> blocksToDestroy = new ArrayList<>();
+        List<Block> blocksToDestroy = new ArrayList<>();
 
         if (callExplosionEvent.getValue().booleanValue()) {
             BlockExplodeEvent blockExplodeEvent = new BlockExplodeEvent(b, blocks, 0);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -91,7 +91,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             }
         }
 
-        ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, blocksToDestroy, item);
+        ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, blocksToDestroy, item, this);
         Bukkit.getServer().getPluginManager().callEvent(event);
 
         if (!event.isCancelled()){

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -3,8 +3,10 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.events.ExplosiveToolBreakBlockEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -39,7 +41,7 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * @see ExplosiveShovel
  *
  */
-class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements NotPlaceable, DamageableItem {
+public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements NotPlaceable, DamageableItem {
 
     private final ItemSetting<Boolean> damageOnUse = new ItemSetting<>("damage-on-use", true);
     private final ItemSetting<Boolean> callExplosionEvent = new ItemSetting<>("call-explosion-event", false);
@@ -51,6 +53,7 @@ class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements NotPla
         addItemSetting(damageOnUse, callExplosionEvent);
     }
 
+    @Nonnull
     @Override
     public ToolUseHandler getItemHandler() {
         return (e, tool, fortune, drops) -> {
@@ -74,14 +77,24 @@ class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements NotPla
             if (!blockExplodeEvent.isCancelled()) {
                 for (Block block : blockExplodeEvent.blockList()) {
                     if (canBreak(p, block)) {
-                        breakBlock(p, item, block, drops);
+                        ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, block, item);
+                        Bukkit.getServer().getPluginManager().callEvent(event);
+
+                        if (!event.isCancelled()) {
+                            breakBlock(p, item, block, drops);
+                        }
                     }
                 }
             }
         } else {
             for (Block block : blocks) {
                 if (canBreak(p, block)) {
-                    breakBlock(p, item, block, drops);
+                    ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, block, item);
+                    Bukkit.getServer().getPluginManager().callEvent(event);
+
+                    if (!event.isCancelled()) {
+                        breakBlock(p, item, block, drops);
+                    }
                 }
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -70,6 +70,8 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
 
     @ParametersAreNonnullByDefault
     private void breakBlocks(Player p, ItemStack item, Block b, List<Block> blocks, List<ItemStack> drops) {
+        ArrayList<Block> blocksToDestroy = new ArrayList<>();
+
         if (callExplosionEvent.getValue().booleanValue()) {
             BlockExplodeEvent blockExplodeEvent = new BlockExplodeEvent(b, blocks, 0);
             Bukkit.getServer().getPluginManager().callEvent(blockExplodeEvent);
@@ -77,26 +79,25 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             if (!blockExplodeEvent.isCancelled()) {
                 for (Block block : blockExplodeEvent.blockList()) {
                     if (canBreak(p, block)) {
-                        ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, block, item);
-                        Bukkit.getServer().getPluginManager().callEvent(event);
-
-                        if (!event.isCancelled()) {
-                            breakBlock(p, item, block, drops);
-                        }
+                        blocksToDestroy.add(block);
                     }
                 }
             }
         } else {
             for (Block block : blocks) {
                 if (canBreak(p, block)) {
-                    ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, block, item);
-                    Bukkit.getServer().getPluginManager().callEvent(event);
-
-                    if (!event.isCancelled()) {
-                        breakBlock(p, item, block, drops);
-                    }
+                    blocksToDestroy.add(block);
                 }
             }
+        }
+
+        ExplosiveToolBreakBlockEvent event = new ExplosiveToolBreakBlockEvent(p, blocksToDestroy, item);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+
+        if (!event.isCancelled()){
+            for (Block block : blocksToDestroy) {
+                breakBlock(p, item, block, drops);
+           }
         }
     }
 


### PR DESCRIPTION
## Description
Added ExplosiveToolBreakBlockEvent triggered by an explosive tool breaking a block.
I need it for my addon, as it can currently break blocks without me having any event to catch.

## Changes
Added ExplosiveToolBreakBlockEvent, made it Cancellable and edited ExplosiveTool to reflect that

## Related Issues
null

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
