### PR TITLE
Fixed an Exception when any GoldPan drops have zero chance of dropping

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -94,7 +94,9 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         randomizer.clear();
 
         for (GoldPanDrop setting : drops) {
-            randomizer.add(setting.getOutput(), setting.getValue());
+            if (setting.getValue() > 0) {
+                randomizer.add(setting.getOutput(), setting.getValue());
+            }
         }
     }
 
@@ -112,11 +114,13 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         return item != null ? item : new ItemStack(Material.AIR);
     }
 
+    @Nonnull
     @Override
     public String getLabelLocalPath() {
         return "guide.tooltips.recipes.gold-pan";
     }
 
+    @Nonnull
     @Override
     public ItemUseHandler getItemHandler() {
         return e -> {
@@ -158,6 +162,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         };
     }
 
+    @Nonnull
     @Override
     public List<ItemStack> getDisplayRecipes() {
         List<ItemStack> recipes = new LinkedList<>();


### PR DESCRIPTION
Resolves #3064

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When a chance for any item in a `GoldPan` is set to 0, our validation allows it but validation in the `RandomizedSet` does not.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add a simple check to `updateRandomizer()` in `GoldPan`
Another option would be to update `RandomizedSet` in cscorelib to accept/handle zero chance values.
I have also tested the case when all drops are set to zero.
This could happen in the `FishermanAndroid` in the future as it also uses the `RandomizedSet` but for now, its chances aren't configurable.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3064

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
