### PR TITLE
Add LimitedUseItem - base class for items with limited uses

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -570,7 +570,7 @@ public final class SlimefunItems {
     public static final SlimefunItemStack STAFF_WIND = new SlimefunItemStack("STAFF_ELEMENTAL_WIND", Material.STICK, "&6Elemental Staff &7- &b&oWind", "", "&7Element: &b&oWind", "", "&eRight Click&7 to launch yourself forward");
     public static final SlimefunItemStack STAFF_FIRE = new SlimefunItemStack("STAFF_ELEMENTAL_FIRE", Material.STICK, "&6Elemental Staff &7- &c&oFire", "", "&7Element: &c&oFire");
     public static final SlimefunItemStack STAFF_WATER = new SlimefunItemStack("STAFF_ELEMENTAL_WATER", Material.STICK, "&6Elemental Staff &7- &1&oWater", "", "&7Element: &1&oWater", "", "&eRight Click&7 to extinguish yourself");
-    public static final SlimefunItemStack STAFF_STORM = new SlimefunItemStack("STAFF_ELEMENTAL_STORM", Material.STICK, "&6Elemental Staff &7- &8&oStorm", "", "&7Element: &8&oStorm", "", "&eRight Click&7 to summon a lightning", "&e" + StormStaff.MAX_USES + " Uses &7left");
+    public static final SlimefunItemStack STAFF_STORM = new SlimefunItemStack("STAFF_ELEMENTAL_STORM", Material.STICK, "&6Elemental Staff &7- &8&oStorm", "", "&7Element: &8&oStorm", "", "&eRight Click&7 to summon a lightning", LoreBuilder.usesLeft(StormStaff.MAX_USES));
 
     static {
         STAFF_WIND.addUnsafeEnchantment(Enchantment.LUCK, 1);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -19,11 +19,11 @@ import org.bukkit.persistence.PersistentDataType;
 
 import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
+import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
@@ -41,8 +41,7 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  */
 public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> {
 
-    private static final NamespacedKey usageKey = new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
-    private static final Pattern REGEX = Pattern.compile(ChatColors.color("&e[0-9]+ Uses &7left"));
+    private final NamespacedKey defaultUsageKey = new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
 
     private int maxUseCount = -1;
 
@@ -72,12 +71,8 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
     public final @Nonnull LimitedUseItem setMaxUseCount(int count) {
         Validate.isTrue(count > 0, "The maximum use count must be greater than zero!");
 
-        if (getState() == ItemState.UNREGISTERED) {
-            maxUseCount = count;
-            return this;
-        } else {
-            throw new IllegalStateException("You cannot modify the maximum use count after the Item was registered.");
-        }
+        maxUseCount = count;
+        return this;
     }
 
     /**
@@ -86,7 +81,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
      * @return The {@link NamespacedKey} to store/load the amount of uses
      */
     protected @Nonnull NamespacedKey getStorageKey() {
-        return usageKey;
+        return defaultUsageKey;
     }
 
     @Override
@@ -140,7 +135,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
         if (lore != null && !lore.isEmpty()) {
             // find the correct line
             for (int i = 0; i < lore.size(); i++) {
-                if (REGEX.matcher(lore.get(i)).matches()) {
+                if (PatternUtils.USES_LEFT_LORE.matcher(lore.get(i)).matches()) {
                     lore.set(i, newLine);
                     meta.setLore(lore);
                     item.setItemMeta(meta);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -2,7 +2,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.items;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -23,7 +22,6 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
-import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -22,6 +22,7 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
+import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
@@ -38,8 +39,6 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * @see StormStaff
  */
 public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> {
-
-    public static final String USES_LEFT_SUFFIX = ChatColors.color("Uses &7left");
 
     private final NamespacedKey defaultUsageKey = new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
     private int maxUseCount = -1;
@@ -134,7 +133,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
         if (lore != null && !lore.isEmpty()) {
             // find the correct line
             for (int i = 0; i < lore.size(); i++) {
-                if (lore.get(i).endsWith(USES_LEFT_SUFFIX)) {
+                if (PatternUtils.USES_LEFT_LORE.matcher(lore.get(i)).matches()) {
                     lore.set(i, newLine);
                     meta.setLore(lore);
                     item.setItemMeta(meta);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -39,8 +39,9 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  */
 public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> {
 
+    public static final String USES_LEFT_SUFFIX = ChatColors.color("Uses &7left");
+
     private final NamespacedKey defaultUsageKey = new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
-    private final String usesLeftSuffix = ChatColors.color("Uses &7left");
 
     private int maxUseCount = -1;
 
@@ -134,7 +135,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
         if (lore != null && !lore.isEmpty()) {
             // find the correct line
             for (int i = 0; i < lore.size(); i++) {
-                if (lore.get(i).endsWith(usesLeftSuffix)) {
+                if (lore.get(i).endsWith(USES_LEFT_SUFFIX)) {
                     lore.set(i, newLine);
                     meta.setLore(lore);
                     item.setItemMeta(meta);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -42,7 +42,6 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
     public static final String USES_LEFT_SUFFIX = ChatColors.color("Uses &7left");
 
     private final NamespacedKey defaultUsageKey = new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
-
     private int maxUseCount = -1;
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -15,6 +16,7 @@ import org.bukkit.persistence.PersistentDataType;
 
 import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
@@ -36,6 +38,10 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  */
 public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> {
 
+    private static final NamespacedKey usageKey = new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
+
+    private int maxUseCount = -1;
+
     @ParametersAreNonnullByDefault
     public LimitedUseItem(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe, null);
@@ -45,11 +51,28 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
 
     /**
      * Returns the number of times this item can be used.
-     * Must be greater than zero.
      *
      * @return The number of times this item can be used.
      */
-    protected abstract int getMaxUseCount();
+    public final int getMaxUseCount() {
+        return maxUseCount;
+    }
+
+    /**
+     * Sets the maximum number of times this item can be used.
+     * The number must be greater than zero.
+     *
+     * @param count The maximum number of times this item can be used.
+     */
+    public final void setMaxUseCount(int count) {
+        Validate.isTrue(count > 0, "The maximum use count must be greater than zero!");
+
+        if (getState() == ItemState.UNREGISTERED) {
+            maxUseCount = count;
+        } else {
+            throw new IllegalStateException("You cannot modify the maximum use count after the Item was registered.");
+        }
+    }
 
     /**
      * Returns the {@link NamespacedKey} under which will the amount of uses left stored.
@@ -57,7 +80,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
      * @return The {@link NamespacedKey} to store/load the amount of uses
      */
     protected @Nonnull NamespacedKey getStorageKey() {
-        return new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
+        return usageKey;
     }
 
     @Override
@@ -102,6 +125,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
         }
     }
 
+    @ParametersAreNonnullByDefault
     private void updateItemLore(ItemStack item, ItemMeta meta, int usesLeft) {
         List<String> lore = meta.getLore();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -45,7 +45,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
 
     @ParametersAreNonnullByDefault
     public LimitedUseItem(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe, null);
+        super(category, item, recipeType, recipe);
 
         addItemHandler(getItemHandler());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -1,0 +1,117 @@
+package io.github.thebusybiscuit.slimefun4.implementation.items;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
+import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+
+/**
+ * This class represents an item with a limited number of uses.
+ * When the item runs out of "uses", it breaks.
+ *
+ * @author Linox
+ * @author Walshy
+ * @author TheBusyBiscuit
+ * @author martinbrom
+ *
+ * @see StormStaff
+ */
+public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> {
+
+    @ParametersAreNonnullByDefault
+    public LimitedUseItem(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe, null);
+
+        addItemHandler(getItemHandler());
+    }
+
+    /**
+     * Returns the number of times this item can be used.
+     * Must be greater than zero.
+     *
+     * @return The number of times this item can be used.
+     */
+    protected abstract int getMaxUseCount();
+
+    /**
+     * Returns the {@link NamespacedKey} under which will the amount of uses left stored.
+     *
+     * @return The {@link NamespacedKey} to store/load the amount of uses
+     */
+    protected @Nonnull NamespacedKey getStorageKey() {
+        return new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
+    }
+
+    @Override
+    public void register(@Nonnull SlimefunAddon addon) {
+        if (getMaxUseCount() < 1) {
+            warn("The use count has not been configured correctly. It needs to be at least 1. The Item was disabled.");
+        } else {
+            super.register(addon);
+        }
+    }
+
+    @ParametersAreNonnullByDefault
+    protected void damageItem(Player p, ItemStack item) {
+        if (item.getAmount() > 1) {
+            item.setAmount(item.getAmount() - 1);
+
+            // Separate one item from the stack and damage it
+            ItemStack separateItem = item.clone();
+            separateItem.setAmount(1);
+            damageItem(p, separateItem);
+
+            // Try to give the Player the new item
+            if (!p.getInventory().addItem(separateItem).isEmpty()) {
+                // or throw it on the ground
+                p.getWorld().dropItemNaturally(p.getLocation(), separateItem);
+            }
+        } else {
+            ItemMeta meta = item.getItemMeta();
+            NamespacedKey key = getStorageKey();
+            PersistentDataContainer pdc = meta.getPersistentDataContainer();
+            int usesLeft = pdc.getOrDefault(key, PersistentDataType.INTEGER, getMaxUseCount());
+
+            if (usesLeft == 1) {
+                p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
+                item.setAmount(0);
+            } else {
+                usesLeft--;
+                pdc.set(key, PersistentDataType.INTEGER, usesLeft);
+
+                updateItemLore(item, meta, usesLeft);
+            }
+        }
+    }
+
+    private void updateItemLore(ItemStack item, ItemMeta meta, int usesLeft) {
+        List<String> lore = meta.getLore();
+
+        if (lore != null && !lore.isEmpty()) {
+            // replace the last line
+            lore.set(lore.size() - 1, ChatColors.color(LoreBuilder.usesLeft(usesLeft)));
+            meta.setLore(lore);
+
+            item.setItemMeta(meta);
+        }
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -42,6 +42,7 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> {
 
     private final NamespacedKey defaultUsageKey = new NamespacedKey(SlimefunPlugin.instance(), "uses_left");
+    private final String usesLeftSuffix = ChatColors.color("Uses &7left");
 
     private int maxUseCount = -1;
 
@@ -135,7 +136,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
         if (lore != null && !lore.isEmpty()) {
             // find the correct line
             for (int i = 0; i < lore.size(); i++) {
-                if (PatternUtils.USES_LEFT_LORE.matcher(lore.get(i)).matches()) {
+                if (lore.get(i).endsWith(usesLeftSuffix)) {
                     lore.set(i, newLine);
                     meta.setLore(lore);
                     item.setItemMeta(meta);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -33,8 +33,9 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  */
 public class StormStaff extends LimitedUseItem {
 
-    private static final NamespacedKey usageKey = new NamespacedKey(SlimefunPlugin.instance(), "stormstaff_usage");
     public static final int MAX_USES = 8;
+
+    private final NamespacedKey usageKey = new NamespacedKey(SlimefunPlugin.instance(), "stormstaff_usage");
 
     @ParametersAreNonnullByDefault
     public StormStaff(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -39,11 +39,8 @@ public class StormStaff extends LimitedUseItem {
     @ParametersAreNonnullByDefault
     public StormStaff(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
-    }
 
-    @Override
-    protected int getMaxUseCount() {
-        return MAX_USES;
+        setMaxUseCount(MAX_USES);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -1,7 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves;
 
-import java.util.List;
-
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -10,20 +8,16 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.Sound;
+import org.bukkit.World;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataType;
 
-import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.items.LimitedUseItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
@@ -32,37 +26,33 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 /**
  * This {@link SlimefunItem} casts a {@link LightningStrike} where you are pointing.
  * Unlike the other Staves, it has a limited amount of uses.
- * 
+ *
  * @author Linox
  * @author Walshy
  * @author TheBusyBiscuit
- *
  */
-public class StormStaff extends SimpleSlimefunItem<ItemUseHandler> {
+public class StormStaff extends LimitedUseItem {
 
     private static final NamespacedKey usageKey = new NamespacedKey(SlimefunPlugin.instance(), "stormstaff_usage");
     public static final int MAX_USES = 8;
 
     @ParametersAreNonnullByDefault
     public StormStaff(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe, getCraftedOutput());
-    }
-
-    @Nonnull
-    private static ItemStack getCraftedOutput() {
-        ItemStack item = SlimefunItems.STAFF_STORM.clone();
-        ItemMeta im = item.getItemMeta();
-        List<String> lore = im.getLore();
-
-        lore.set(4, ChatColors.color("&e" + MAX_USES + " Uses &7left"));
-
-        im.setLore(lore);
-        item.setItemMeta(im);
-        return item;
+        super(category, item, recipeType, recipe);
     }
 
     @Override
-    public ItemUseHandler getItemHandler() {
+    protected int getMaxUseCount() {
+        return MAX_USES;
+    }
+
+    @Override
+    protected @Nonnull NamespacedKey getStorageKey() {
+        return usageKey;
+    }
+
+    @Override
+    public @Nonnull ItemUseHandler getItemHandler() {
         return e -> {
             Player p = e.getPlayer();
             ItemStack item = e.getItem();
@@ -87,7 +77,10 @@ public class StormStaff extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
     private void useItem(Player p, ItemStack item, Location loc) {
-        loc.getWorld().strikeLightning(loc);
+        World world = loc.getWorld();
+        if (world != null) {
+            world.strikeLightning(loc);
+        }
 
         if (item.getType() == Material.SHEARS) {
             return;
@@ -103,41 +96,6 @@ public class StormStaff extends SimpleSlimefunItem<ItemUseHandler> {
         }
 
         damageItem(p, item);
-    }
-
-    @ParametersAreNonnullByDefault
-    private void damageItem(Player p, ItemStack item) {
-        if (item.getAmount() > 1) {
-            item.setAmount(item.getAmount() - 1);
-
-            // Seperate one item from the stack and damage it
-            ItemStack seperateItem = item.clone();
-            seperateItem.setAmount(1);
-            damageItem(p, seperateItem);
-
-            // Try to give the Player the new item
-            if (!p.getInventory().addItem(seperateItem).isEmpty()) {
-                // or throw it on the ground
-                p.getWorld().dropItemNaturally(p.getLocation(), seperateItem);
-            }
-        } else {
-            ItemMeta meta = item.getItemMeta();
-            int usesLeft = meta.getPersistentDataContainer().getOrDefault(usageKey, PersistentDataType.INTEGER, MAX_USES);
-
-            if (usesLeft == 1) {
-                p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
-                item.setAmount(0);
-            } else {
-                usesLeft--;
-                meta.getPersistentDataContainer().set(usageKey, PersistentDataType.INTEGER, usesLeft);
-
-                List<String> lore = meta.getLore();
-                lore.set(4, ChatColors.color("&e" + usesLeft + ' ' + (usesLeft > 1 ? "Uses" : "Use") + " &7left"));
-                meta.setLore(lore);
-
-                item.setItemMeta(meta);
-            }
-        }
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
@@ -74,7 +74,7 @@ public final class LoreBuilder {
     }
 
     public static @Nonnull String usesLeft(int usesLeft) {
-        return "&e" + usesLeft + ' ' + (usesLeft > 1 ? "Uses" : "Use") + " &7left";
+        return "&e" + usesLeft + " Uses &7left";
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
@@ -83,4 +83,9 @@ public final class LoreBuilder {
         return "&7Range: &c" + blocks + " blocks";
     }
 
+    @Nonnull
+    public static String usesLeft(int usesLeft) {
+        return "&e" + usesLeft + ' ' + (usesLeft > 1 ? "Uses" : "Use") + " &7left";
+    }
+
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
@@ -33,58 +33,47 @@ public final class LoreBuilder {
 
     private LoreBuilder() {}
 
-    @Nonnull
-    public static String radioactive(@Nonnull Radioactivity radioactivity) {
+    public static @Nonnull String radioactive(@Nonnull Radioactivity radioactivity) {
         return radioactivity.getLore();
     }
 
-    @Nonnull
-    public static String machine(@Nonnull MachineTier tier, @Nonnull MachineType type) {
+    public static @Nonnull String machine(@Nonnull MachineTier tier, @Nonnull MachineType type) {
         return tier + " " + type;
     }
 
-    @Nonnull
-    public static String speed(float speed) {
+    public static @Nonnull String speed(float speed) {
         return "&8\u21E8 &b\u26A1 &7Speed: &b" + speed + 'x';
     }
 
-    @Nonnull
-    public static String powerBuffer(int power) {
+    public static @Nonnull String powerBuffer(int power) {
         return power(power, " Buffer");
     }
 
-    @Nonnull
-    public static String powerPerSecond(int power) {
+    public static @Nonnull String powerPerSecond(int power) {
         return power(power, "/s");
     }
 
-    @Nonnull
-    public static String power(int power, @Nonnull String suffix) {
+    public static @Nonnull String power(int power, @Nonnull String suffix) {
         return "&8\u21E8 &e\u26A1 &7" + power + " J" + suffix;
     }
 
-    @Nonnull
-    public static String powerCharged(int charge, int capacity) {
+    public static @Nonnull String powerCharged(int charge, int capacity) {
         return "&8\u21E8 &e\u26A1 &7" + charge + " / " + capacity + " J";
     }
 
-    @Nonnull
-    public static String material(@Nonnull String material) {
+    public static @Nonnull String material(@Nonnull String material) {
         return "&8\u21E8 &7Material: &b" + material;
     }
 
-    @Nonnull
-    public static String hunger(double value) {
+    public static @Nonnull String hunger(double value) {
         return "&7&oRestores &b&o" + hungerFormat.format(value) + " &7&oHunger";
     }
 
-    @Nonnull
-    public static String range(int blocks) {
+    public static @Nonnull String range(int blocks) {
         return "&7Range: &c" + blocks + " blocks";
     }
 
-    @Nonnull
-    public static String usesLeft(int usesLeft) {
+    public static @Nonnull String usesLeft(int usesLeft) {
         return "&e" + usesLeft + ' ' + (usesLeft > 1 ? "Uses" : "Use") + " &7left";
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
@@ -10,6 +10,7 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.MachineTier;
 import io.github.thebusybiscuit.slimefun4.core.attributes.MachineType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactivity;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.items.LimitedUseItem;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 /**
@@ -74,7 +75,7 @@ public final class LoreBuilder {
     }
 
     public static @Nonnull String usesLeft(int usesLeft) {
-        return "&e" + usesLeft + " Uses &7left";
+        return "&e" + usesLeft + " " + LimitedUseItem.USES_LEFT_SUFFIX;
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/LoreBuilder.java
@@ -10,7 +10,6 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.MachineTier;
 import io.github.thebusybiscuit.slimefun4.core.attributes.MachineType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactivity;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
-import io.github.thebusybiscuit.slimefun4.implementation.items.LimitedUseItem;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 /**
@@ -75,7 +74,7 @@ public final class LoreBuilder {
     }
 
     public static @Nonnull String usesLeft(int usesLeft) {
-        return "&e" + usesLeft + " " + LimitedUseItem.USES_LEFT_SUFFIX;
+        return "&e" + usesLeft + ' ' + (usesLeft > 1 ? "Uses" : "Use") + " &7left";
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
@@ -36,6 +36,6 @@ public final class PatternUtils {
     public static final Pattern MINECRAFT_TAG = Pattern.compile("#minecraft:[a-z_]+");
     public static final Pattern SLIMEFUN_TAG = Pattern.compile("#slimefun:[a-z_]+");
 
-    public static final Pattern USES_LEFT_LORE = Pattern.compile(ChatColors.color("&e[0-9]+ Use[s]* &7left"));
+    public static final Pattern USES_LEFT_LORE = Pattern.compile(ChatColors.color("&e[0-9]+ Uses? &7left"));
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
@@ -2,8 +2,6 @@ package io.github.thebusybiscuit.slimefun4.utils;
 
 import java.util.regex.Pattern;
 
-import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
-
 /**
  * This class is created for common-use patterns used in things such as {@link String#split(String)}. <br>
  * Every time something like {@link String#split(String)} is called it will compile a {@link Pattern},
@@ -34,7 +32,5 @@ public final class PatternUtils {
     public static final Pattern MINECRAFT_MATERIAL = Pattern.compile("minecraft:[a-z_]+");
     public static final Pattern MINECRAFT_TAG = Pattern.compile("#minecraft:[a-z_]+");
     public static final Pattern SLIMEFUN_TAG = Pattern.compile("#slimefun:[a-z_]+");
-
-    public static final Pattern USES_LEFT_LORE = Pattern.compile(ChatColors.color("&e[0-9]+ Uses &7left"));
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
@@ -2,6 +2,8 @@ package io.github.thebusybiscuit.slimefun4.utils;
 
 import java.util.regex.Pattern;
 
+import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
+
 /**
  * This class is created for common-use patterns used in things such as {@link String#split(String)}. <br>
  * Every time something like {@link String#split(String)} is called it will compile a {@link Pattern},
@@ -14,7 +16,8 @@ import java.util.regex.Pattern;
  */
 public final class PatternUtils {
 
-    private PatternUtils() {}
+    private PatternUtils() {
+    }
 
     public static final Pattern COLON = Pattern.compile(":");
     public static final Pattern SEMICOLON = Pattern.compile(";");
@@ -32,4 +35,7 @@ public final class PatternUtils {
     public static final Pattern MINECRAFT_MATERIAL = Pattern.compile("minecraft:[a-z_]+");
     public static final Pattern MINECRAFT_TAG = Pattern.compile("#minecraft:[a-z_]+");
     public static final Pattern SLIMEFUN_TAG = Pattern.compile("#slimefun:[a-z_]+");
+
+    public static final Pattern USES_LEFT_LORE = Pattern.compile(ChatColors.color("&e[0-9]+ Use[s]* &7left"));
+
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
@@ -2,6 +2,8 @@ package io.github.thebusybiscuit.slimefun4.utils;
 
 import java.util.regex.Pattern;
 
+import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
+
 /**
  * This class is created for common-use patterns used in things such as {@link String#split(String)}. <br>
  * Every time something like {@link String#split(String)} is called it will compile a {@link Pattern},
@@ -32,4 +34,7 @@ public final class PatternUtils {
     public static final Pattern MINECRAFT_MATERIAL = Pattern.compile("minecraft:[a-z_]+");
     public static final Pattern MINECRAFT_TAG = Pattern.compile("#minecraft:[a-z_]+");
     public static final Pattern SLIMEFUN_TAG = Pattern.compile("#slimefun:[a-z_]+");
+
+    public static final Pattern USES_LEFT_LORE = Pattern.compile(ChatColors.color("&e[0-9]+ Uses &7left"));
+
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
@@ -32,5 +32,4 @@ public final class PatternUtils {
     public static final Pattern MINECRAFT_MATERIAL = Pattern.compile("minecraft:[a-z_]+");
     public static final Pattern MINECRAFT_TAG = Pattern.compile("#minecraft:[a-z_]+");
     public static final Pattern SLIMEFUN_TAG = Pattern.compile("#slimefun:[a-z_]+");
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/PatternUtils.java
@@ -16,8 +16,7 @@ import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
  */
 public final class PatternUtils {
 
-    private PatternUtils() {
-    }
+    private PatternUtils() {}
 
     public static final Pattern COLON = Pattern.compile(":");
     public static final Pattern SEMICOLON = Pattern.compile(";");


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This change makes it easier for Slimefun or Slimefun addon devs to create items with a limited number of uses.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add LimitedUseItem - base class for items with limited uses
Update StormStaff to extend LimitedUseItem
Add 'usesLeft' function to LoreBuilder

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
none

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
