### PR TITLE
Fix Icy Bow ignores shields

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -44,6 +44,7 @@ public class ExplosiveBow extends SlimefunBow {
         addItemSetting(range);
     }
 
+    @Nonnull
     @Override
     public BowShootHandler onShoot() {
         return (e, target) -> {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/IcyBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/IcyBow.java
@@ -1,10 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.weapons;
 
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -16,7 +19,7 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 /**
  * The {@link IcyBow} is a special kind of bow which slows down any
  * {@link LivingEntity} it hits.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -27,9 +30,17 @@ public class IcyBow extends SlimefunBow {
         super(category, item, recipe);
     }
 
+    @Nonnull
     @Override
     public BowShootHandler onShoot() {
         return (e, n) -> {
+            if (n instanceof Player) {
+                Player p = (Player) n;
+                if (p.isBlocking() && e.getFinalDamage() == 0) {
+                    return;
+                }
+            }
+
             n.getWorld().playEffect(n.getLocation(), Effect.STEP_SOUND, Material.ICE);
             n.getWorld().playEffect(n.getEyeLocation(), Effect.STEP_SOUND, Material.ICE);
             n.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 20 * 2, 10));


### PR DESCRIPTION
Resolves #3060

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When a player holding a shield is hit with Icy Bow, the effects still apply

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Check for final damage caused and if the player hit is blocking

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3060

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
