### PR TITLE
Fixes NPE when hand is empty while talisman of the anvil triggers

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -196,8 +196,8 @@ public class TalismanListener implements Listener {
             PlayerInventory inv = e.getPlayer().getInventory();
             int slot = inv.getHeldItemSlot();
 
-            // Did the tool in our hand broke or was it an Armorpiece?
-            if (!inv.getItem(inv.getHeldItemSlot()).equals(e.getBrokenItem())) {
+            // Did the tool in our hand break or was it an armor piece?
+            if (!e.getBrokenItem().equals(inv.getItemInMainHand())) {
                 for (int s : armorSlots) {
                     if (e.getBrokenItem().equals(inv.getItem(s))) {
                         slot = s;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Talisman of the anvil throws NPE if the select hand slot is empty.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Switch the order of checking for equality as the broken item is always not null.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #2987 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
