### PR TITLE
Show generating in debug fish

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/DebugFishListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/DebugFishListener.java
@@ -155,6 +155,12 @@ public class DebugFishListener implements Listener {
             } else {
                 p.sendMessage(ChatColors.color("&dChargeable: " + redCross));
             }
+
+            if (item instanceof EnergyNetProvider) {
+                EnergyNetProvider provider = (EnergyNetProvider) item;
+
+                p.sendMessage(ChatColors.color("  &dGenerating: &e" + provider.getGeneratedOutput(b.getLocation(), BlockStorage.getLocationInfo(b.getLocation()))));
+            }
         }
 
         p.sendMessage(ChatColors.color("&6" + BlockStorage.getBlockInfoAsJson(b)));


### PR DESCRIPTION
## Description
There's no real way to see how much some things are generating, some addons obviously have a GUI for this but for the most part there isn't one. This is a quick and easy way for staff to verify the generator is producing what is expected.

Now, there are a few points to mention:
* Obviously this wont always be the same value - this does often change depending on circumstances
  * For me, this makes sense and it's what I would want this to show. But, do we add any disclaimer/info about this?
* This is per SF tick, do we add a `/t` into this? Maybe could do a in brackets seconds one too. For example: `Generating: 2/t (3.6/s)`
  * If we did add a per second, should it be correct (so, use configured ticks) or not? For normal SF items I can see bug reports from this being correct. "The lore says 4/s but it's doing 3.6/s"

I believe this is a good, informational change however there due to the weirdness around this area it could cause problems. Is it a net positive or a net negative?

## Changes
Added a new message from the debug fish listener which shows how much it is generating

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
