### PR TITLE
Fixed 2650

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Fixed #2903
 * Fixed #2913
 * Fixed #2914
+* Fixed #2650
 
 ## Release Candidate 21 (14 Mar 2021)
 https://thebusybiscuit.github.io/builds/TheBusyBiscuit/Slimefun4/stable/#21

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
@@ -41,7 +41,7 @@ public class SoulboundListener implements Listener {
         for (int slot = 0; slot < p.getInventory().getSize(); slot++) {
             ItemStack item = p.getInventory().getItem(slot);
 
-            // Store soulbound items for later rtrieval
+            // Store soulbound items for later retrieval
             if (SlimefunUtils.isSoulbound(item, p.getWorld())) {
                 items.put(slot, item);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
@@ -1,7 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 
@@ -42,8 +41,8 @@ public class SoulboundListener implements Listener {
         for (int slot = 0; slot < p.getInventory().getSize(); slot++) {
             ItemStack item = p.getInventory().getItem(slot);
 
-            // Store soulbound items for later retrieval
-            if (SlimefunUtils.isSoulbound(item)) {
+            // Store soulbound items for later rtrieval
+            if (SlimefunUtils.isSoulbound(item, p.getWorld())) {
                 items.put(slot, item);
             }
         }
@@ -58,14 +57,7 @@ public class SoulboundListener implements Listener {
         }
 
         // Remove soulbound items from our drops
-        Iterator<ItemStack> drops = e.getDrops().iterator();
-        while (drops.hasNext()) {
-            ItemStack item = drops.next();
-
-            if (SlimefunUtils.isSoulbound(item)) {
-                drops.remove();
-            }
-        }
+        e.getDrops().removeIf(itemStack -> SlimefunUtils.isSoulbound(itemStack, p.getWorld()));
     }
 
     @EventHandler

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -14,6 +14,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -79,15 +80,29 @@ public final class SlimefunUtils {
 
     /**
      * This method checks whether the given {@link ItemStack} is considered {@link Soulbound}.
-     * 
+     *
      * @param item
      *            The {@link ItemStack} to check for
      * @return Whether the given item is soulbound
      */
     public static boolean isSoulbound(@Nullable ItemStack item) {
-        if (item == null || item.getType() == Material.AIR) {
-            return false;
-        } else {
+        return isSoulbound(item, null);
+    }
+
+    /**
+     * This method checks whether the given {@link ItemStack} is considered {@link Soulbound}.
+     * If the provided item is a {@link SlimefunItem} then this method will also check that the item
+     * is enabled in the provided {@link World}.
+     *
+     * @param item
+     *              The {@link ItemStack} to check for
+     * @param world
+     *              The {@link World} to check if the {@link SlimefunItem} is enabled in if applicable.
+     *              If {@code null} then this will not do a world check.
+     * @return Whether the given item is soulbound
+     */
+    public static boolean isSoulbound(@Nullable ItemStack item, @Nullable World world) {
+        if (item != null && item.getType() != Material.AIR) {
             ItemMeta meta = item.hasItemMeta() ? item.getItemMeta() : null;
 
             if (hasSoulboundFlag(meta)) {
@@ -97,13 +112,17 @@ public final class SlimefunUtils {
             SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
             if (sfItem instanceof Soulbound) {
-                return !sfItem.isDisabled();
+                if (world != null) {
+                    return !sfItem.isDisabled() && !sfItem.isDisabledIn(world);
+                } else {
+                    return !sfItem.isDisabled();
+                }
             } else if (meta != null) {
                 return meta.hasLore() && meta.getLore().contains(SOULBOUND_LORE);
             }
 
-            return false;
         }
+        return false;
     }
 
     private static boolean hasSoulboundFlag(@Nullable ItemMeta meta) {
@@ -111,9 +130,7 @@ public final class SlimefunUtils {
             PersistentDataContainer container = meta.getPersistentDataContainer();
             NamespacedKey key = SlimefunPlugin.getRegistry().getSoulboundDataKey();
 
-            if (container.has(key, PersistentDataType.BYTE)) {
-                return true;
-            }
+            return container.has(key, PersistentDataType.BYTE);
         }
 
         return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -113,7 +113,7 @@ public final class SlimefunUtils {
 
             if (sfItem instanceof Soulbound) {
                 if (world != null) {
-                    return !sfItem.isDisabled() && !sfItem.isDisabledIn(world);
+                    return !sfItem.isDisabledIn(world);
                 } else {
                     return !sfItem.isDisabled();
                 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestSoulboundListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestSoulboundListener.java
@@ -1,17 +1,16 @@
 package io.github.thebusybiscuit.slimefun4.testing.tests.listeners;
 
-import be.seeseemelk.mockbukkit.WorldMock;
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.SoulboundItem;
 import io.github.thebusybiscuit.slimefun4.testing.TestUtilities;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -42,6 +41,7 @@ class TestSoulboundListener {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
+    @DisplayName("Test if the soulbound item is dropped or not")
     void testItemDrop(boolean soulbound) {
         PlayerMock player = server.addPlayer();
         ItemStack item = new CustomItem(Material.DIAMOND_SWORD, "&4Cool Sword");
@@ -56,6 +56,7 @@ class TestSoulboundListener {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
+    @DisplayName("Test if soulbound item is dropped if disabled")
     void testItemDropIfItemDisabled(boolean enabled) {
         PlayerMock player = server.addPlayer();
 
@@ -79,6 +80,7 @@ class TestSoulboundListener {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
+    @DisplayName("Test if soulbound item is returned to player")
     void testItemRecover(boolean soulbound) {
         PlayerMock player = server.addPlayer();
         ItemStack item = new CustomItem(Material.DIAMOND_SWORD, "&4Cool Sword");

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestSoulboundListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestSoulboundListener.java
@@ -58,14 +58,13 @@ class TestSoulboundListener {
     @ValueSource(booleans = { true, false })
     void testItemDropIfItemDisabled(boolean enabled) {
         PlayerMock player = server.addPlayer();
-        World world = new WorldMock(Material.DIRT, 3);
 
         SlimefunItemStack item = new SlimefunItemStack("SOULBOUND_ITEM_" + (enabled ? "ENABLED" : "DISABLED"), Material.DIAMOND_SWORD, "&5Soulbound Sword");
         SoulboundItem soulboundItem = new SoulboundItem(TestUtilities.getCategory(plugin, "soulbound"), item, RecipeType.NULL, new ItemStack[9]);
         soulboundItem.register(plugin);
 
         if (!enabled) {
-            SlimefunPlugin.getWorldSettingsService().setEnabled(world, soulboundItem, false);
+            SlimefunPlugin.getWorldSettingsService().setEnabled(player.getWorld(), soulboundItem, false);
         }
 
         player.getInventory().setItem(0, item);


### PR DESCRIPTION
## Description
I thought this was a pretty good and simple fix, I have made another method in SlimefunUtils for isSoulbound which accepts a world. If the item is a SF Item and it has been disabled in that world then soulbound returns false. The same as if it was disabled in general.

Added a unit test to cover this case as well.

## Changes
* SlimefunUtils.isSoulbound(ItemStack, World)
* SlimefunUtils.isSoulbound(ItemStack) now calls isSoulbound(ItemStack, null)

## Related Issues
Resolves #2650

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
