### PR TITLE
Smart Filling Mode For Single Stack of Item

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/AbstractItemNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/AbstractItemNetwork.java
@@ -1,5 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.core.networks.cargo;
 
+// This file might will be modified for this PR.
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I'm making this PR draft so I can gather opinions for people to see if this would be an ok feature to be added into the game.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I want to add a new feature to the smart filling mode so that it not only transfers stack of items but also single items when there is only one stack of item. More specifically, when smart filling mode is enabled, it doesn't transfer the whole stack of item if there is only one stack of that type of item in the container. Instead, it will leave one item in the slot and transfer the rest. That reason this feature would be useful is because the one item left in the slot can serve as a filter, so that only that type of item can be put into that slot.