### PR TITLE
Add grinding of higher level lumps back into 4 lower level lumps

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -79,6 +79,18 @@ public class GrindStone extends MultiBlockMachine {
 
         recipes.add(new ItemStack(Material.QUARTZ_BLOCK));
         recipes.add(new ItemStack(Material.QUARTZ, 4));
+
+        recipes.add(SlimefunItems.MAGIC_LUMP_2);
+        recipes.add(new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 4));
+
+        recipes.add(SlimefunItems.MAGIC_LUMP_3);
+        recipes.add(new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_2, 4));
+
+        recipes.add(SlimefunItems.ENDER_LUMP_2);
+        recipes.add(new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 4));
+
+        recipes.add(SlimefunItems.ENDER_LUMP_3);
+        recipes.add(new SlimefunItemStack(SlimefunItems.ENDER_LUMP_2, 4));
     }
 
     @Override


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This change allows lumps to be stored more easily and also helps when too many certain lumps are crafted by mistake.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
4 new recipes in the GrindStone

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Discord suggestion 1183

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
