### PR TITLE
Fix WoodcutterAndroid getting stuck while chopping a tree with full inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@
 * Fixed #3041
 * Fixed #3036
 * Possibly fixed #2927
-* Fixed #2964
 
 ## Release Candidate 22 (18 Apr 2021)
 https://thebusybiscuit.github.io/builds/TheBusyBiscuit/Slimefun4/stable/#22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * Fixed #3041
 * Fixed #3036
 * Possibly fixed #2927
+* Fixed #2964
 
 ## Release Candidate 22 (18 Apr 2021)
 https://thebusybiscuit.github.io/builds/TheBusyBiscuit/Slimefun4/stable/#22

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
@@ -69,13 +69,14 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
 
         if (menu.fits(drop, getOutputSlots())) {
             menu.pushItem(drop, getOutputSlots());
-            log.getWorld().playEffect(log.getLocation(), Effect.STEP_SOUND, log.getType());
+        }
 
-            if (log.getY() == android.getRelative(face).getY()) {
-                replant(log);
-            } else {
-                log.setType(Material.AIR);
-            }
+        log.getWorld().playEffect(log.getLocation(), Effect.STEP_SOUND, log.getType());
+
+        if (log.getY() == android.getRelative(face).getY()) {
+            replant(log);
+        } else {
+            log.setType(Material.AIR);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
@@ -67,12 +67,12 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
     private void breakLog(Block log, Block android, BlockMenu menu, BlockFace face) {
         ItemStack drop = new ItemStack(log.getType());
 
-        if (menu.fits(drop, getOutputSlots())) {
-            menu.pushItem(drop, getOutputSlots());
-        }
+        // We try to push the log into the android's inventory, but nothing happens if it does not fit
+        menu.pushItem(drop, getOutputSlots());
 
         log.getWorld().playEffect(log.getLocation(), Effect.STEP_SOUND, log.getType());
 
+        // If the android just chopped the bottom log, we replant the appropriate sapling
         if (log.getY() == android.getRelative(face).getY()) {
             replant(log);
         } else {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -86,6 +86,17 @@ public class DirtyChestMenu extends ChestMenu {
         return InvUtils.fits(toInventory(), new ItemStackWrapper(item), slots);
     }
 
+    /**
+     * Adds given {@link ItemStack} to any of the given inventory slots.
+     * Items will be added to the inventory slots based on their order in the function argument.
+     * Items will be added either to any empty inventory slots or any partially filled slots, in which case
+     * as many items as can fit will be added to that specific spot.
+     *
+     * @param item  {@link ItemStack} to be added to the inventory
+     * @param slots Numbers of slots to add the {@link ItemStack} to
+     * @return {@link ItemStack} with any items that did not fit into the inventory
+     *         or null when everything had fit
+     */
     @Nullable
     public ItemStack pushItem(ItemStack item, int... slots) {
         if (item == null || item.getType() == Material.AIR) {


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Currently, players need to come up with clever ways to handle the overflow of logs from the Woodcutter Android otherwise the android will inevitably get stuck in a loop and will need to be restarted manually by adding fuel to it when it runs out.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
If the android's inventory is full while in the middle of chopping a tree, the logs will 'get lost', meaning chopped successfully but not added to the android's inventory. The miner android does kind of the same thing.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #2964 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
