### PR TITLE
Changed ProtectionType from Enum to Class

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -477,7 +477,7 @@ public class PlayerProfile {
                 }
 
                 for (ProtectionType protectionType : protectedArmor.getProtectionTypes()) {
-                    if (protectionType == type) {
+                    if (protectionType.equals(type)) {
                         if (setId == null) {
                             return true;
                         } else if (setId.equals(protectedArmor.getArmorSetId())) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/ProtectionType.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/ProtectionType.java
@@ -12,21 +12,22 @@ import org.bukkit.entity.Bee;
  * @see ProtectiveArmor
  *
  */
-public enum ProtectionType {
+@SuppressWarnings("InstantiationOfUtilityClass")
+public final class ProtectionType {
 
     /**
      * This damage type represents damage inflicted by {@link Radioactive} materials.
      */
-    RADIATION,
+    public static final ProtectionType RADIATION = new ProtectionType();
 
     /**
      * This damage type represents damage caused by a {@link Bee}
      */
-    BEES,
+    public static final ProtectionType BEES = new ProtectionType();
 
     /**
      * This damage type represents damage caused by flying into a wall with an elytra
      */
-    FLYING_INTO_WALL;
+    public static final ProtectionType FLYING_INTO_WALL = new ProtectionType();
 
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Changed ProtectionType from enum to class so that addons can add their own. I haven't tested but I've checked out the bytecode and it appears that enum constants and fields are accessed the same way, so it shouldn't break anything.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Changed ProtectionType from an enum to a class

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
