### PR TITLE
Auto Crafter Empty Slot Check

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AutoCrafterListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AutoCrafterListener.java
@@ -1,5 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+// This file probably going to be modified in this PR.
+
 import java.util.Optional;
 
 import javax.annotation.Nonnull;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Making auto crafters able to check and craft when there are no empty slots in the chest. I think this is a pretty important feature since it would make automation a lot easier. A while ago I made a pull request (#3149) making the auto crafters check every slot in the chest for any non-full slot with the same item as the result of the recipe. But Biscuit said item comparisons are expensive so that would be laggy.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I'm thinking should I add a new small option in the auto crafter menu that allows the player to choose an "output slot" so only the output slot is checked every tick.

I haven't started coding this yet, so ignore the commits added to this. I just wanna make a draft first to see what people do think about this. I can start coding it if most of us think it's not a bad idea.