### PR TITLE
Add charcoal->coal recipe to Pressure Chamber

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -30,6 +30,12 @@ public class PressureChamber extends MultiBlockMachine {
     }
 
     @Override
+    public void registerDefaultRecipes(List<ItemStack> recipes) {
+        recipes.add(new ItemStack(Material.CHARCOAL, 5));
+        recipes.add(new ItemStack(Material.COAL));
+    }
+
+    @Override
     public List<ItemStack> getDisplayRecipes() {
         return recipes.stream().map(items -> items[0]).collect(Collectors.toList());
     }


### PR DESCRIPTION
## Description
Implement a simple Discord suggestion

## Changes
- Overrides #registerDefaultRecipes()
- Adds 5 charcoal -> 1 coal recipe

## Related Issues (if applicable)
Discord issue 1277

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
