### PR TITLE
Make energy net use long

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -226,7 +226,7 @@ public class EnergyNet extends Network implements HologramOwner {
                         loc.getBlock().setType(Material.LAVA);
                         loc.getWorld().createExplosion(loc, 0F, false);
                     });
-                } else {
+                } else if (supply != MAX_ENERGY) {
                     supply += provider.getGeneratedOutput(loc, data);
 
                     if (provider.isChargeable()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -131,9 +131,9 @@ public class EnergyNet extends Network implements HologramOwner {
         if (connectorNodes.isEmpty() && terminusNodes.isEmpty()) {
             updateHologram(b, "&4No Energy Network found");
         } else {
-            int supply = tickAllGenerators(timestamp::getAndAdd) + tickAllCapacitors();
-            int remainingEnergy = supply;
-            int demand = 0;
+            long supply = tickAllGenerators(timestamp::getAndAdd) + tickAllCapacitors();
+            long remainingEnergy = supply;
+            long demand = 0;
 
             for (Map.Entry<Location, EnergyNetComponent> entry : consumers.entrySet()) {
                 Location loc = entry.getKey();
@@ -150,7 +150,7 @@ public class EnergyNet extends Network implements HologramOwner {
                             component.setCharge(loc, capacity);
                             remainingEnergy -= availableSpace;
                         } else {
-                            component.setCharge(loc, charge + remainingEnergy);
+                            component.setCharge(loc, (int) (charge + remainingEnergy));
                             remainingEnergy = 0;
                         }
                     }
@@ -165,7 +165,7 @@ public class EnergyNet extends Network implements HologramOwner {
         SlimefunPlugin.getProfiler().closeEntry(b.getLocation(), SlimefunItems.ENERGY_REGULATOR.getItem(), timestamp.get());
     }
 
-    private void storeRemainingEnergy(int remainingEnergy) {
+    private void storeRemainingEnergy(long remainingEnergy) {
         for (Map.Entry<Location, EnergyNetComponent> entry : capacitors.entrySet()) {
             Location loc = entry.getKey();
             EnergyNetComponent component = entry.getValue();
@@ -177,7 +177,7 @@ public class EnergyNet extends Network implements HologramOwner {
                     component.setCharge(loc, capacity);
                     remainingEnergy -= capacity;
                 } else {
-                    component.setCharge(loc, remainingEnergy);
+                    component.setCharge(loc, (int) remainingEnergy);
                     remainingEnergy = 0;
                 }
             } else {
@@ -195,7 +195,7 @@ public class EnergyNet extends Network implements HologramOwner {
                     component.setCharge(loc, capacity);
                     remainingEnergy -= capacity;
                 } else {
-                    component.setCharge(loc, remainingEnergy);
+                    component.setCharge(loc, (int) remainingEnergy);
                     remainingEnergy = 0;
                 }
             } else {
@@ -204,9 +204,9 @@ public class EnergyNet extends Network implements HologramOwner {
         }
     }
 
-    private int tickAllGenerators(@Nonnull LongConsumer timings) {
+    private long tickAllGenerators(@Nonnull LongConsumer timings) {
         Set<Location> explodedBlocks = new HashSet<>();
-        int supply = 0;
+        long supply = 0;
 
         for (Map.Entry<Location, EnergyNetProvider> entry : generators.entrySet()) {
             long timestamp = SlimefunPlugin.getProfiler().newEntry();
@@ -250,8 +250,8 @@ public class EnergyNet extends Network implements HologramOwner {
         return supply;
     }
 
-    private int tickAllCapacitors() {
-        int supply = 0;
+    private long tickAllCapacitors() {
+        long supply = 0;
 
         for (Map.Entry<Location, EnergyNetComponent> entry : capacitors.entrySet()) {
             supply += entry.getValue().getCharge(entry.getKey());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -44,6 +44,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 public class EnergyNet extends Network implements HologramOwner {
 
     private static final int RANGE = 6;
+    private static final long MAX_ENERGY = Long.MAX_VALUE;
 
     private final Map<Location, EnergyNetProvider> generators = new HashMap<>();
     private final Map<Location, EnergyNetComponent> capacitors = new HashMap<>();
@@ -216,11 +217,6 @@ public class EnergyNet extends Network implements HologramOwner {
 
             try {
                 Config data = BlockStorage.getLocationInfo(loc);
-                int energy = provider.getGeneratedOutput(loc, data);
-
-                if (provider.isChargeable()) {
-                    energy += provider.getCharge(loc, data);
-                }
 
                 if (provider.willExplode(loc, data)) {
                     explodedBlocks.add(loc);
@@ -231,7 +227,15 @@ public class EnergyNet extends Network implements HologramOwner {
                         loc.getWorld().createExplosion(loc, 0F, false);
                     });
                 } else {
-                    supply += energy;
+                    supply += provider.getGeneratedOutput(loc, data);
+
+                    if (provider.isChargeable()) {
+                        supply += provider.getCharge(loc, data);
+                    }
+                    
+                    if (supply < 0 || supply > MAX_ENERGY) {
+                        supply = MAX_ENERGY;
+                    }
                 }
             } catch (Exception | LinkageError throwable) {
                 explodedBlocks.add(loc);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -226,7 +226,7 @@ public class EnergyNet extends Network implements HologramOwner {
                         loc.getBlock().setType(Material.LAVA);
                         loc.getWorld().createExplosion(loc, 0F, false);
                     });
-                } else if (supply != MAX_ENERGY) {
+                } else {
                     supply += provider.getGeneratedOutput(loc, data);
 
                     if (provider.isChargeable()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -217,6 +217,8 @@ public class EnergyNet extends Network implements HologramOwner {
 
             try {
                 Config data = BlockStorage.getLocationInfo(loc);
+                
+                long generated = provider.getGeneratedOutput(loc, data);
 
                 if (provider.willExplode(loc, data)) {
                     explodedBlocks.add(loc);
@@ -227,7 +229,7 @@ public class EnergyNet extends Network implements HologramOwner {
                         loc.getWorld().createExplosion(loc, 0F, false);
                     });
                 } else {
-                    supply += provider.getGeneratedOutput(loc, data);
+                    supply += generated;
 
                     if (provider.isChargeable()) {
                         supply += provider.getCharge(loc, data);


### PR DESCRIPTION
## Description
This will allow energy networks to have a total production/capactity of more than 2.1 billion. Previously it would reset to 0 or go negative.

![image](https://user-images.githubusercontent.com/69326411/116341331-50fb7a80-a7a6-11eb-933c-e428f138faf3.png)

## Proposed changes
Changed a fews ints to longs

## Related Issues (if applicable)
x

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
