### PR TITLE
Add the item to the research message

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -1115,7 +1115,7 @@ public class SlimefunItem implements Placeable {
                  * required Research to use this SlimefunItem.
                  */
                 if (sendMessage && !(this instanceof VanillaItem)) {
-                    SlimefunPlugin.getLocalization().sendMessage(p, "messages.not-researched", true);
+                    SlimefunPlugin.getLocalization().sendMessage(p, "messages.not-researched", true, s -> s.replace("%item%", getItemName()));
                 }
 
                 return false;

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -139,7 +139,7 @@ guide:
       translator: '&9Translator'
 
 messages:
-  not-researched: '&4You do not have enough knowledge to understand this'
+  not-researched: '&4You do not have enough knowledge to understand this. You need to research %item%'
   not-enough-xp: '&4You do not have enough XP to unlock this'
   unlocked: '&bYou have unlocked &7"%research%"'
   only-players: '&4This command is only for Players'


### PR DESCRIPTION
## Description
Very simple change, it adds the item to the not researched message. This way people know what they actually need to research. This should significantly reduce the number of people coming to Discord asking why they have the message.

**Note:** I had to delete `messages.yml` in `plugins/Slimefun/messages.yml` - Do we have a good way around this currently?

## Proposed changes
`&4You do not have enough knowledge to understand this` -> `&4You do not have enough knowledge to understand this. You need to research %item%`

## Related Issues (if applicable)
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
