### PR TITLE
Allow onBlockBreak to be cancelled by BlockBreakHandler

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -169,6 +169,9 @@ public class BlockListener implements Listener {
                 }
             } else {
                 sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(e, item, drops));
+                if (e.isCancelled()) {
+                    return;
+                }
             }
 
             drops.addAll(sfItem.getDrops());


### PR DESCRIPTION
## Description
Added a check for if the BlockBreakHandler was cancelled and returned accordingly. This prevents Slimefun block data from being cleared when the BlockBreakEvent gets cancelled within the handler.

## Changes
Modified BlockListener.java to return if the BlockBreakEvent is cancelled.

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
