### PR TITLE
Add Amethyst Block -> 4 Amethyst Shard recipe to grindstone

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -79,6 +80,11 @@ public class GrindStone extends MultiBlockMachine {
 
         recipes.add(new ItemStack(Material.QUARTZ_BLOCK));
         recipes.add(new ItemStack(Material.QUARTZ, 4));
+
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
+            recipes.add(new ItemStack(Material.AMETHYST_BLOCK));
+            recipes.add(new ItemStack(Material.AMETHYST_SHARD, 4));
+        }
 
         recipes.add(SlimefunItems.MAGIC_LUMP_2);
         recipes.add(new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 4));


### PR DESCRIPTION
## Description
I made this pull request because I found it logical that you should be able to grind amethyst blocks into amethyst shards, and the idea came to one of my friends while they were playing on 1.17, and they asked me to implement it in some form

## Proposed changes
I have added an Amethyst Block -> 4 Amethyst Shard recipe to the grind stone multiblock

## Related Issues (if applicable)
N/A

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
