### PR TITLE
Fix disappearing items with output chest by machines

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemSpawnReason.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemSpawnReason.java
@@ -5,6 +5,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunItemSpawnEvent;
 import io.github.thebusybiscuit.slimefun4.core.networks.cargo.CargoNet;
+import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientPedestal;
 import io.github.thebusybiscuit.slimefun4.implementation.items.seasonal.ChristmasPresent;
 import io.github.thebusybiscuit.slimefun4.implementation.items.seasonal.EasterEgg;
@@ -39,12 +40,18 @@ public enum ItemSpawnReason {
     CARGO_OVERFLOW,
 
     /**
-     * THe {@link ItemStack} is dropped as the result of an opened {@link ChristmasPresent}.
+     * The {@link ItemStack} is dropped as the result of a {@link MultiBlockMachine}
+     * overflowing.
+     */
+    MULTIBLOCK_MACHINE_OVERFLOW,
+
+    /**
+     * The {@link ItemStack} is dropped as the result of an opened {@link ChristmasPresent}.
      */
     CHRISTMAS_PRESENT_OPENED,
 
     /**
-     * THe {@link ItemStack} is dropped as the result of an opened {@link EasterEgg}.
+     * The {@link ItemStack} is dropped as the result of an opened {@link EasterEgg}.
      */
     EASTER_EGG_OPENED,
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -178,20 +178,18 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
      *          A crafted {@link ItemStack} from {@link MultiBlockMachine}
      * @param block
      *          Main {@link Block} of our {@link Container} from {@link MultiBlockMachine}
+     * @param blockInv
+     *          The {@link Inventory} of our {@link Container}
      *
      */
     @ParametersAreNonnullByDefault
-    protected void handleCraftedItem(ItemStack outputItem, Block block) {
-        BlockState state = PaperLib.getBlockState(block, false).getState();
-        Validate.isTrue(state instanceof Container);
-        Container container = (Container) state;
-        Inventory containerInv = container.getInventory();
-        Inventory outputInv = findOutputInventory(outputItem, block, containerInv);
+    protected void handleCraftedItem(ItemStack outputItem, Block block, Inventory blockInv) {
+        Inventory outputInv = findOutputInventory(outputItem, block, blockInv);
 
         if (outputInv != null) {
             outputInv.addItem(outputItem);
-        } else if (InvUtils.fits(containerInv, outputItem)) {
-            containerInv.addItem(outputItem);
+        } else if (InvUtils.fits(blockInv, outputItem)) {
+            blockInv.addItem(outputItem);
         } else {
             // fallback
             SlimefunUtils.spawnItem(block.getLocation(), outputItem, ItemSpawnReason.MULTIBLOCK_MACHINE_OVERFLOW, true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -185,11 +185,13 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
 
         if (outputInv != null) {
             outputInv.addItem(outputItem);
-        } else if (InvUtils.fits(blockInv, outputItem)) {
-            blockInv.addItem(outputItem);
         } else {
-            // fallback
-            SlimefunUtils.spawnItem(block.getLocation(), outputItem, ItemSpawnReason.MULTIBLOCK_MACHINE_OVERFLOW, true);
+            ItemStack rest = blockInv.addItem(outputItem).get(0);
+
+            // fallback: drop item
+            if (rest != null) {
+                SlimefunUtils.spawnItem(block.getLocation(), rest, ItemSpawnReason.MULTIBLOCK_MACHINE_OVERFLOW, true);
+            }
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -14,7 +14,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.type.Dispenser;
+import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -162,6 +162,29 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
             return dispInv;
         } else {
             return outputChest.orElse(null);
+        }
+    }
+
+    /**
+     * This method handles a output {@link ItemStack} from the {@link MultiBlockMachine} which has a crafting delay
+     *
+     * @param outputItem
+     *          A crafted {@link ItemStack} from {@link MultiBlockMachine}
+     * @param dispenser
+     *          Our {@link Dispenser} from {@link MultiBlockMachine}
+     *
+     */
+    protected void handleCraftedItem(ItemStack outputItem, Dispenser dispenser) {
+        Inventory dispInv = dispenser.getInventory();
+        Inventory outputInv = findOutputInventory(outputItem, dispenser.getBlock(), dispInv);
+
+        if (outputInv != null) {
+            outputInv.addItem(outputItem);
+        } else if (InvUtils.fits(dispInv, outputItem)) {
+            dispInv.addItem(outputItem);
+        } else {
+            // fallback
+            dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), outputItem);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -14,7 +14,6 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
@@ -31,8 +30,6 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.MultiBlockInteractionHan
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.OutputChest;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-
-import io.papermc.lib.PaperLib;
 
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -172,7 +172,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
      * @param outputItem
      *          A crafted {@link ItemStack} from {@link MultiBlockMachine}
      * @param container
-     *          Our {@link Container} from {@link MultiBlockMachine}
+     *          Our main {@link Container} from {@link MultiBlockMachine}
      *
      */
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -14,6 +14,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.Container;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -170,21 +171,21 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
      *
      * @param outputItem
      *          A crafted {@link ItemStack} from {@link MultiBlockMachine}
-     * @param dispenser
-     *          Our {@link Dispenser} from {@link MultiBlockMachine}
+     * @param container
+     *          Our {@link Container} from {@link MultiBlockMachine}
      *
      */
-    protected void handleCraftedItem(ItemStack outputItem, Dispenser dispenser) {
-        Inventory dispInv = dispenser.getInventory();
-        Inventory outputInv = findOutputInventory(outputItem, dispenser.getBlock(), dispInv);
+    protected void handleCraftedItem(ItemStack outputItem, Container container) {
+        Inventory containerInv = container.getInventory();
+        Inventory outputInv = findOutputInventory(outputItem, container.getBlock(), containerInv);
 
         if (outputInv != null) {
             outputInv.addItem(outputItem);
-        } else if (InvUtils.fits(dispInv, outputItem)) {
-            dispInv.addItem(outputItem);
+        } else if (InvUtils.fits(containerInv, outputItem)) {
+            containerInv.addItem(outputItem);
         } else {
             // fallback
-            dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), outputItem);
+            container.getWorld().dropItemNaturally(container.getLocation(), outputItem);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -175,6 +175,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
      *          Our {@link Container} from {@link MultiBlockMachine}
      *
      */
+    @ParametersAreNonnullByDefault
     protected void handleCraftedItem(ItemStack outputItem, Container container) {
         Inventory containerInv = container.getInventory();
         Inventory outputInv = findOutputInventory(outputItem, container.getBlock(), containerInv);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -169,7 +169,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     }
 
     /**
-     * This method handles a output {@link ItemStack} from the {@link MultiBlockMachine} which has a crafting delay
+     * This method handles an output {@link ItemStack} from the {@link MultiBlockMachine} which has a crafting delay
      *
      * @param outputItem
      *          A crafted {@link ItemStack} from {@link MultiBlockMachine}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -9,8 +9,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -25,11 +23,13 @@ import org.bukkit.inventory.ItemStack;
 import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.core.handlers.MultiBlockInteractionHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.OutputChest;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -14,6 +14,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
@@ -30,6 +31,8 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.MultiBlockInteractionHan
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.OutputChest;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+
+import io.papermc.lib.PaperLib;
 
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
@@ -173,14 +176,17 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
      *
      * @param outputItem
      *          A crafted {@link ItemStack} from {@link MultiBlockMachine}
-     * @param container
-     *          Our main {@link Container} from {@link MultiBlockMachine}
+     * @param block
+     *          Main {@link Block} of our {@link Container} from {@link MultiBlockMachine}
      *
      */
     @ParametersAreNonnullByDefault
-    protected void handleCraftedItem(ItemStack outputItem, Container container) {
+    protected void handleCraftedItem(ItemStack outputItem, Block block) {
+        BlockState state = PaperLib.getBlockState(block, false).getState();
+        Validate.isTrue(state instanceof Container);
+        Container container = (Container) state;
         Inventory containerInv = container.getInventory();
-        Inventory outputInv = findOutputInventory(outputItem, container.getBlock(), containerInv);
+        Inventory outputInv = findOutputInventory(outputItem, block, containerInv);
 
         if (outputInv != null) {
             outputInv.addItem(outputItem);
@@ -188,7 +194,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
             containerInv.addItem(outputItem);
         } else {
             // fallback
-            SlimefunUtils.spawnItem(container.getLocation(), outputItem, ItemSpawnReason.MULTIBLOCK_MACHINE_OVERFLOW, true);
+            SlimefunUtils.spawnItem(block.getLocation(), outputItem, ItemSpawnReason.MULTIBLOCK_MACHINE_OVERFLOW, true);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -186,7 +188,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
             containerInv.addItem(outputItem);
         } else {
             // fallback
-            container.getWorld().dropItemNaturally(container.getLocation(), outputItem);
+            SlimefunUtils.spawnItem(container.getLocation(), outputItem, ItemSpawnReason.MULTIBLOCK_MACHINE_OVERFLOW, true);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -90,16 +90,17 @@ public class ArmorForge extends AbstractCraftingTable {
                 SlimefunPlugin.runSync(() -> {
                     if (current < 3) {
                         p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
-                    } else if (InvUtils.fits(outputInv, output)) {
-                        p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                        outputInv.addItem(output);
-                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                        p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                        dispenser.getInventory().addItem(output);
                     } else {
-                        // fallback
+                        Inventory outputInv2 = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
                         p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                        if (outputInv2 != null) {
+                            outputInv2.addItem(output);
+                        } else if (InvUtils.fits(dispenser.getInventory(), output)) {
+                            dispenser.getInventory().addItem(output);
+                        } else {
+                            // fallback
+                            dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                        }
                     }
                 }, j * 20L);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -91,17 +91,8 @@ public class ArmorForge extends AbstractCraftingTable {
                     if (current < 3) {
                         p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
                     } else {
-                        Inventory dispInv = dispenser.getInventory();
-                        Inventory outputInv2 = findOutputInventory(output, dispenser.getBlock(), dispInv);
                         p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                        if (outputInv2 != null) {
-                            outputInv2.addItem(output);
-                        } else if (InvUtils.fits(dispInv, output)) {
-                            dispInv.addItem(output);
-                        } else {
-                            // fallback
-                            dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
-                        }
+                        handleCraftedItem(output, dispenser);
                     }
                 }, j * 20L);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -91,12 +91,13 @@ public class ArmorForge extends AbstractCraftingTable {
                     if (current < 3) {
                         p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
                     } else {
-                        Inventory outputInv2 = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
+                        Inventory dispInv = dispenser.getInventory();
+                        Inventory outputInv2 = findOutputInventory(output, dispenser.getBlock(), dispInv);
                         p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                         if (outputInv2 != null) {
                             outputInv2.addItem(output);
-                        } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                            dispenser.getInventory().addItem(output);
+                        } else if (InvUtils.fits(dispInv, output)) {
+                            dispInv.addItem(output);
                         } else {
                             // fallback
                             dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -91,7 +91,7 @@ public class ArmorForge extends AbstractCraftingTable {
                         p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
                     } else {
                         p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                        handleCraftedItem(output, dispenser);
+                        handleCraftedItem(output, dispenser, inv);
                     }
                 }, j * 20L);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -44,7 +44,7 @@ public class ArmorForge extends AbstractCraftingTable {
                     ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
 
                     if (SlimefunUtils.canPlayerUseItem(p, output, true)) {
-                        craft(p, output, inv, disp);
+                        craft(p, output, inv, dispenser);
                     }
 
                     return;
@@ -70,9 +70,9 @@ public class ArmorForge extends AbstractCraftingTable {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, ItemStack output, Inventory inv, Dispenser dispenser) {
+    private void craft(Player p, ItemStack output, Inventory inv, Block dispenser) {
         Inventory fakeInv = createVirtualInventory(inv);
-        Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), inv, fakeInv);
+        Inventory outputInv = findOutputInventory(output, dispenser, inv, fakeInv);
 
         if (outputInv != null) {
             for (int j = 0; j < 9; j++) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -16,6 +15,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
+import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
-import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -44,7 +45,7 @@ public class ArmorForge extends AbstractCraftingTable {
                     ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
 
                     if (SlimefunUtils.canPlayerUseItem(p, output, true)) {
-                        craft(p, output, inv, dispenser);
+                        craft(p, output, inv, disp);
                     }
 
                     return;
@@ -70,9 +71,9 @@ public class ArmorForge extends AbstractCraftingTable {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, ItemStack output, Inventory inv, Block dispenser) {
+    private void craft(Player p, ItemStack output, Inventory inv, Dispenser dispenser) {
         Inventory fakeInv = createVirtualInventory(inv);
-        Inventory outputInv = findOutputInventory(output, dispenser, inv, fakeInv);
+        Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), inv, fakeInv);
 
         if (outputInv != null) {
             for (int j = 0; j < 9; j++) {
@@ -89,9 +90,16 @@ public class ArmorForge extends AbstractCraftingTable {
                 SlimefunPlugin.runSync(() -> {
                     if (current < 3) {
                         p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
-                    } else {
+                    } else if (InvUtils.fits(outputInv, output)) {
                         p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                         outputInv.addItem(output);
+                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
+                        p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+                        dispenser.getInventory().addItem(output);
+                    } else {
+                        // fallback
+                        p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
                     }
                 }, j * 20L);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -16,7 +16,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
-import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -17,6 +16,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
+import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
@@ -87,6 +87,7 @@ public class Compressor extends MultiBlockMachine {
         }
     }
 
+    @ParametersAreNonnullByDefault
     private void craft(Player p, ItemStack output, Inventory outputInv, Dispenser dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -96,12 +96,13 @@ public class Compressor extends MultiBlockMachine {
                 if (j < 3) {
                     p.getWorld().playSound(p.getLocation(), j == 1 ? Sound.BLOCK_PISTON_CONTRACT : Sound.BLOCK_PISTON_EXTEND, 1F, j == 0 ? 1F : 2F);
                 } else {
-                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
+                    Inventory dispInv = dispenser.getInventory();
+                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispInv);
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                     if (outputInv != null) {
                         outputInv.addItem(output);
-                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                        dispenser.getInventory().addItem(output);
+                    } else if (InvUtils.fits(dispInv, output)) {
+                        dispInv.addItem(output);
                     } else {
                         // fallback
                         dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -72,7 +73,7 @@ public class Compressor extends MultiBlockMachine {
                             removing.setAmount(recipeInput.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, output, outputInv);
+                            craft(p, output, outputInv, disp);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -86,16 +87,23 @@ public class Compressor extends MultiBlockMachine {
         }
     }
 
-    private void craft(Player p, ItemStack output, Inventory outputInv) {
+    private void craft(Player p, ItemStack output, Inventory outputInv, Dispenser dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 
             SlimefunPlugin.runSync(() -> {
                 if (j < 3) {
                     p.getWorld().playSound(p.getLocation(), j == 1 ? Sound.BLOCK_PISTON_CONTRACT : Sound.BLOCK_PISTON_EXTEND, 1F, j == 0 ? 1F : 2F);
-                } else {
+                } else if (InvUtils.fits(outputInv, output)) {
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                     outputInv.addItem(output);
+                } else if (InvUtils.fits(dispenser.getInventory(), output)) {
+                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+                    dispenser.getInventory().addItem(output);
+                } else {
+                    // fallback
+                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+                    dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -96,17 +96,8 @@ public class Compressor extends MultiBlockMachine {
                 if (j < 3) {
                     p.getWorld().playSound(p.getLocation(), j == 1 ? Sound.BLOCK_PISTON_CONTRACT : Sound.BLOCK_PISTON_EXTEND, 1F, j == 0 ? 1F : 2F);
                 } else {
-                    Inventory dispInv = dispenser.getInventory();
-                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispInv);
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    if (outputInv != null) {
-                        outputInv.addItem(output);
-                    } else if (InvUtils.fits(dispInv, output)) {
-                        dispInv.addItem(output);
-                    } else {
-                        // fallback
-                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
-                    }
+                    handleCraftedItem(output, dispenser);
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -73,7 +73,7 @@ public class Compressor extends MultiBlockMachine {
                             removing.setAmount(recipeInput.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, output, outputInv, disp);
+                            craft(p, output, disp);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -88,23 +88,24 @@ public class Compressor extends MultiBlockMachine {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, ItemStack output, Inventory outputInv, Dispenser dispenser) {
+    private void craft(Player p, ItemStack output, Dispenser dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 
             SlimefunPlugin.runSync(() -> {
                 if (j < 3) {
                     p.getWorld().playSound(p.getLocation(), j == 1 ? Sound.BLOCK_PISTON_CONTRACT : Sound.BLOCK_PISTON_EXTEND, 1F, j == 0 ? 1F : 2F);
-                } else if (InvUtils.fits(outputInv, output)) {
-                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    outputInv.addItem(output);
-                } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    dispenser.getInventory().addItem(output);
                 } else {
-                    // fallback
+                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                    if (outputInv != null) {
+                        outputInv.addItem(output);
+                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
+                        dispenser.getInventory().addItem(output);
+                    } else {
+                        // fallback
+                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                    }
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -72,7 +72,7 @@ public class Compressor extends MultiBlockMachine {
                             removing.setAmount(recipeInput.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, output, disp);
+                            craft(p, output, dispBlock);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -87,7 +87,7 @@ public class Compressor extends MultiBlockMachine {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, ItemStack output, Dispenser dispenser) {
+    private void craft(Player p, ItemStack output, Block dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -72,7 +72,7 @@ public class Compressor extends MultiBlockMachine {
                             removing.setAmount(recipeInput.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, output, dispBlock);
+                            craft(p, output, dispBlock, inv);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -87,7 +87,7 @@ public class Compressor extends MultiBlockMachine {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, ItemStack output, Block dispenser) {
+    private void craft(Player p, ItemStack output, Block dispenser, Inventory dispInv) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 
@@ -96,7 +96,7 @@ public class Compressor extends MultiBlockMachine {
                     p.getWorld().playSound(p.getLocation(), j == 1 ? Sound.BLOCK_PISTON_CONTRACT : Sound.BLOCK_PISTON_EXTEND, 1F, j == 0 ? 1F : 2F);
                 } else {
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    handleCraftedItem(output, dispenser);
+                    handleCraftedItem(output, dispenser, dispInv);
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -90,13 +90,13 @@ public class MagicWorkbench extends AbstractCraftingTable {
                 }
             }
 
-            startAnimation(p, b, dispenser, output);
+            startAnimation(p, b, inv, dispenser, output);
         } else {
             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
         }
     }
 
-    private void startAnimation(Player p, Block b, Block dispenser, ItemStack output) {
+    private void startAnimation(Player p, Block b, Inventory dispInv, Block dispenser, ItemStack output) {
         for (int j = 0; j < 4; j++) {
             int current = j;
             SlimefunPlugin.runSync(() -> {
@@ -107,7 +107,7 @@ public class MagicWorkbench extends AbstractCraftingTable {
                     p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1F, 1F);
                 } else {
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    handleCraftedItem(output, dispenser);
+                    handleCraftedItem(output, dispenser, dispInv);
                 }
             }, j * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -106,17 +106,8 @@ public class MagicWorkbench extends AbstractCraftingTable {
                 if (current < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1F, 1F);
                 } else {
-                    Inventory dispInv = dispenser.getInventory();
-                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispInv);
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    if (outputInv != null) {
-                        outputInv.addItem(output);
-                    } else if (InvUtils.fits(dispInv, output)) {
-                        dispInv.addItem(output);
-                    } else {
-                        // fallback
-                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
-                    }
+                    handleCraftedItem(output, dispenser);
                 }
             }, j * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -17,6 +16,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
+import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
@@ -69,6 +69,7 @@ public class MagicWorkbench extends AbstractCraftingTable {
         }
     }
 
+    @ParametersAreNonnullByDefault
     private void craft(Inventory inv, Dispenser dispenser, Player p, Block b, ItemStack output) {
         Inventory fakeInv = createVirtualInventory(inv);
         Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), inv, fakeInv);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -106,12 +106,13 @@ public class MagicWorkbench extends AbstractCraftingTable {
                 if (current < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1F, 1F);
                 } else {
-                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
+                    Inventory dispInv = dispenser.getInventory();
+                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispInv);
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                     if (outputInv != null) {
                         outputInv.addItem(output);
-                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                        dispenser.getInventory().addItem(output);
+                    } else if (InvUtils.fits(dispInv, output)) {
+                        dispInv.addItem(output);
                     } else {
                         // fallback
                         dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -91,31 +91,31 @@ public class MagicWorkbench extends AbstractCraftingTable {
                 }
             }
 
-            startAnimation(p, b, outputInv, output, dispenser);
+            startAnimation(p, b, output, dispenser);
         } else {
             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
         }
     }
 
-    private void startAnimation(Player p, Block b, Inventory inv, ItemStack output, Dispenser dispenser) {
+    private void startAnimation(Player p, Block b, ItemStack output, Dispenser dispenser) {
         for (int j = 0; j < 4; j++) {
             int current = j;
             SlimefunPlugin.runSync(() -> {
                 p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-
                 if (current < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1F, 1F);
-                } else if (InvUtils.fits(inv, output)) {
-                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    inv.addItem(output);
-                } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    dispenser.getInventory().addItem(output);
                 } else {
-                    // fallback
+                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                    if (outputInv != null) {
+                        outputInv.addItem(output);
+                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
+                        dispenser.getInventory().addItem(output);
+                    } else {
+                        // fallback
+                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                    }
                 }
             }, j * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -16,7 +16,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
-import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -53,7 +53,7 @@ public class MagicWorkbench extends AbstractCraftingTable {
                     ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
 
                     if (SlimefunUtils.canPlayerUseItem(p, output, true)) {
-                        craft(inv, disp, p, b, output);
+                        craft(inv, dispenser, p, b, output);
                     }
 
                     return;
@@ -69,9 +69,9 @@ public class MagicWorkbench extends AbstractCraftingTable {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Inventory inv, Dispenser dispenser, Player p, Block b, ItemStack output) {
+    private void craft(Inventory inv, Block dispenser, Player p, Block b, ItemStack output) {
         Inventory fakeInv = createVirtualInventory(inv);
-        Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), inv, fakeInv);
+        Inventory outputInv = findOutputInventory(output, dispenser, inv, fakeInv);
 
         if (outputInv != null) {
             SlimefunItem sfItem = SlimefunItem.getByItem(output);
@@ -90,18 +90,19 @@ public class MagicWorkbench extends AbstractCraftingTable {
                 }
             }
 
-            startAnimation(p, b, output, dispenser);
+            startAnimation(p, b, dispenser, output);
         } else {
             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
         }
     }
 
-    private void startAnimation(Player p, Block b, ItemStack output, Dispenser dispenser) {
+    private void startAnimation(Player p, Block b, Block dispenser, ItemStack output) {
         for (int j = 0; j < 4; j++) {
             int current = j;
             SlimefunPlugin.runSync(() -> {
                 p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
+
                 if (current < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1F, 1F);
                 } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -85,17 +85,8 @@ public class PressureChamber extends MultiBlockMachine {
                 if (j < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1F, 1F);
                 } else {
-                    Inventory dispInv = dispenser.getInventory();
-                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispInv);
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    if (outputInv != null) {
-                        outputInv.addItem(output);
-                    } else if (InvUtils.fits(dispInv, output)) {
-                        dispInv.addItem(output);
-                    } else {
-                        // fallback
-                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
-                    }
+                    handleCraftedItem(output, dispenser);
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -57,7 +57,7 @@ public class PressureChamber extends MultiBlockMachine {
                             removing.setAmount(convert.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, b, output, dispBlock);
+                            craft(p, b, output, inv, dispBlock);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -71,7 +71,7 @@ public class PressureChamber extends MultiBlockMachine {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, Block b, ItemStack output, Block dispenser) {
+    private void craft(Player p, Block b, ItemStack output, Inventory dispInv, Block dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 
@@ -85,7 +85,7 @@ public class PressureChamber extends MultiBlockMachine {
                     p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1F, 1F);
                 } else {
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    handleCraftedItem(output, dispenser);
+                    handleCraftedItem(output, dispenser, dispInv);
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -17,7 +17,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
-import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -70,6 +70,7 @@ public class PressureChamber extends MultiBlockMachine {
             SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
         }
     }
+
     @ParametersAreNonnullByDefault
     private void craft(Player p, Block b, ItemStack output, Inventory outputInv, Dispenser dispenser) {
         for (int i = 0; i < 4; i++) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -58,7 +58,7 @@ public class PressureChamber extends MultiBlockMachine {
                             removing.setAmount(convert.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, b, output, outputInv, disp);
+                            craft(p, b, output, disp);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -72,7 +72,7 @@ public class PressureChamber extends MultiBlockMachine {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, Block b, ItemStack output, Inventory outputInv, Dispenser dispenser) {
+    private void craft(Player p, Block b, ItemStack output, Dispenser dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 
@@ -84,16 +84,17 @@ public class PressureChamber extends MultiBlockMachine {
 
                 if (j < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1F, 1F);
-                } else if (InvUtils.fits(outputInv, output)) {
-                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    outputInv.addItem(output);
-                } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    dispenser.getInventory().addItem(output);
                 } else {
-                    // fallback
+                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-                    dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                    if (outputInv != null) {
+                        outputInv.addItem(output);
+                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
+                        dispenser.getInventory().addItem(output);
+                    } else {
+                        // fallback
+                        dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
+                    }
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -85,12 +85,13 @@ public class PressureChamber extends MultiBlockMachine {
                 if (j < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1F, 1F);
                 } else {
-                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispenser.getInventory());
+                    Inventory dispInv = dispenser.getInventory();
+                    Inventory outputInv = findOutputInventory(output, dispenser.getBlock(), dispInv);
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                     if (outputInv != null) {
                         outputInv.addItem(output);
-                    } else if (InvUtils.fits(dispenser.getInventory(), output)) {
-                        dispenser.getInventory().addItem(output);
+                    } else if (InvUtils.fits(dispInv, output)) {
+                        dispInv.addItem(output);
                     } else {
                         // fallback
                         dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -54,7 +55,7 @@ public class PressureChamber extends MultiBlockMachine {
                             removing.setAmount(convert.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, b, output, outputInv);
+                            craft(p, b, output, outputInv, disp);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -67,7 +68,7 @@ public class PressureChamber extends MultiBlockMachine {
         }
     }
 
-    private void craft(Player p, Block b, ItemStack output, Inventory outputInv) {
+    private void craft(Player p, Block b, ItemStack output, Inventory outputInv, Dispenser dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 
@@ -79,9 +80,16 @@ public class PressureChamber extends MultiBlockMachine {
 
                 if (j < 3) {
                     p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1F, 1F);
-                } else {
+                } else if (InvUtils.fits(outputInv, output)) {
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                     outputInv.addItem(output);
+                } else if (InvUtils.fits(dispenser.getInventory(), output)) {
+                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+                    dispenser.getInventory().addItem(output);
+                } else {
+                    // fallback
+                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+                    dispenser.getWorld().dropItemNaturally(dispenser.getLocation(), output);
                 }
             }, i * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -57,7 +57,7 @@ public class PressureChamber extends MultiBlockMachine {
                             removing.setAmount(convert.getAmount());
                             inv.removeItem(removing);
 
-                            craft(p, b, output, disp);
+                            craft(p, b, output, dispBlock);
                         } else {
                             SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
                         }
@@ -71,7 +71,7 @@ public class PressureChamber extends MultiBlockMachine {
     }
 
     @ParametersAreNonnullByDefault
-    private void craft(Player p, Block b, ItemStack output, Dispenser dispenser) {
+    private void craft(Player p, Block b, ItemStack output, Block dispenser) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 


### PR DESCRIPTION
## Description
This fixes disappearing items with machines connected to almost full output chest.
These machines are: Compressor, Magic Workbench, Armor Forge, Pressure Chamber.

## Proposed changes
Added to `Compressor`, `MagicWorkbench`, `ArmorForge` and `PressureChamber` check if the items can be added to the output chest after crafting.
If items can't be added then item will be added to another output chest (if it exists). And if items can't be added to any output chests then item will be added to dispenser. And if item can't be added to dispenser then the item will drop on the ground.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3136 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
