### PR TITLE
Wood Cutter Android fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -706,10 +706,9 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                     BlockStorage.addBlockInfo(b, "index", String.valueOf(0));
                     break;
                 case CHOP_TREE:
-                    // We only move to the next step if we finished chopping wood
-                    if (chopTree(b, inv, face)) {
-                        BlockStorage.addBlockInfo(b, "index", String.valueOf(index));
-                    }
+                    // Move to the next step and try to chop the tree
+                    BlockStorage.addBlockInfo(b, "index", String.valueOf(index));
+                    chopTree(b, inv, face);
                     break;
                 default:
                     // We set the index here in advance to fix moving android issues
@@ -894,7 +893,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         throw new UnsupportedOperationException("Non-mining Android tried to mine!");
     }
 
-    protected boolean chopTree(Block b, BlockMenu menu, BlockFace face) {
+    protected void chopTree(Block b, BlockMenu menu, BlockFace face) {
         throw new UnsupportedOperationException("Non-woodcutter Android tried to chop a Tree!");
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -893,7 +893,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         throw new UnsupportedOperationException("Non-mining Android tried to mine!");
     }
 
-    protected void chopTree(Block b, BlockMenu menu, BlockFace face) {
+    protected boolean chopTree(Block b, BlockMenu menu, BlockFace face) {
         throw new UnsupportedOperationException("Non-woodcutter Android tried to chop a Tree!");
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
@@ -41,7 +41,7 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
     }
 
     @Override
-    protected boolean chopTree(Block b, BlockMenu menu, BlockFace face) {
+    protected void chopTree(Block b, BlockMenu menu, BlockFace face) {
         Block target = b.getRelative(face);
 
         if (Tag.LOGS.isTagged(target.getType())) {
@@ -55,12 +55,8 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
                 if (SlimefunPlugin.getProtectionManager().hasPermission(owner, log.getLocation(), ProtectableAction.BREAK_BLOCK)) {
                     breakLog(log, b, menu, face);
                 }
-
-                return false;
             }
         }
-
-        return true;
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
@@ -41,7 +41,7 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
     }
 
     @Override
-    protected void chopTree(Block b, BlockMenu menu, BlockFace face) {
+    protected boolean chopTree(Block b, BlockMenu menu, BlockFace face) {
         Block target = b.getRelative(face);
 
         if (Tag.LOGS.isTagged(target.getType())) {
@@ -57,6 +57,8 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
                 }
             }
         }
+        
+        return true;
     }
 
     @ParametersAreNonnullByDefault


### PR DESCRIPTION
## Description
The wood cutter android won't stop at the chopTree instruction forever, it will keep looping.

## Proposed changes
Changed WoodcutterAndroid#chopTree to return void

## Related Issues (if applicable)
Fixes #2964 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
