### PR TITLE
Change config for consistency and improvement

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -256,11 +256,8 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
             PaperLib.suggestPaper(this);
         }
 
-        // Disabling backwards-compatibility for fresh Slimefun installs
+        // If the server has no "data-storage" folder, it's _probably_ a new install. So mark it for metrics.
         if (!new File("data-storage/Slimefun").exists()) {
-            config.setValue("options.backwards-compatibility", false);
-            config.save();
-
             isNewlyInstalled = true;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -257,9 +257,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         }
 
         // If the server has no "data-storage" folder, it's _probably_ a new install. So mark it for metrics.
-        if (!new File("data-storage/Slimefun").exists()) {
-            isNewlyInstalled = true;
-        }
+        isNewlyInstalled = !new File("data-storage/Slimefun").exists();
 
         // Creating all necessary Folders
         getLogger().log(Level.INFO, "Creating directories...");

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -305,7 +305,7 @@ public class SlimefunItem implements Placeable {
      * @return An {@link Optional} describing the result
      */
     @SuppressWarnings("unchecked")
-    public <T> @Nonnull Optional<ItemSetting<T>> getItemSetting(@Nonnull String key, @Nonnull Class<T> c) {
+    public @Nonnull <T> Optional<ItemSetting<T>> getItemSetting(@Nonnull String key, @Nonnull Class<T> c) {
         for (ItemSetting<?> setting : itemSettings) {
             if (setting.getKey().equals(key) && setting.isType(c)) {
                 return Optional.of((ItemSetting<T>) setting);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,7 @@ options:
   # You can download the latest stable build here: https://thebusybiscuit.github.io/builds/TheBusyBiscuit/Slimefun4/stable/
 
   auto-update: true
-  backwards-compatibility: true
+  backwards-compatibility: false
   chat-prefix: '&a&lSlimefun 4&7> '
   armor-update-interval: 10
   enable-armor-effects: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,7 +30,7 @@ researches:
 
 URID:
   info-delay: 3000
-  custom-ticker-delay: 12
+  custom-ticker-delay: 10
   enable-tickers: true
 
 networks:


### PR DESCRIPTION
## Description
This PR aims to just cleanup the config a little to fix inconsistency and a case where issues can easily occur.

### Tick Delay
Slimefun is so much more optimised than it used to be. Insanely so. The 12 ticks has never made sense to me. Regardless though, this 12 tick delay has always caused issues for people due to the fact that all Slimefun lores assume this is 10 ticks. They have production * 2 in the lore.

This changed should cause no real issue due to the fact it's always been changeable anyway. No addon or core Slimefun functionality should be based on this being 12.

### Backwards Compatibility
It has now been 2 years since this was introduced. All servers which didn't have this config option definitely do now. If we look at bStats 80% of servers have this disabled. A lot of those which have it enabled do not actually know about it.

There's a common bug which has occurred from this being true by default. People often copy the data-storage folder when resetting or moving but do NOT copy config.yml due to them not changing it. This results in backward compatibility being enabled. We've seen multiple cases of this in the Discord server which makes me believe a good chunk of that 20% is due to this. 

## Proposed changes
* custom-ticker-delay: 12 -> 10
* backwards-compatibility: true -> false

## Related Issues (if applicable)
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
