### PR TITLE
Add a configurable step delay to the Ancient Altar

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientAltar.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientAltar.java
@@ -3,6 +3,9 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.altar;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.events.AncientAltarCraftEvent;
@@ -19,23 +22,29 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * The {@link AncientAltar} is a multiblock structure.
  * The altar itself stands in the center, surrounded by {@link AncientPedestal Pedestals}, it is used
  * to craft various magical items.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ * @author martinbrom
+ *
  * @see AncientAltarListener
  * @see AncientAltarTask
  * @see AncientAltarCraftEvent
  * @see AncientPedestal
- *
  */
 public class AncientAltar extends SlimefunItem {
 
+    /**
+     * This number represents a delay in ticks between two ritual steps.
+     * The whole ritual process consists of 36 steps, an item is consumed every 4 steps (8 times)
+     * and the output is spawned after the 36th step completes.
+     */
     private static final int DEFAULT_STEP_DELAY = 8;
 
     private final List<AltarRecipe> recipes = new ArrayList<>();
 
     private final ItemSetting<Integer> stepDelay = new IntRangeSetting(this, "step-delay", 0, DEFAULT_STEP_DELAY, Integer.MAX_VALUE);
 
+    @ParametersAreNonnullByDefault
     public AncientAltar(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
@@ -43,16 +52,17 @@ public class AncientAltar extends SlimefunItem {
     }
 
     /**
-     * This returns the speed of this {@link AncientAltar}.
+     * This returns the delay of this {@link AncientAltar}.
      * This number determines how many ticks happen in between a step in the ritual animation.
      * The default is {@value #DEFAULT_STEP_DELAY} ticks.
-     * 
-     * @return The speed of this {@link AncientAltar}
+     *
+     * @return The delay between two ritual steps of this {@link AncientAltar}
      */
-    public int getSpeed() {
+    public int getStepDelay() {
         return stepDelay.getValue();
     }
 
+    @Nonnull
     public List<AltarRecipe> getRecipes() {
         return recipes;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientAltar.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientAltar.java
@@ -6,6 +6,8 @@ import java.util.List;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.events.AncientAltarCraftEvent;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
+import io.github.thebusybiscuit.slimefun4.api.items.settings.IntRangeSetting;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.AncientAltarListener;
 import io.github.thebusybiscuit.slimefun4.implementation.tasks.AncientAltarTask;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
@@ -28,28 +30,27 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  */
 public class AncientAltar extends SlimefunItem {
 
-    private final int speed;
+    private static final int DEFAULT_STEP_DELAY = 8;
+
     private final List<AltarRecipe> recipes = new ArrayList<>();
 
-    public AncientAltar(Category category, int speed, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    private final ItemSetting<Integer> stepDelay = new IntRangeSetting(this, "step-delay", 0, DEFAULT_STEP_DELAY, Integer.MAX_VALUE);
+
+    public AncientAltar(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
-        if (speed < 1) {
-            throw new IllegalArgumentException("The speed must be at least 1.");
-        }
-
-        this.speed = speed;
+        addItemSetting(stepDelay);
     }
 
     /**
      * This returns the speed of this {@link AncientAltar}.
-     * This number determines how much ticks happen inbetween a step in the ritual animation.
-     * The default is 8 ticks.
+     * This number determines how many ticks happen in between a step in the ritual animation.
+     * The default is {@value #DEFAULT_STEP_DELAY} ticks.
      * 
      * @return The speed of this {@link AncientAltar}
      */
     public int getSpeed() {
-        return speed;
+        return stepDelay.getValue();
     }
 
     public List<AltarRecipe> getRecipes() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -225,7 +225,7 @@ public class AncientAltarListener implements Listener {
 
                 b.getWorld().playSound(b.getLocation(), Sound.ENTITY_ILLUSIONER_PREPARE_MIRROR, 1, 1);
 
-                AncientAltarTask task = new AncientAltarTask(this, b, altarItem.getSpeed(), result.get(), pedestals, consumed, p);
+                AncientAltarTask task = new AncientAltarTask(this, b, altarItem.getStepDelay(), result.get(), pedestals, consumed, p);
                 SlimefunPlugin.runSync(task, 10L);
             } else {
                 altars.remove(b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1492,7 +1492,7 @@ public final class SlimefunItemSetup {
         new SlimefunItemStack(SlimefunItems.ANCIENT_PEDESTAL, 4))
         .register(plugin);
 
-        new AncientAltar(categories.magicalGadgets, 8, SlimefunItems.ANCIENT_ALTAR, RecipeType.MAGIC_WORKBENCH,
+        new AncientAltar(categories.magicalGadgets, SlimefunItems.ANCIENT_ALTAR, RecipeType.MAGIC_WORKBENCH,
         new ItemStack[] {null, new ItemStack(Material.ENCHANTING_TABLE), null, SlimefunItems.MAGIC_LUMP_3, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.OBSIDIAN), SlimefunItems.GOLD_8K, new ItemStack(Material.OBSIDIAN)})
         .register(plugin);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
@@ -46,7 +46,7 @@ public class AncientAltarTask implements Runnable {
     private final AncientPedestal pedestalItem = (AncientPedestal) SlimefunItems.ANCIENT_PEDESTAL.getItem();
 
     private final Block altar;
-    private final int speed;
+    private final int stepDelay;
     private final Location dropLocation;
     private final ItemStack output;
     private final List<Block> pedestals;
@@ -60,10 +60,10 @@ public class AncientAltarTask implements Runnable {
     private final Player player;
 
     @ParametersAreNonnullByDefault
-    public AncientAltarTask(AncientAltarListener listener, Block altar, int speed, ItemStack output, List<Block> pedestals, List<ItemStack> items, Player player) {
+    public AncientAltarTask(AncientAltarListener listener, Block altar, int stepDelay, ItemStack output, List<Block> pedestals, List<ItemStack> items, Player player) {
         this.listener = listener;
         this.dropLocation = altar.getLocation().add(0.5, 1.3, 0.5);
-        this.speed = speed;
+        this.stepDelay = stepDelay;
         this.altar = altar;
         this.output = output;
         this.pedestals = pedestals;
@@ -102,7 +102,7 @@ public class AncientAltarTask implements Runnable {
         }
 
         this.stage += 1;
-        SlimefunPlugin.runSync(this, speed);
+        SlimefunPlugin.runSync(this, stepDelay);
     }
 
     private boolean checkLockedItems() {


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Mass crafting rune in base Slimefun is currently very tedious. This gives the server owners the option to configure the speed themselves.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add `IntRangeSetting` to the `AncientAltar`
Remove check for zero-tick step delay, now it is possible to craft instantly

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
