### PR TITLE
Fix android click handler errors while moving

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -243,7 +243,11 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
         menu.addItem(0, new CustomItem(Instruction.START.getItem(), SlimefunPlugin.getLocalization().getMessage(p, "android.scripts.instructions.START"), "", "&7\u21E8 &eLeft Click &7to return to the Android's interface"));
         menu.addMenuClickHandler(0, (pl, slot, item, action) -> {
-            BlockStorage.getInventory(b).open(pl);
+            BlockMenu inv = BlockStorage.getInventory(b);
+            // Fixes #2937
+            if (inv != null) {
+                inv.open(pl);
+            }
             return false;
         });
 
@@ -266,7 +270,11 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                 int slot = i + (hasFreeSlot ? 1 : 0);
                 menu.addItem(slot, new CustomItem(Instruction.REPEAT.getItem(), SlimefunPlugin.getLocalization().getMessage(p, "android.scripts.instructions.REPEAT"), "", "&7\u21E8 &eLeft Click &7to return to the Android's interface"));
                 menu.addMenuClickHandler(slot, (pl, s, item, action) -> {
-                    BlockStorage.getInventory(b).open(pl);
+                    BlockMenu inv = BlockStorage.getInventory(b);
+                    // Fixes #2937
+                    if (inv != null) {
+                        inv.open(pl);
+                    }
                     return false;
                 });
             } else {
@@ -482,11 +490,15 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
         menu.addItem(1, new CustomItem(HeadTexture.SCRIPT_FORWARD.getAsItemStack(), "&2> Edit Script", "", "&aEdits your current Script"));
         menu.addMenuClickHandler(1, (pl, slot, item, action) -> {
-            if (PatternUtils.DASH.split(BlockStorage.getLocationInfo(b.getLocation()).getString("script")).length <= MAX_SCRIPT_LENGTH) {
-                openScript(pl, b, getScript(b.getLocation()));
-            } else {
-                pl.closeInventory();
-                SlimefunPlugin.getLocalization().sendMessage(pl, "android.scripts.too-long");
+            String script = BlockStorage.getLocationInfo(b.getLocation()).getString("script");
+            // Fixes #2937
+            if (script != null) {
+                if (PatternUtils.DASH.split(script).length <= MAX_SCRIPT_LENGTH) {
+                    openScript(pl, b, getScript(b.getLocation()));
+                } else {
+                    pl.closeInventory();
+                    SlimefunPlugin.getLocalization().sendMessage(pl, "android.scripts.too-long");
+                }
             }
             return false;
         });
@@ -505,7 +517,11 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
         menu.addItem(8, new CustomItem(HeadTexture.SCRIPT_LEFT.getAsItemStack(), "&6> Back", "", "&7Return to the Android's interface"));
         menu.addMenuClickHandler(8, (pl, slot, item, action) -> {
-            BlockStorage.getInventory(b).open(p);
+            BlockMenu inv = BlockStorage.getInventory(b);
+            // Fixes #2937
+            if (inv != null) {
+                inv.open(pl);
+            }
             return false;
         });
 
@@ -660,6 +676,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
         if ("false".equals(data.getString("paused"))) {
             BlockMenu menu = BlockStorage.getInventory(b);
+            
             String fuelData = data.getString("fuel");
             float fuel = fuelData == null ? 0 : Float.parseFloat(fuelData);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -681,7 +681,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
             // The Android was destroyed or moved.
             return;
         }
-        
+
         if ("false".equals(data.getString("paused"))) {
             BlockMenu menu = BlockStorage.getInventory(b);
             

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -247,6 +247,8 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
             // Fixes #2937
             if (inv != null) {
                 inv.open(pl);
+            } else {
+                pl.closeInventory();
             }
             return false;
         });
@@ -274,6 +276,8 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                     // Fixes #2937
                     if (inv != null) {
                         inv.open(pl);
+                    } else {
+                        pl.closeInventory();
                     }
                     return false;
                 });
@@ -499,6 +503,8 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                     pl.closeInventory();
                     SlimefunPlugin.getLocalization().sendMessage(pl, "android.scripts.too-long");
                 }
+            } else {
+                pl.closeInventory();
             }
             return false;
         });
@@ -521,6 +527,8 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
             // Fixes #2937
             if (inv != null) {
                 inv.open(pl);
+            } else {
+                pl.closeInventory();
             }
             return false;
         });
@@ -673,7 +681,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
             // The Android was destroyed or moved.
             return;
         }
-
+        
         if ("false".equals(data.getString("paused"))) {
             BlockMenu menu = BlockStorage.getInventory(b);
             


### PR DESCRIPTION
## Description
title

## Proposed changes
Added null checks when getting the block menu for the android block

## Related Issues (if applicable)
Fixes #2937

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
