### PR TITLE
Fix Auto Crafter Empty Slot Check

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -398,11 +398,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
             for (ItemStack matchingItem : inv.getContents()) {
                 // Checks if any item stack that is not full that is the same type as the result.
-                if (
-                        ((!(resultItem instanceof SlimefunItemStack) && resultItem.isSimilar(matchingItem))
-                        || ((resultItem instanceof SlimefunItemStack) && SlimefunUtils.isItemSimilar(matchingItem, resultItem, true)))
-                        && matchingItem.getAmount() < matchingItem.getMaxStackSize()
-                ){
+                if (((!(resultItem instanceof SlimefunItemStack) && resultItem.isSimilar(matchingItem)) || ((resultItem instanceof SlimefunItemStack) && SlimefunUtils.isItemSimilar(matchingItem, resultItem, true))) && matchingItem.getAmount() < matchingItem.getMaxStackSize()){
                     return true;
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -391,6 +392,29 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         return false;
     }
 
+    public boolean inventoryAvailable(@Nonnull Inventory inv, @Nonnull ItemStack resultItem) {
+
+        if(inv.firstEmpty() < 0){
+
+            for (ItemStack matchingItem : inv.getContents()) {
+                // Checks if any item stack that is not full that is the same type as the result.
+                if (
+                        ((!(resultItem instanceof SlimefunItemStack) && resultItem.isSimilar(matchingItem))
+                        || ((resultItem instanceof SlimefunItemStack) && SlimefunUtils.isItemSimilar(matchingItem, resultItem, true)))
+                        && matchingItem.getAmount() < matchingItem.getMaxStackSize()
+                ){
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Returns true if the first empty slot in the inventory is >= 0, which means there is an empty slot.
+        else {
+            return true;
+        }
+    }
+
     /**
      * This method performs a crafting operation.
      * It will attempt to fulfill the provided {@link AbstractRecipe} using
@@ -414,8 +438,8 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
             return false;
         }
 
-        // Check if we have an empty slot
-        if (inv.firstEmpty() != -1) {
+        // Check if the inventory have any available space
+        if (inventoryAvailable(inv, recipe.getResult())) {
             Map<Integer, Integer> itemQuantities = new HashMap<>();
 
             for (Predicate<ItemStack> predicate : recipe.getIngredients()) {


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
There is an empty slot checking bug in the auto crafters. They only check if there is a slot in the chest that is completely empty. But if there is a stack of item in the chest that is not full but same item as the result of the recipe, the auto crafter will stop crafting because it thinks there are no empty slots.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I added a new method in the Abstract Auto Crafter file that checks if there is a stack of item that is the same type if there are no slots that are completely empty.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
