### PR TITLE
Main Menu Page History Fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.core.guide;
 
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -28,6 +29,7 @@ public class GuideHistory {
 
     private final PlayerProfile profile;
     private final Deque<GuideEntry<?>> queue = new LinkedList<>();
+    private int mainMenuPage = 1;
 
     /**
      * This creates a new {@link GuideHistory} for the given {@link PlayerProfile}
@@ -45,6 +47,27 @@ public class GuideHistory {
      */
     public void clear() {
         queue.clear();
+    }
+
+    /**
+     * This method sets the page of the main menu of this {@link GuideHistory}
+     * 
+     * @param page
+     *            The current page of the main menu that should be stored
+     */
+    public void setMainMenuPage(int page) {
+        Validate.isTrue(page >= 1, "page must be greater than 0!");
+        
+        mainMenuPage = page;
+    }
+
+    /**
+     * This returns the current main menu page of this {@link GuideHistory}
+     * 
+     * @return The main menu page of this {@link GuideHistory}
+     */
+    public int getMainMenuPage() {
+        return mainMenuPage;
     }
 
     /**
@@ -165,7 +188,7 @@ public class GuideHistory {
 
     private <T> void open(@Nonnull SlimefunGuideImplementation guide, @Nullable GuideEntry<T> entry) {
         if (entry == null) {
-            guide.openMainMenu(profile, 1);
+            guide.openMainMenu(profile, mainMenuPage);
         } else if (entry.getIndexedObject() instanceof Category) {
             guide.openCategory(profile, (Category) entry.getIndexedObject(), entry.getPage());
         } else if (entry.getIndexedObject() instanceof SlimefunItem) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -2,7 +2,6 @@ package io.github.thebusybiscuit.slimefun4.core.guide;
 
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -146,6 +146,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         if (isSurvivalMode()) {
             profile.getGuideHistory().clear();
         }
+        profile.getGuideHistory().setMainMenuPage(page);
 
         ChestMenu menu = create(p);
         List<Category> categories = getVisibleCategories(p, profile);
@@ -602,7 +603,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
             menu.addMenuClickHandler(slot, (pl, s, is, action) -> {
                 if (action.isShiftClicked()) {
-                    openMainMenu(profile, 1);
+                    openMainMenu(profile, profile.getGuideHistory().getMainMenuPage());
                 } else {
                     history.goBack(this);
                 }
@@ -612,7 +613,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         } else {
             menu.addItem(slot, new CustomItem(ChestMenuUtils.getBackButton(p, "", ChatColor.GRAY + SlimefunPlugin.getLocalization().getMessage(p, "guide.back.guide"))));
             menu.addMenuClickHandler(slot, (pl, s, is, action) -> {
-                openMainMenu(profile, 1);
+                openMainMenu(profile, profile.getGuideHistory().getMainMenuPage());
                 return false;
             });
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -145,8 +145,8 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
         if (isSurvivalMode()) {
             profile.getGuideHistory().clear();
+            profile.getGuideHistory().setMainMenuPage(page);
         }
-        profile.getGuideHistory().setMainMenuPage(page);
 
         ChestMenu menu = create(p);
         List<Category> categories = getVisibleCategories(p, profile);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -144,8 +144,9 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         }
 
         if (isSurvivalMode()) {
-            profile.getGuideHistory().clear();
-            profile.getGuideHistory().setMainMenuPage(page);
+            GuideHistory history = profile.getGuideHistory();
+            history.clear();
+            history.setMainMenuPage(page);
         }
 
         ChestMenu menu = create(p);


### PR DESCRIPTION
## Description
Keeps the main menu page history saved

## Proposed changes
Added a main menu page field to GuideHistory, added getters and setters. When the guide is opened, it sets the main menu page to the page it was opened to.

## Related Issues (if applicable)
Fixes #2593

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
