### PR TITLE
Fixes #2977

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -53,7 +53,7 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
 
             // Check if the item is enchantable
             if (!isEnchantable(item)) {
-                return null;
+                continue;
             }
 
             // Call an event so other Plugins can modify it.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -79,13 +79,11 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
     protected MachineRecipe enchant(BlockMenu menu, ItemStack target, ItemStack enchantedBook) {
         EnchantmentStorageMeta meta = (EnchantmentStorageMeta) enchantedBook.getItemMeta();
         Map<Enchantment, Integer> enchantments = new HashMap<>();
-        int amount = 0;
 
         // Find applicable enchantments
         for (Map.Entry<Enchantment, Integer> entry : meta.getStoredEnchants().entrySet()) {
             if (entry.getKey().canEnchantItem(target)) {
                 if (isEnchantmentLevelAllowed(entry.getValue())) {
-                    amount++;
                     enchantments.put(entry.getKey(), entry.getValue());
                 } else if (!menu.toInventory().getViewers().isEmpty()) {
                     showEnchantmentLevelWarning(menu);
@@ -95,15 +93,12 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
         }
 
         // Check if we found any valid enchantments
-        if (amount > 0) {
+        if (!enchantments.isEmpty()) {
             ItemStack enchantedItem = target.clone();
             enchantedItem.setAmount(1);
+            enchantedItem.addUnsafeEnchantments(enchantments);
 
-            for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
-                enchantedItem.addUnsafeEnchantment(entry.getKey(), entry.getValue());
-            }
-
-            MachineRecipe recipe = new MachineRecipe(75 * amount / this.getSpeed(), new ItemStack[] { target, enchantedBook }, new ItemStack[] { enchantedItem, new ItemStack(Material.BOOK) });
+            MachineRecipe recipe = new MachineRecipe(75 * enchantments.size() / getSpeed(), new ItemStack[] { target, enchantedBook }, new ItemStack[] { enchantedItem, new ItemStack(Material.BOOK) });
 
             if (!InvUtils.fitAll(menu.toInventory(), recipe.getOutput(), getOutputSlots())) {
                 return null;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Auto Enchanter now considers both combinations of enchanted book and item (item in first or second slot).

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
The machine now tries to check if the second combination could possibly be valid instead of exiting immediately as before.
Uses `addUnsafeEnchantments` instead of `addUnsafeEnchantment` to skip the loop over map entries.
Uses `isEmpty` and `map.size()` instead of a separate amount variable.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #2977 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
