### PR TITLE
Fixed menu loading issues and probably improved BlockStorage load times

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -242,7 +242,7 @@ public class BlockStorage {
 
     private void loadInventories() {
         for (File file : new File("data-storage/Slimefun/stored-inventories").listFiles()) {
-            if (file.getName().endsWith(".sfi")) {
+            if (file.getName().startsWith(this.world.getName()) && file.getName().endsWith(".sfi")) {
                 try {
                     Location l = deserializeLocation(file.getName().replace(".sfi", ""));
                     

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -59,6 +59,8 @@ public class BlockStorage {
     private final Map<String, Config> blocksCache = new ConcurrentHashMap<>();
 
     private static int chunkChanges = 0;
+    private static boolean chunksLoaded = false;
+    private static boolean universalInventoriesLoaded = false;
 
     private int changes = 0;
     private AtomicBoolean isMarkedForRemoval = new AtomicBoolean(false);
@@ -214,6 +216,12 @@ public class BlockStorage {
     }
 
     private void loadChunks() {
+        if (chunksLoaded) {
+            return;
+        }
+
+        chunksLoaded = true;
+        
         File chunks = new File(PATH_CHUNKS + "chunks.sfc");
 
         if (chunks.exists()) {
@@ -234,9 +242,15 @@ public class BlockStorage {
 
     private void loadInventories() {
         for (File file : new File("data-storage/Slimefun/stored-inventories").listFiles()) {
-            if (file.getName().startsWith(world.getName()) && file.getName().endsWith(".sfi")) {
+            if (file.getName().endsWith(".sfi")) {
                 try {
                     Location l = deserializeLocation(file.getName().replace(".sfi", ""));
+                    
+                    // We only want to only load this world's menus
+                    if (world != l.getWorld()) {
+                        continue;
+                    }
+                    
                     io.github.thebusybiscuit.cscorelib2.config.Config cfg = new io.github.thebusybiscuit.cscorelib2.config.Config(file);
                     BlockMenuPreset preset = BlockMenuPreset.getPreset(cfg.getString("preset"));
 
@@ -253,6 +267,12 @@ public class BlockStorage {
             }
         }
 
+        if (universalInventoriesLoaded) {
+            return;
+        }
+        
+        universalInventoriesLoaded = true;
+        
         for (File file : new File("data-storage/Slimefun/universal-inventories").listFiles()) {
             if (file.getName().endsWith(".sfi")) {
                 try {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -242,7 +242,7 @@ public class BlockStorage {
 
     private void loadInventories() {
         for (File file : new File("data-storage/Slimefun/stored-inventories").listFiles()) {
-            if (file.getName().startsWith(this.world.getName()) && file.getName().endsWith(".sfi")) {
+            if (file.getName().startsWith(world.getName()) && file.getName().endsWith(".sfi")) {
                 try {
                     Location l = deserializeLocation(file.getName().replace(".sfi", ""));
                     


### PR DESCRIPTION
## Description
Stored inventories were getting loaded multiple times, overwriting the previous ones each time. Universal menus and stored chunks aswell. This is intended to be a temporary fix while BlockStorage is hopefully deleted and rewritten lol.

## Proposed changes
Added 2 checks to see if chunks and UniversalBlockMenus have already been loaded, and a check for world when loading BlockMenus.

## Related Issues (if applicable)
Fixes #2979

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
