### PR TITLE
Fixed explosive tool handling for blocks with a BlockBreakHandler

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -156,7 +156,9 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
              */
             BlockBreakEvent dummyEvent = new BlockBreakEvent(b, e.getPlayer());
 
-            if (!sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops)) && !dummyEvent.isCancelled()) {
+            sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
+            
+            if (!dummyEvent.isCancelled()) {
                 drops.addAll(sfItem.getDrops(p));
                 b.setType(Material.AIR);
                 BlockStorage.clearBlockInfo(b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -156,6 +156,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
              */
             BlockBreakEvent dummyEvent = new BlockBreakEvent(b, e.getPlayer());
 
+            // Call the BlockBreakHandler if the block has it to allow for cancelling.
             sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
             
             if (!dummyEvent.isCancelled()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -156,9 +156,13 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
              */
             BlockBreakEvent dummyEvent = new BlockBreakEvent(b, e.getPlayer());
 
-            // Call the BlockBreakHandler if the block has it to allow for cancelling.
+            /*
+             * Fixes #3036 and handling in general.
+             * Call the BlockBreakHandler if the block has one to allow for proper handling.
+             */
             sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
             
+            // Make sure the event wasn't cancelled by the BlockBreakHandler.
             if (!dummyEvent.isCancelled()) {
                 drops.addAll(sfItem.getDrops(p));
                 b.setType(Material.AIR);


### PR DESCRIPTION
## Description
Previously, a slimefun block could only be destroyed by an explosive tool's blast radius if the item had no
BlockBreakHandler. Now, it will correctly break it as long as the handler doesn't cancel the dummy event, or if there is no handler.

## Proposed changes
Moved callItemHandler out of if statement

## Related Issues (if applicable)
Fixes #3036 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
