### PR TITLE
Add Block of Coal -> Carbon recipe to the Carbon Press and Compressor

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CarbonPress.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CarbonPress.java
@@ -24,6 +24,7 @@ public class CarbonPress extends AContainer implements RecipeDisplayItem {
     protected void registerDefaultRecipes() {
         registerRecipe(15, new ItemStack[] { new ItemStack(Material.CHARCOAL, 4) }, new ItemStack[] { new ItemStack(Material.COAL) });
         registerRecipe(20, new ItemStack[] { new ItemStack(Material.COAL, 8) }, new ItemStack[] { SlimefunItems.CARBON });
+        registerRecipe(180, new ItemStack[] { new ItemStack(Material.COAL_BLOCK, 8) }, new ItemStack[] { new SlimefunItemStack(SlimefunItems.CARBON, 9) });
         registerRecipe(30, new ItemStack[] { new CustomItem(SlimefunItems.CARBON, 4) }, new ItemStack[] { SlimefunItems.COMPRESSED_CARBON });
         registerRecipe(60, new ItemStack[] { SlimefunItems.CARBON_CHUNK, SlimefunItems.SYNTHETIC_DIAMOND }, new ItemStack[] { SlimefunItems.RAW_CARBONADO });
         registerRecipe(60, new ItemStack[] { SlimefunItems.CARBON_CHUNK }, new ItemStack[] { SlimefunItems.SYNTHETIC_DIAMOND });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -36,6 +36,9 @@ public class Compressor extends MultiBlockMachine {
 
         recipes.add(new ItemStack(Material.FLINT, 8));
         recipes.add(new ItemStack(Material.COBBLESTONE));
+
+        recipes.add(new ItemStack(Material.COAL_BLOCK, 8));
+        recipes.add(new SlimefunItemStack(SlimefunItems.CARBON, 9));
     }
 
     @Override


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Compressor and Carbon Press now accept 8 coal blocks and use those to craft 9 carbon. This is useful when moving and processing large amounts of coal.
Carbon Press coal block recipe gives no processing speed or product amount advantage over using the standard coal one. (9x slower, 9 carbon).

## Changes
<!-- Please list all the changes you have made. -->

- Added recipe to the Compressor multiblock
- Added recipe to the CarbonPress machine

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
none, Discord suggestion 915

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
