### PR TITLE
Change the way the TickerTask tracks Blocks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
@@ -121,10 +121,8 @@ final class TickerCollection {
     private static @Nonnull Set<Location> convertToLocation(@Nonnull World world, @Nonnull Collection<Long> raw) {
         Set<Location> locations = new HashSet<>(raw.size());
         for (long compressed : raw) {
-            int x = (int) (compressed >> 38);
-            int y = (int) (compressed & 0XFFF);
-            int z = (int) (compressed << 26 >> 38);
-            locations.add(new Location(world, x, y, z));
+            int[] decompressed = BlockPosition.decompress(compressed);
+            locations.add(new Location(world, decompressed[0], decompressed[1], decompressed[2]));
         }
         return locations;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
@@ -1,6 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.implementation.tasks;
 
-
 import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
@@ -49,17 +49,15 @@ final class TickerCollection {
         blocks.keySet().removeIf(uid -> Bukkit.getWorld(uid) == null);
         for (Map.Entry<UUID, Set<Long>> entry : blocks.entrySet()) {
             World world = Bukkit.getWorld(entry.getKey());
-            // assert world != null
-            Set<Location> converted = convertToLocation(world, entry.getValue());
-            locations.addAll(converted);
+            locations.addAll(convertToLocation(world, entry.getValue()));
         }
         return locations;
     }
 
     /**
-     * Add a location to this ticker collection, duplicates will be ignored.
+     * Add a {@link BlockPosition} to this ticker collection, duplicates will be ignored.
      *
-     * @param block The block to add
+     * @param block The {@link BlockPosition} to add
      * @see #addBlock(Location)
      */
     public void addBlock(@Nonnull BlockPosition block) {
@@ -67,9 +65,9 @@ final class TickerCollection {
     }
 
     /**
-     * Add a location to this ticker collection, duplicates will be ignored.
+     * Add a {@link Location} to this ticker collection, duplicates will be ignored.
      *
-     * @param location The location of the block to add
+     * @param location The {@link Location} of the block to add
      * @see #addBlock(BlockPosition)
      */
     public void addBlock(@Nonnull Location location) {
@@ -77,9 +75,9 @@ final class TickerCollection {
     }
 
     /**
-     * Remove a block from this ticker collection
+     * Remove a {@link BlockPosition} from this ticker collection. If the collection is empty after a successful removal then this will also remove the underline {@link Set} for this {@link World}.
      *
-     * @param block The block to remove
+     * @param block The {@link BlockPosition} to remove
      * @see #removeBlock(Location)
      */
     public void removeBlock(@Nonnull BlockPosition block) {
@@ -95,9 +93,9 @@ final class TickerCollection {
     }
 
     /**
-     * Remove a location from this ticker collection.
+     * Remove a {@link Location} from this ticker collection.
      *
-     * @param location The location of the block to remove
+     * @param location The {@link Location} of the block to remove
      * @see #removeBlock(BlockPosition)
      */
     public void removeBlock(@Nonnull Location location) {
@@ -106,7 +104,8 @@ final class TickerCollection {
 
     /**
      * Clear all the blocks for a given {@link World}
-     * @param key The world to clear the key for
+     *
+     * @param key The {@link World} to remove blocks from
      */
     public void clear(@Nonnull World key) {
         blocks.remove(key.getUID());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
@@ -40,7 +40,7 @@ final class TickerCollection {
 
     /**
      * Get a copy of all the blocks stored in the form of {@link BlockPosition BlockPositions}
-     * The returned {@link Set} is not guaranteed to be thread-safe.
+     * The returned {@link Set} is not thread-safe.
      *
      * @return Returns a {@link Set} of {@link BlockPosition BlockPositions}
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerCollection.java
@@ -7,6 +7,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -20,6 +21,7 @@ import java.util.WeakHashMap;
  *
  * @author md5sha256
  */
+@ThreadSafe
 final class TickerCollection {
 
     private final Cache<World, Set<Long>> blocks = CacheBuilder.newBuilder().weakKeys().build();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -70,7 +70,7 @@ public final class TickerTask {
     /**
      * This Map holds all currently actively ticking locations.
      */
-    private final TickingBlocks tickingBlocks = new TickingBlocks();
+    private final TickerCollection tickerCollection = new TickerCollection();
 
     /**
      * This Map tracks how many bugs have occurred in a given Location.
@@ -287,7 +287,7 @@ public final class TickerTask {
             }
 
             if (!halted) {
-                Collection<Location> toTick = tickingBlocks.getBlocksAsLocations();
+                Collection<Location> toTick = tickerCollection.getBlocksAsLocations();
                 tickLocations(tickers, toTick);
             }
 
@@ -489,7 +489,7 @@ public final class TickerTask {
         Validate.notNull(l, "Location cannot be null!");
         Validate.notNull(l.getWorld(), "Location must have a world!");
 
-        tickingBlocks.addBlock(l);
+        tickerCollection.addBlock(l);
     }
 
     /**
@@ -503,6 +503,6 @@ public final class TickerTask {
         Validate.notNull(l, "Location cannot be null!");
         Validate.notNull(l.getWorld(), "Location must have a world!");
 
-        tickingBlocks.removeBlock(l);
+        tickerCollection.removeBlock(l);
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -66,7 +66,6 @@ public final class TickerTask {
      */
     private static final long MAX_WAIT_TIME = 1_500_000L;
 
-
     /**
      * This Map holds all currently actively ticking locations.
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -99,11 +99,11 @@ public final class TickerTask {
 
 
     /**
-     *  These are "Queues" of blocks that need to be removed or moved.
-     *  <p>
-     *  Whilst the {@link ConcurrentHashMap} implementation is thread-safe,
-     *  the {@link Location Locations} are not. Therefore, the internal copy of the locations
-     *  should be treated as <strong>read only</strong> and never exposed externally.
+     * These are "Queues" of blocks that need to be removed or moved.
+     * <p>
+     * Whilst the {@link ConcurrentHashMap} implementation is thread-safe,
+     * the {@link Location Locations} are not. Therefore, the internal copy of the locations
+     * should be treated as <strong>read only</strong> and never exposed externally.
      */
     private final Map<Location, Location> movingQueue = new ConcurrentHashMap<>();
     private final Map<Location, Boolean> deletionQueue = new ConcurrentHashMap<>();
@@ -321,7 +321,7 @@ public final class TickerTask {
     }
 
     /**
-     * Executes all tasks in a given {@link Collection} of locations
+     * Executes all tasks in a given {@link Collection} of {@link Location locations}
      */
     private void tickLocations(Collection<BlockTicker> tickers, @Nonnull Collection<Location> locations) {
         for (Location l : locations) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -1,9 +1,28 @@
 package io.github.thebusybiscuit.slimefun4.implementation.tasks;
 
+import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
+import io.github.thebusybiscuit.cscorelib2.blocks.ChunkPosition;
+import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.block.Block;
+import org.bukkit.scheduler.BukkitScheduler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -19,27 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.apache.commons.lang.Validate;
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Server;
-import org.bukkit.block.Block;
-import org.bukkit.scheduler.BukkitScheduler;
-
-import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
-import io.github.thebusybiscuit.cscorelib2.blocks.ChunkPosition;
-import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
 
 /**
  * The {@link TickerTask} is responsible for ticking every {@link BlockTicker}, synchronous
@@ -75,10 +73,17 @@ public final class TickerTask {
      */
     private static final long MAX_WAIT_TIME = 1_500_000L;
 
+
+    /**
+     * Given that the values in tickingLocations are mutable, we should synchronize their
+     * access externally. This locks serves that purpose.
+     */
+    private final ReadWriteLock tickingLocationLock = new ReentrantReadWriteLock();
+
     /**
      * This Map holds all currently actively ticking locations.
      */
-    private final Map<ChunkPosition, Set<Location>> tickingLocations = new ConcurrentHashMap<>();
+    private final Map<ChunkPosition, Set<Location>> tickingLocations = new HashMap<>();
 
     /**
      * This Map tracks how many bugs have occurred in a given Location.
@@ -101,15 +106,11 @@ public final class TickerTask {
 
     /**
      * This is our {@link Thread} pool.
-     * Using an {@link ExecutorService} here instead of continously spawning a new {@link Thread}
+     * Using an {@link ExecutorService} here instead of continuously spawning a new {@link Thread}
      * will help performance.
      */
     private final ExecutorService asyncExecutor = Executors.newSingleThreadExecutor(threadFactory);
 
-    /**
-     * Making collections concurrent doesn't make their iterators thread safe.
-     */
-    private final ReadWriteLock queueLock = new ReentrantReadWriteLock();
 
     // These are "Queues" of blocks that need to be removed or moved
     private final Map<Location, Location> movingQueue = new ConcurrentHashMap<>();
@@ -282,38 +283,40 @@ public final class TickerTask {
             List<BlockTicker> tickers = new LinkedList<>();
 
             /*
-             * Iterators will throw ConcurrentModificationExceptions if something
-             * modifies the collection during iteration.
+             * Copy the queue, this way we don't have to update the queue after each deletion,
+             * reducing update contention.
              */
-            queueLock.writeLock().lock();
-            Map<Location, Boolean> deletionQueueCopy;
-            try {
-                // Copy the queue, this way we don't have keep the queue locked whilst removing
-                deletionQueueCopy = new HashMap<>(deletionQueue);
-                deletionQueue.clear();
-            } finally {
-                queueLock.writeLock().unlock();
-            }
+            Map<Location, Boolean> deletionQueueCopy = new HashMap<>(deletionQueue);
+            deletionQueue.clear();
 
             for (Map.Entry<Location, Boolean> entry : deletionQueueCopy.entrySet()) {
                 BlockStorage.deleteLocationInfoUnsafely(entry.getKey(), entry.getValue());
             }
 
             if (!halted) {
-                for (Map.Entry<ChunkPosition, Set<Location>> entry : tickingLocations.entrySet()) {
-                    tickChunk(entry.getKey(), tickers, entry.getValue());
+                /*
+                 * The Sets in tickingLocations aren't thread safe so we must synchronize externally.
+                 *
+                 * Implementation note: Since we are only acquiring the read lock,
+                 * care must be taken to ensure that TickerTask#tickChunk does not modify
+                 * the passed Set<Location> in any manner whatsoever.
+                 */
+                tickingLocationLock.readLock().lock();
+                try {
+                    for (Map.Entry<ChunkPosition, Set<Location>> entry : tickingLocations.entrySet()) {
+                        tickChunk(entry.getKey(), tickers, entry.getValue());
+                    }
+                } finally {
+                    tickingLocationLock.readLock().unlock();
                 }
             }
 
-            queueLock.writeLock().lock();
-            Map<Location, Location> moveCopy;
-            try {
-                // Copy the queue, this way we don't have keep the queue locked whilst moving
-                moveCopy = new HashMap<>(movingQueue);
-                movingQueue.clear();
-            } finally {
-                queueLock.writeLock().unlock();
-            }
+            /*
+             * Copy the queue, this way we don't have to update the queue after each deletion,
+             * reducing update contention.
+             */
+            Map<Location, Location> moveCopy = new HashMap<>(movingQueue);
+            movingQueue.clear();
 
             for (Map.Entry<Location, Location> entry : moveCopy.entrySet()) {
                 BlockStorage.moveLocationInfoUnsafely(entry.getKey(), entry.getValue());
@@ -338,6 +341,14 @@ public final class TickerTask {
         }
     }
 
+    /**
+     * Execute all tasks registered to a given {@link ChunkPosition}
+     *
+     * @implNote The {@link Collection} passed in <code>locations</code> must not be modified.
+     * Additionally, the {@link Location Locations} themselves should also be accessed in a read-only fashion
+     * as the caller is only guaranteed to have acquired a read lock on the passed {@link Collection}
+     * @see #processAsyncTasks()
+     */
     @ParametersAreNonnullByDefault
     private void tickChunk(ChunkPosition chunk, Collection<BlockTicker> tickers, Collection<Location> locations) {
         // Only continue if the Chunk is actually loaded
@@ -445,28 +456,14 @@ public final class TickerTask {
         Validate.notNull(from, "Source Location cannot be null!");
         Validate.notNull(to, "Target Location cannot be null!");
 
-        // This collection is iterated over in a different thread. Need to lock it.
-        queueLock.writeLock().lock();
-
-        try {
-            movingQueue.put(from, to);
-        } finally {
-            queueLock.writeLock().unlock();
-        }
+        movingQueue.put(from, to);
     }
 
     @ParametersAreNonnullByDefault
     public void queueDelete(Location l, boolean destroy) {
         Validate.notNull(l, "Location must not be null!");
 
-        // This collection is iterated over in a different thread. Need to lock it.
-        queueLock.writeLock().lock();
-
-        try {
-            deletionQueue.put(l, destroy);
-        } finally {
-            queueLock.writeLock().unlock();
-        }
+        deletionQueue.put(l, destroy);
     }
 
     /**
@@ -490,10 +487,10 @@ public final class TickerTask {
 
     /**
      * This method checks if a given {@link Location} will be deleted on the next tick.
-     * 
+     *
      * @param l
      *            The {@link Location} to check
-     * 
+     *
      * @return Whether this {@link Location} will be deleted on the next tick
      */
     public boolean isDeletedSoon(@Nonnull Location l) {
@@ -512,81 +509,155 @@ public final class TickerTask {
     }
 
     /**
-     * This method returns a <strong>read-only</strong> {@link Map}
+     * This method returns a deep cloned {@link Map}
      * representation of every {@link ChunkPosition} and its corresponding
      * {@link Set} of ticking {@link Location Locations}.
-     * 
-     * This does include any {@link Location} from an unloaded {@link Chunk} too!
-     * 
+     * <p>
+     * {@link Location Locations} from unloaded {@link Chunk Chunks} will also be present.
+     * </p>
+     * Note: this is a blocking method which may be expensive as values have to be cloned.
      * @return A {@link Map} representation of all ticking {@link Location Locations}
+     * <p>
+     * The returned {@link Map} should be treated as a snapshot. Modifications to the Map
+     * will <strong>not</strong> change the values held by this instance and vice versa.
+     * </p>
+     * @see #getLocations(Chunk)
      */
     @Nonnull
     public Map<ChunkPosition, Set<Location>> getLocations() {
-        return Collections.unmodifiableMap(tickingLocations);
+
+        /*
+         * Perform a deep clone of the Map.
+         * Since the stored values stored by the map are mutable and not thread-safe,
+         * we must perform a deep clone to prevent unsafe modification of the
+         * internal state.
+         */
+        tickingLocationLock.readLock().lock();
+        try {
+
+            /*
+             * Create a shallow copy of the map.
+             * We don't need to deep clone the keys -- ChunkPosition is immutable.
+             */
+            Map<ChunkPosition, Set<Location>> clone = new HashMap<>(tickingLocations);
+
+            for (Map.Entry<ChunkPosition, Set<Location>> entry : clone.entrySet()) {
+                /*
+                 * Perform a deep clone of the value for each entry
+                 * Since the stored Set and Location are mutable and not thread-safe,
+                 * we must perform a deep clone to prevent unsafe modification of the
+                 * internal state.
+                 */
+                Set<Location> original = entry.getValue();
+                Set<Location> cloned = new HashSet<>(original.size());
+                for (Location location : original) {
+                    cloned.add(location.clone());
+                }
+                entry.setValue(cloned);
+            }
+            return clone;
+        } finally {
+            tickingLocationLock.readLock().unlock();
+        }
     }
 
     /**
-     * This method returns a <strong>read-only</strong> {@link Set}
-     * of all ticking {@link Location Locations} in a given {@link Chunk}.
+     * This method returns a deep-cloned {@link Set} of all ticking
+     * {@link Location Locations} in a given {@link Chunk}.
+     * <p>
      * The {@link Chunk} does not have to be loaded.
+     * </p>
+     * <p>
      * If no {@link Location} is present, the returned {@link Set} will be empty.
-     * 
-     * @param chunk
-     *            The {@link Chunk}
-     * 
+     * </p>
+     * Note: this is a blocking method which may be expensive as values have to be cloned.
+     * @param chunk The {@link Chunk}
      * @return A {@link Set} of all ticking {@link Location Locations}
+     * <p>
+     * The returned {@link Set} should be treated as a snapshot. Modifications to the collection
+     * will <strong>not</strong> change the values held by this instance and vice versa.
+     * </p>
+     * @see #getLocations()
      */
     @Nonnull
     public Set<Location> getLocations(@Nonnull Chunk chunk) {
         Validate.notNull(chunk, "The Chunk cannot be null!");
 
-        Set<Location> locations = tickingLocations.getOrDefault(new ChunkPosition(chunk), new HashSet<>());
-        return Collections.unmodifiableSet(locations);
+        tickingLocationLock.readLock().lock();
+        try {
+            Set<Location> locations = tickingLocations.get(new ChunkPosition(chunk));
+            if (locations == null) {
+                return Collections.emptySet();
+            }
+            /*
+             * Perform a deep clone of the Set.
+             * Since the stored Set and Location are mutable and not thread-safe,
+             * we must perform a deep clone to prevent unsafe modification of the
+             * internal state.
+             */
+            Set<Location> cloned = new HashSet<>(locations.size());
+            for (Location location : locations) {
+                cloned.add(location.clone());
+            }
+            return cloned;
+        } finally {
+            tickingLocationLock.readLock().unlock();
+        }
     }
 
     /**
-     * This enables the ticker at the given {@link Location} and adds it to our "queue".
-     * 
-     * @param l
-     *            The {@link Location} to activate
+     * This enables the ticker at the given {@link Location} and adds it to the our queue.
+     *
+     * @param l The {@link Location} to activate
+     * @see #disableTicker(Location)
      */
     public void enableTicker(@Nonnull Location l) {
         Validate.notNull(l, "Location cannot be null!");
+        Validate.notNull(l.getWorld(), "Location must have a world!");
 
         ChunkPosition chunk = new ChunkPosition(l.getWorld(), l.getBlockX() >> 4, l.getBlockZ() >> 4);
-        Set<Location> newValue = new HashSet<>();
-        Set<Location> oldValue = tickingLocations.putIfAbsent(chunk, newValue);
 
-        /*
-         * This is faster than doing computeIfAbsent(...)
-         * on a ConcurrentHashMap because it won't block the Thread for too long
-         */
-        if (oldValue != null) {
-            oldValue.add(l);
-        } else {
-            newValue.add(l);
+        // We clone the location to ensure the instance we store is synchronized effectively
+        Location clonedLocation = l.clone();
+
+        // The values in tickingLocations are mutable so we must synchronize externally.
+        tickingLocationLock.writeLock().lock();
+        try {
+            Set<Location> locations = tickingLocations.computeIfAbsent(chunk, (unused) -> new HashSet<>());
+            locations.add(clonedLocation);
+        } finally {
+            tickingLocationLock.writeLock().unlock();
         }
     }
 
     /**
      * This method disables the ticker at the given {@link Location} and removes it from our internal
      * "queue".
-     * 
-     * @param l
-     *            The {@link Location} to remove
+     *
+     * @param l The {@link Location} to remove
+     * @see #enableTicker(Location)
      */
     public void disableTicker(@Nonnull Location l) {
         Validate.notNull(l, "Location cannot be null!");
+        Validate.notNull(l.getWorld(), "Location must have a world!");
 
         ChunkPosition chunk = new ChunkPosition(l.getWorld(), l.getBlockX() >> 4, l.getBlockZ() >> 4);
-        Set<Location> locations = tickingLocations.get(chunk);
 
-        if (locations != null) {
-            locations.remove(l);
+        // The values in tickingLocations are mutable so we must synchronize externally.
+        tickingLocationLock.writeLock().lock();
+        try {
+            Set<Location> locations = tickingLocations.get(chunk);
 
-            if (locations.isEmpty()) {
-                tickingLocations.remove(chunk);
+            if (locations != null) {
+                // Remove the location. We don't clone as we aren't storing the location
+                locations.remove(l);
+
+                if (locations.isEmpty()) {
+                    tickingLocations.remove(chunk);
+                }
             }
+        } finally {
+            tickingLocationLock.writeLock().unlock();
         }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickingBlocks.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickingBlocks.java
@@ -1,0 +1,165 @@
+package io.github.thebusybiscuit.slimefun4.implementation.tasks;
+
+import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
+import org.bukkit.Location;
+import org.bukkit.World;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+/**
+ * Memory efficient, synchronized collection of {@link BlockPosition BlockPositions} used by the
+ * {@link TickerTask}. All methods are thread-safe unless explicitly stated otherwise.
+ *
+ * @author md5sha256
+ */
+final class TickingBlocks {
+
+    private final Map<World, Set<Long>> blocks = Collections.synchronizedMap(new WeakHashMap<>());
+
+    /**
+     * Get the compressed {@link BlockPosition BlockPositions} mapped to a given {@link World}.
+     * The returned {@link Set} is thread-safe. Changes to set will be reflected in this instance.
+     *
+     * @param world The world
+     * @return Returns a {@link Set} of {@link Long Longs} which are compressed {@link BlockPosition BlockPositions}
+     *
+     * @see #getBlocksCopy()
+     */
+    public @Nonnull Set<Long> getBlocks(@Nonnull World world) {
+        return blocks.computeIfAbsent(world, (unused) -> Collections.synchronizedSet(new HashSet<>()));
+    }
+
+    /**
+     * Get a copy of the blocks mapped to a given {@link World} in the form of {@link BlockPosition BlockPositions}
+     * The returned {@link Set} is guaranteed to be a copy; however, it is not guaranteed to be thread-safe.
+     *
+     * @param world The world
+     * @return Returns a {@link Set} of {@link BlockPosition BlockPositions}
+     * @see #getBlocksCopy()
+     */
+    public @Nonnull Set<BlockPosition> getBlocksCopy(@Nonnull World world) {
+        Collection<Long> compressed = blocks.get(world);
+        if (compressed == null) {
+            return Collections.emptySet();
+        }
+        return convertToBlockPosition(world, compressed);
+    }
+
+    /**
+     * Get a copy of all the blocks stored in the form of {@link BlockPosition BlockPositions}
+     * The returned {@link Set} is not guaranteed to be thread-safe.
+     *
+     * @return Returns a {@link Set} of {@link BlockPosition BlockPositions}
+     * @see #getBlocksCopy(World)
+     */
+    public @Nonnull Set<BlockPosition> getBlocksCopy() {
+        Set<BlockPosition> positions = new HashSet<>();
+        for (Map.Entry<World, Set<Long>> entry : blocks.entrySet()) {
+            World world = entry.getKey();
+            Set<BlockPosition> converted = convertToBlockPosition(world, entry.getValue());
+            positions.addAll(converted);
+        }
+        return positions;
+    }
+
+    /**
+     * Get a copy of all the blocks in a given {@link World} in the form of {@link BlockPosition BlockPositions}
+     * The returned {@link Set} is not guaranteed to be thread-safe.
+     *
+     * @return Returns a {@link Set} of {@link BlockPosition BlockPositions}
+     * @see #getBlocksAsLocations()
+     */
+    public @Nonnull Set<Location> getBlocksAsLocations(@Nonnull World world) {
+        Collection<Long> compressed = blocks.get(world);
+        if (compressed == null) {
+            return Collections.emptySet();
+        }
+        return convertToLocation(world, compressed);
+    }
+
+    /**
+     * Get a copy of all the blocks stored in the form of {@link BlockPosition BlockPositions}
+     * The returned {@link Set} is not guaranteed to be thread-safe.
+     *
+     * @return Returns a {@link Set} of {@link BlockPosition BlockPositions}
+     * @see #getBlocksAsLocations(World)
+     */
+    public @Nonnull Set<Location> getBlocksAsLocations() {
+        Set<Location> locations = new HashSet<>();
+        for (Map.Entry<World, Set<Long>> entry : blocks.entrySet()) {
+            World world = entry.getKey();
+            Set<Location> converted = convertToLocation(world, entry.getValue());
+            locations.addAll(converted);
+        }
+        return locations;
+    }
+
+    public void addBlock(@Nonnull BlockPosition block) {
+        getBlocks(block.getWorld()).add(block.getPosition());
+    }
+
+    public void addBlock(@Nonnull Location location) {
+        addBlock(new BlockPosition(location));
+    }
+
+    public void removeBlock(@Nonnull BlockPosition block) {
+        World world = block.getWorld();
+        Collection<Long> positions = blocks.get(world);
+        if (positions == null) {
+            return;
+        }
+        positions.remove(block.getPosition());
+        if (positions.isEmpty()) {
+            blocks.remove(world);
+        }
+    }
+
+    public void removeBlock(@Nonnull Location location) {
+        removeBlock(new BlockPosition(location));
+    }
+
+    /**
+     * Clear all the blocks for a given {@link World}
+     * @param key The world to clear the key for
+     */
+    public void clear(@Nonnull World key) {
+        blocks.remove(key);
+    }
+
+    /**
+     * Clear all entries from this instance
+     */
+    public void clear() {
+        blocks.clear();
+    }
+
+    private static @Nonnull Set<BlockPosition> convertToBlockPosition(@Nonnull World world, @Nonnull Collection<Long> raw) {
+        if (raw.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<BlockPosition> positions = new HashSet<>(raw.size());
+        for (long compressed : raw) {
+            positions.add(new BlockPosition(world, compressed));
+        }
+        return positions;
+    }
+
+
+    private static @Nonnull Set<Location> convertToLocation(@Nonnull World world, @Nonnull Collection<Long> raw) {
+        Set<Location> locations = new HashSet<>(raw.size());
+        for (long compressed : raw) {
+            int x = (int) (compressed >> 38);
+            int y = (int) (compressed & 0XFFF);
+            int z = (int) (compressed << 26 >> 38);
+            locations.add(new Location(world, x, y, z));
+        }
+        return locations;
+    }
+
+}

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TestTickerCollection.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TestTickerCollection.java
@@ -1,0 +1,137 @@
+package io.github.thebusybiscuit.slimefun4.implementation.tasks;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.WorldMock;
+import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
+import io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerCollection;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class TestTickerCollection {
+
+    private static ServerMock serverMock;
+
+    @BeforeAll
+    public static void init() {
+        serverMock = MockBukkit.mock();
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    @DisplayName("Test the validity of the getters and setters")
+    void testGettersAndAdding() {
+        WorldMock world = new WorldMock();
+        serverMock.addWorld(world);
+        Location location = new Location(world, 0, 0, 0);
+        long compressedBlockPosition = BlockPosition.getAsLong(0, 0, 0);
+        TickerCollection tickerCollection = new TickerCollection();
+        tickerCollection.addBlock(location);
+        Set<Location> locations = tickerCollection.getBlocksAsLocations();
+        Assertions.assertEquals(1, locations.size());
+        Assertions.assertTrue(locations.contains(location));
+        tickerCollection.getBlocks(world);
+        Set<Long> compressedPositions = tickerCollection.getBlocks(world);
+        Assertions.assertEquals(1, compressedPositions.size());
+        Assertions.assertTrue(compressedPositions.contains(compressedBlockPosition));
+    }
+
+    @Test
+    @DisplayName("Test the validity of clearing and removing")
+    void testClearingAndRemoving() {
+        WorldMock world = new WorldMock();
+        serverMock.addWorld(world);
+        Location location = new Location(world, 0, 0, 0);
+        TickerCollection tickerCollection = new TickerCollection();
+
+        tickerCollection.addBlock(location);
+        Location anotherLocation = new Location(world, 1, 1, 1);
+        long anotherCompressedPosition = BlockPosition.getAsLong(1, 1, 1);
+
+        Set<Location> originalLocations = tickerCollection.getBlocksAsLocations();
+        Assertions.assertEquals(1, originalLocations.size());
+        Assertions.assertTrue(originalLocations.contains(location));
+
+        Set<Long> compressedPositions = tickerCollection.getBlocks(world);
+        Assertions.assertFalse(compressedPositions.contains(anotherCompressedPosition));
+        Assertions.assertEquals(1, compressedPositions.size());
+        tickerCollection.removeBlock(anotherLocation);
+
+        Set<Location> newLocations1 = tickerCollection.getBlocksAsLocations();
+        Assertions.assertTrue(newLocations1.contains(location));
+        Assertions.assertFalse(compressedPositions.contains(anotherCompressedPosition));
+        tickerCollection.removeBlock(location);
+
+        Set<Location> newLocations2 = tickerCollection.getBlocksAsLocations();
+        Assertions.assertFalse(newLocations2.contains(location));
+        tickerCollection.addBlock(location);
+        tickerCollection.addBlock(anotherLocation);
+        Assertions.assertEquals(2, tickerCollection.getBlocksAsLocations().size());
+        Assertions.assertEquals(2, tickerCollection.getBlocks(world).size());
+
+        tickerCollection.clear();
+        Assertions.assertTrue(tickerCollection.getBlocksAsLocations().isEmpty());
+        Assertions.assertTrue(compressedPositions.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Test the concurrent capability of the collection")
+    void testConcurrency() {
+        int processors = Runtime.getRuntime().availableProcessors();
+        ExecutorService executor = Executors.newFixedThreadPool(processors);
+        final TickerCollection collection = new TickerCollection();
+        final Map<World, Queue<BlockPosition>> worldPositionMap = new HashMap<>();
+        for (int i = 0; i < 20; i++) {
+            WorldMock world = new WorldMock();
+            serverMock.addWorld(world);
+            Queue<BlockPosition> positions = new ArrayDeque<>(20);
+            for (int j = 0; j < 20; j++) {
+                positions.add(new BlockPosition(world, j, j, j));
+            }
+            worldPositionMap.put(world, positions);
+        }
+        int i = 0;
+        for (Map.Entry<World, Queue<BlockPosition>> entry : worldPositionMap.entrySet()) {
+            World world = entry.getKey();
+            Queue<BlockPosition> positions = entry.getValue();
+            BlockPosition removed;
+            // Write tasks to read tasks = 1 : 2
+            for (; !positions.isEmpty(); i++) {
+                removed = positions.remove();
+                BlockPosition finalPosition = removed;
+                if (i++ % 3 == 0) {
+                    executor.submit(() -> collection.addBlock(finalPosition));
+                } else {
+                    executor.submit(() -> collection.getBlocks(world).contains(finalPosition.getPosition()));
+                }
+            }
+        }
+        executor.shutdown();
+        try {
+            executor.awaitTermination(1, TimeUnit.MINUTES);
+        } catch (Exception ex) {
+            String msg = "Failed to shutdown the executor service for TestTickerCollection#testConcucrrency";
+            Assertions.fail(msg, ex);
+        }
+    }
+
+}


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
As per a discussion in the SF discord, this PR removes the use of explicit locks used in TickerTask. 
I'm not a massive fan of the implementation of `TickingBlocks` as it is right now. Currently its just been wrapped (mutex) so it isn't that much better for performance than it was before (might even be worse on that end). However, we now map the world to a long as opposed to `ChunkPosition --> Set<Location>` which means the memory footprint is considerably lower. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Add `TickingBlocks`, a class that serves as an accessor/wrapper for a `Map<World, Set<Long>>`. In other words, a `BlockPositionSet`. 
- Removes the public getters for the `tickingLocations`
- Swap out the `Lock` + `Map<ChunkPosition, Set<Location>>` for `TickingBlocks`
- Added relevant docs

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
