### PR TITLE
Fix addon blockmenu loading with custom worlds

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -93,7 +93,6 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.SoulboundList
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.TalismanListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.VampireBladeListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.VillagerTradingListener;
-import io.github.thebusybiscuit.slimefun4.implementation.listeners.WorldListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.AnvilListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.BrewingStandListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.CartographyTableListener;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -667,9 +667,6 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         // Handle Slimefun Guide being given on Join
         new SlimefunGuideListener(this, config.getBoolean("guide.receive-on-first-join"));
 
-        // Load/Unload Worlds in Slimefun
-        new WorldListener(this);
-
         // Clear the Slimefun Guide History upon Player Leaving
         new PlayerProfileListener(this);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/SlimefunStartupTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/SlimefunStartupTask.java
@@ -58,7 +58,7 @@ public class SlimefunStartupTask implements Runnable {
             }
         }
         
-        // Load/Unload Worlds, only after all plugins have started up.
+        // Load/Unload Worlds, only after all plugins have started up. Fixes #2862
         new WorldListener(this.plugin);
 
         // Only load this Listener if the corresponding items are enabled

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/SlimefunStartupTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/SlimefunStartupTask.java
@@ -4,6 +4,7 @@ import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.WorldListener;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 
@@ -56,6 +57,9 @@ public class SlimefunStartupTask implements Runnable {
                 SlimefunPlugin.logger().log(Level.SEVERE, x, () -> "An Error occurred while trying to load World \"" + world.getName() + "\" for Slimefun v" + SlimefunPlugin.getVersion());
             }
         }
+        
+        // Load/Unload Worlds, only after all plugins have started up.
+        new WorldListener(this.plugin);
 
         // Only load this Listener if the corresponding items are enabled
         if (isEnabled("ELEVATOR_PLATE", "GPS_ACTIVATION_DEVICE_SHARED", "GPS_ACTIVATION_DEVICE_PERSONAL")) {


### PR DESCRIPTION
## Description
When custom worlds were loaded before a certain addon had been loaded, the BlockMenuPresets for the stored inventories couldn't be found, so the block had no inventory. When the listener is registered after all addons load, it allows all the presets to be loaded before inventories are. The BlockStorages for the worlds are still created because Slimefun is already iterating through all of the default ones during the startup task.

## Changes
Moved WorldListener creation from registerListeners to SlimefunStartupTask

## Related Issues
Resolves #2862 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
