### PR TITLE
Fixes #2942

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * Fixed Grappling Hook vanishing in creative mode
 * Fixed #2944
 * Fixed #2837
+* Fixed #2942
 
 ## Release Candidate 21 (14 Mar 2021)
 https://thebusybiscuit.github.io/builds/TheBusyBiscuit/Slimefun4/stable/#21

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
@@ -143,14 +143,16 @@ public class LocalizationService extends SlimefunLocalization {
         return plugin.getClass().getResource("/languages/" + file + ".yml") != null;
     }
 
+    @Nonnull
     @Override
     public Language getDefaultLanguage() {
         return defaultLanguage;
     }
 
+    @Nonnull
     @Override
     public Language getLanguage(@Nonnull Player p) {
-        Validate.notNull("Player cannot be null!");
+        Validate.notNull(p, "Player cannot be null!");
 
         PersistentDataContainer container = p.getPersistentDataContainer();
         String language = container.get(languageKey, PersistentDataType.STRING);
@@ -253,7 +255,7 @@ public class LocalizationService extends SlimefunLocalization {
     }
 
     @Nonnull
-    private Set<String> getKeys(FileConfiguration... files) {
+    private Set<String> getKeys(@Nonnull FileConfiguration... files) {
         Set<String> keys = new HashSet<>();
 
         for (FileConfiguration cfg : files) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
@@ -143,13 +143,11 @@ public class LocalizationService extends SlimefunLocalization {
         return plugin.getClass().getResource("/languages/" + file + ".yml") != null;
     }
 
-    @Nonnull
     @Override
     public Language getDefaultLanguage() {
         return defaultLanguage;
     }
 
-    @Nonnull
     @Override
     public Language getLanguage(@Nonnull Player p) {
         Validate.notNull(p, "Player cannot be null!");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/Language.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/Language.java
@@ -160,8 +160,7 @@ public final class Language {
      */
     @Nonnull
     public String getName(@Nonnull Player p) {
-        String name = SlimefunPlugin.getLocalization().getMessage(p, "languages." + id);
-        return name != null ? name : toString();
+        return SlimefunPlugin.getLocalization().getMessage(p, "languages." + id);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -67,7 +67,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
      *
      * @return The {@link Language} that was selected by the given {@link Player}
      */
-    @Nonnull
+    @Nullable
     public abstract Language getLanguage(@Nonnull Player p);
 
     /**
@@ -75,7 +75,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
      *
      * @return The default {@link Language}
      */
-    @Nonnull
+    @Nullable
     public abstract Language getDefaultLanguage();
 
     /**
@@ -128,7 +128,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
 
         Language language = getDefaultLanguage();
 
-        String message = language.getMessagesFile().getString(key);
+        String message = language == null ? null : language.getMessagesFile().getString(key);
 
         if (message == null) {
             Language fallback = getLanguage(SupportedLanguage.ENGLISH.getLanguageId());
@@ -200,7 +200,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
 
         Language language = getLanguage(p);
 
-        if (language.getResearchesFile() == null) {
+        if (language == null || language.getResearchesFile() == null) {
             return null;
         }
 
@@ -214,7 +214,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
 
         Language language = getLanguage(p);
 
-        if (language.getCategoriesFile() == null) {
+        if (language == null || language.getCategoriesFile() == null) {
             return null;
         }
 
@@ -228,7 +228,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
 
         Language language = getLanguage(p);
 
-        String value = language.getResourcesFile() != null ? language.getResourcesFile().getString(key) : null;
+        String value = language != null && language.getResourcesFile() != null ? language.getResourcesFile().getString(key) : null;
 
         if (value != null) {
             return value;
@@ -247,11 +247,11 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
         ItemStack item = recipeType.toItem();
         NamespacedKey key = recipeType.getKey();
 
-        if (language.getRecipeTypesFile() == null || !language.getRecipeTypesFile().contains(key.getNamespace() + "." + key.getKey())) {
+        if (language == null || language.getRecipeTypesFile() == null || !language.getRecipeTypesFile().contains(key.getNamespace() + '.' + key.getKey())) {
             language = getLanguage("en");
         }
 
-        if (!language.getRecipeTypesFile().contains(key.getNamespace() + "." + key.getKey())) {
+        if (!language.getRecipeTypesFile().contains(key.getNamespace() + '.' + key.getKey())) {
             return item;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -284,6 +284,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
 
     public void sendActionbarMessage(@Nonnull Player player, @Nonnull String key, boolean addPrefix) {
         Validate.notNull(player, "Player cannot be null!");
+        Validate.notNull(key, "Message key cannot be null!");
 
         String prefix = addPrefix ? getPrefix() : "";
         String message = ChatColors.color(prefix + getMessage(player, key));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -1,13 +1,15 @@
 package io.github.thebusybiscuit.slimefun4.core.services.localization;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
@@ -33,9 +35,9 @@ import net.md_5.bungee.api.chat.TextComponent;
 /**
  * This is an abstract parent class of {@link LocalizationService}.
  * There is not really much more I can say besides that...
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see LocalizationService
  *
  */
@@ -48,10 +50,10 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     /**
      * This method attempts to return the {@link Language} with the given
      * language code.
-     * 
+     *
      * @param id
      *            The language code
-     * 
+     *
      * @return A {@link Language} with the given id or null
      */
     @Nullable
@@ -59,28 +61,30 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
 
     /**
      * This method returns the currently selected {@link Language} of a {@link Player}.
-     * 
+     *
      * @param p
      *            The {@link Player} to query
-     * 
+     *
      * @return The {@link Language} that was selected by the given {@link Player}
      */
+    @Nonnull
     public abstract Language getLanguage(@Nonnull Player p);
 
     /**
      * This method returns the default {@link Language} of this {@link Server}
-     * 
+     *
      * @return The default {@link Language}
      */
+    @Nonnull
     public abstract Language getDefaultLanguage();
 
     /**
      * This returns whether a {@link Language} with the given id exists within
      * the project resources.
-     * 
+     *
      * @param id
      *            The {@link Language} id
-     * 
+     *
      * @return Whether the project contains a {@link Language} with that id
      */
     protected abstract boolean hasLanguage(@Nonnull String id);
@@ -88,7 +92,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     /**
      * This method returns a full {@link Collection} of every {@link Language} that was
      * found.
-     * 
+     *
      * @return A {@link Collection} that contains every installed {@link Language}
      */
     @Nonnull
@@ -96,7 +100,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
 
     /**
      * This method adds a new {@link Language} with the given id and texture.
-     * 
+     *
      * @param id
      *            The {@link Language} id
      * @param texture
@@ -117,7 +121,28 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
         }
     }
 
-    public String getMessage(Player p, String key) {
+    @Nonnull
+    @Override
+    public String getMessage(@Nonnull String key) {
+        Validate.notNull(key, "Message key cannot be null!");
+
+        Language language = getDefaultLanguage();
+
+        String message = language.getMessagesFile().getString(key);
+
+        if (message == null) {
+            Language fallback = getLanguage(SupportedLanguage.ENGLISH.getLanguageId());
+            return fallback.getMessagesFile().getString(key);
+        }
+
+        return message;
+    }
+
+    @Nonnull
+    public String getMessage(@Nonnull Player p, @Nonnull String key) {
+        Validate.notNull(p, "Player cannot be null!");
+        Validate.notNull(key, "Message key cannot be null!");
+
         Language language = getLanguage(p);
 
         if (language == null) {
@@ -134,11 +159,15 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
         return message;
     }
 
-    public List<String> getMessages(Player p, String key) {
+    @Nonnull
+    public List<String> getMessages(@Nonnull Player p, @Nonnull String key) {
+        Validate.notNull(p, "Player cannot be null!");
+        Validate.notNull(key, "Message key cannot be null!");
+
         Language language = getLanguage(p);
 
         if (language == null) {
-            return Arrays.asList("NO LANGUAGE FOUND");
+            return Collections.singletonList("NO LANGUAGE FOUND");
         }
 
         List<String> messages = language.getMessagesFile().getStringList(key);
@@ -151,34 +180,52 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
         return messages;
     }
 
+    @Nonnull
+    @ParametersAreNonnullByDefault
     public List<String> getMessages(Player p, String key, UnaryOperator<String> function) {
+        Validate.notNull(p, "Player cannot be null!");
+        Validate.notNull(key, "Message key cannot be null!");
+        Validate.notNull(function, "Function cannot be null!");
+
         List<String> messages = getMessages(p, key);
         messages.replaceAll(function);
 
         return messages;
     }
 
-    public String getResearchName(Player p, NamespacedKey key) {
+    @Nullable
+    public String getResearchName(@Nonnull Player p, @Nonnull NamespacedKey key) {
+        Validate.notNull(p, "Player cannot be null!");
+        Validate.notNull(key, "NamespacedKey cannot be null!");
+
         Language language = getLanguage(p);
 
         if (language.getResearchesFile() == null) {
             return null;
         }
 
-        return language.getResearchesFile().getString(key.getNamespace() + "." + key.getKey());
+        return language.getResearchesFile().getString(key.getNamespace() + '.' + key.getKey());
     }
 
-    public String getCategoryName(Player p, NamespacedKey key) {
+    @Nullable
+    public String getCategoryName(@Nonnull Player p, @Nonnull NamespacedKey key) {
+        Validate.notNull(p, "Player cannot be null!");
+        Validate.notNull(key, "NamespacedKey cannot be null!");
+
         Language language = getLanguage(p);
 
         if (language.getCategoriesFile() == null) {
             return null;
         }
 
-        return language.getCategoriesFile().getString(key.getNamespace() + "." + key.getKey());
+        return language.getCategoriesFile().getString(key.getNamespace() + '.' + key.getKey());
     }
 
-    public String getResourceString(Player p, String key) {
+    @Nonnull
+    public String getResourceString(@Nonnull Player p, @Nonnull String key) {
+        Validate.notNull(p, "Player cannot be null!");
+        Validate.notNull(key, "Message key cannot be null!");
+
         Language language = getLanguage(p);
 
         String value = language.getResourcesFile() != null ? language.getResourcesFile().getString(key) : null;
@@ -191,7 +238,11 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
         }
     }
 
-    public ItemStack getRecipeTypeItem(Player p, RecipeType recipeType) {
+    @Nonnull
+    public ItemStack getRecipeTypeItem(@Nonnull Player p, @Nonnull RecipeType recipeType) {
+        Validate.notNull(p, "Player cannot be null!");
+        Validate.notNull(recipeType, "Recipe type cannot be null!");
+
         Language language = getLanguage(p);
         ItemStack item = recipeType.toItem();
         NamespacedKey key = recipeType.getKey();
@@ -218,7 +269,10 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     }
 
     @Override
-    public void sendMessage(CommandSender recipient, String key, boolean addPrefix) {
+    public void sendMessage(@Nonnull CommandSender recipient, @Nonnull String key, boolean addPrefix) {
+        Validate.notNull(recipient, "Recipient cannot be null!");
+        Validate.notNull(key, "Message key cannot be null!");
+
         String prefix = addPrefix ? getPrefix() : "";
 
         if (recipient instanceof Player) {
@@ -229,6 +283,8 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     }
 
     public void sendActionbarMessage(@Nonnull Player player, @Nonnull String key, boolean addPrefix) {
+        Validate.notNull(player, "Player cannot be null!");
+
         String prefix = addPrefix ? getPrefix() : "";
         String message = ChatColors.color(prefix + getMessage(player, key));
 
@@ -237,15 +293,17 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     }
 
     @Override
-    public void sendMessage(CommandSender recipient, String key) {
+    public void sendMessage(@Nonnull CommandSender recipient, @Nonnull String key) {
         sendMessage(recipient, key, true);
     }
 
+    @ParametersAreNonnullByDefault
     public void sendMessage(CommandSender recipient, String key, UnaryOperator<String> function) {
         sendMessage(recipient, key, true, function);
     }
 
     @Override
+    @ParametersAreNonnullByDefault
     public void sendMessage(CommandSender recipient, String key, boolean addPrefix, UnaryOperator<String> function) {
         if (SlimefunPlugin.getMinecraftVersion() == MinecraftVersion.UNIT_TEST) {
             return;
@@ -261,7 +319,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     }
 
     @Override
-    public void sendMessages(CommandSender recipient, String key) {
+    public void sendMessages(@Nonnull CommandSender recipient, @Nonnull String key) {
         String prefix = getPrefix();
 
         if (recipient instanceof Player) {
@@ -278,6 +336,7 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
     }
 
     @Override
+    @ParametersAreNonnullByDefault
     public void sendMessages(CommandSender recipient, String key, boolean addPrefix, UnaryOperator<String> function) {
         String prefix = addPrefix ? getPrefix() : "";
 
@@ -294,8 +353,8 @@ public abstract class SlimefunLocalization extends Localization implements Keyed
         }
     }
 
+    @ParametersAreNonnullByDefault
     public void sendMessages(CommandSender recipient, String key, UnaryOperator<String> function) {
         sendMessages(recipient, key, true, function);
     }
-
 }


### PR DESCRIPTION
## Description
In the case of calling `Localization#getMessage(String)` there was no override in SlimefunLocalization meaning that no fallback was done.

Also fixed an issue with an invalid validation (https://github.com/Slimefun/Slimefun4/pull/2956/files#diff-b74eb692f379f300a12715d1a757f82e7aaeaa379276b8b528a5e78543a298beR155). Added some extra validates too.

## Changes
* Fixes #2942 
* Fixed incorrect Validate
* Added more Validates

## Related Issues
Resolves #2942 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
