### PR TITLE
FlexCategories can now be made visible in CheatSheet and Survival SlimefunGuide

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/categories/FlexCategory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/categories/FlexCategory.java
@@ -77,12 +77,12 @@ public abstract class FlexCategory extends Category {
     }
 
     @Override
-    public final void add(SlimefunItem item) {
+    public final void add(@Nonnull SlimefunItem item) {
         throw new UnsupportedOperationException("You cannot add items to a FlexCategory!");
     }
 
     @Override
-    public final List<SlimefunItem> getItems() {
+    public final @Nonnull List<SlimefunItem> getItems() {
         throw new UnsupportedOperationException("A FlexCategory has no items!");
     }
 
@@ -92,7 +92,7 @@ public abstract class FlexCategory extends Category {
     }
 
     @Override
-    public final void remove(SlimefunItem item) {
+    public final void remove(@Nonnull SlimefunItem item) {
         throw new UnsupportedOperationException("A FlexCategory has no items, so there is nothing remove!");
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/categories/MultiCategory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/categories/MultiCategory.java
@@ -64,7 +64,7 @@ public class MultiCategory extends FlexCategory {
     @Override
     @ParametersAreNonnullByDefault
     public boolean isVisible(Player p, PlayerProfile profile, SlimefunGuideMode mode) {
-        return true;
+        return mode == SlimefunGuideMode.SURVIVAL_MODE;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
@@ -47,13 +47,12 @@ public class CheatSheetSlimefunGuide extends SurvivalSlimefunGuide {
      *            The {@link PlayerProfile} of the {@link Player}
      * @return a {@link List} of visible {@link Category} instances
      */
-    @Nonnull
     @Override
-    protected List<Category> getVisibleCategories(@Nonnull Player p, @Nonnull PlayerProfile profile) {
+    protected @Nonnull List<Category> getVisibleCategories(@Nonnull Player p, @Nonnull PlayerProfile profile) {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {
-            if (!(category instanceof FlexCategory)) {
+            if (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getMode())) {
                 categories.add(category);
             }
         }
@@ -61,15 +60,13 @@ public class CheatSheetSlimefunGuide extends SurvivalSlimefunGuide {
         return categories;
     }
 
-    @Nonnull
     @Override
-    public SlimefunGuideMode getMode() {
+    public @Nonnull SlimefunGuideMode getMode() {
         return SlimefunGuideMode.CHEAT_MODE;
     }
 
-    @Nonnull
     @Override
-    public ItemStack getItem() {
+    public @Nonnull ItemStack getItem() {
         return item;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -55,7 +55,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 /**
  * The {@link SurvivalSlimefunGuide} is the standard version of our {@link SlimefunGuide}.
  * It uses an {@link Inventory} to display {@link SlimefunGuide} contents.
- * 
+ *
  * @author TheBusyBiscuit
  * 
  * @see SlimefunGuide
@@ -83,18 +83,17 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
      * 
      * @return The {@link Sound}
      */
-    @Nonnull
-    public Sound getSound() {
+    public @Nonnull Sound getSound() {
         return sound;
     }
 
     @Override
-    public SlimefunGuideMode getMode() {
+    public @Nonnull SlimefunGuideMode getMode() {
         return SlimefunGuideMode.SURVIVAL_MODE;
     }
 
     @Override
-    public ItemStack getItem() {
+    public @Nonnull ItemStack getItem() {
         return item;
     }
 
@@ -111,13 +110,16 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
      *            The {@link PlayerProfile} of the {@link Player}
      * @return a {@link List} of visible {@link Category} instances
      */
-    @Nonnull
-    protected List<Category> getVisibleCategories(@Nonnull Player p, @Nonnull PlayerProfile profile) {
+    protected @Nonnull List<Category> getVisibleCategories(@Nonnull Player p, @Nonnull PlayerProfile profile) {
         List<Category> categories = new LinkedList<>();
 
         for (Category category : SlimefunPlugin.getRegistry().getCategories()) {
             try {
-                if (!category.isHidden(p) && (!(category instanceof FlexCategory) || ((FlexCategory) category).isVisible(p, profile, getMode()))) {
+                if (category instanceof FlexCategory) {
+                    if (((FlexCategory) category).isVisible(p, profile, getMode())) {
+                        categories.add(category);
+                    }
+                } else if (!category.isHidden(p)) {
                     categories.add(category);
                 }
             } catch (Exception | LinkageError x) {
@@ -219,6 +221,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
     }
 
     @Override
+    @ParametersAreNonnullByDefault
     public void openCategory(PlayerProfile profile, Category category, int page) {
         Player p = profile.getPlayer();
 
@@ -321,6 +324,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
     }
 
     @Override
+    @ParametersAreNonnullByDefault
     public void openSearch(PlayerProfile profile, String input, boolean addToHistory) {
         Player p = profile.getPlayer();
 
@@ -382,6 +386,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
     }
 
     @Override
+    @ParametersAreNonnullByDefault
     public void displayItem(PlayerProfile profile, ItemStack item, int index, boolean addToHistory) {
         Player p = profile.getPlayer();
 
@@ -486,6 +491,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
     }
 
     @Override
+    @ParametersAreNonnullByDefault
     public void displayItem(PlayerProfile profile, SlimefunItem item, boolean addToHistory) {
         Player p = profile.getPlayer();
 
@@ -619,9 +625,8 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         }
     }
 
-    @Nonnull
     @ParametersAreNonnullByDefault
-    private static ItemStack getDisplayItem(Player p, boolean isSlimefunRecipe, ItemStack item) {
+    private static @Nonnull ItemStack getDisplayItem(Player p, boolean isSlimefunRecipe, ItemStack item) {
         if (isSlimefunRecipe) {
             SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
 
@@ -722,8 +727,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         return SlimefunPlugin.getPermissionsService().hasPermission(p, item);
     }
 
-    @Nonnull
-    private ChestMenu create(@Nonnull Player p) {
+    private @Nonnull ChestMenu create(@Nonnull Player p) {
         ChestMenu menu = new ChestMenu(SlimefunPlugin.getLocalization().getMessage(p, "guide.title.main"));
 
         menu.setEmptySlotsClickable(false);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Currently, it is impossible to display FlexCategories in the CheatSheetSlimefunGuide.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add checks for `isVisible()` to both the Survival and CheatSheet books in the case of a `FlexCategory`.
A better option would probably to stop using the `isHidden()` altogether and move towards `isVisible()` since `isHidden()` is used only in one place in the whole Slimefun codebase anyway but this breaking change could introduce issues for other addons.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
No related issue, discussed for a bit in the programming-help channel.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
