### PR TITLE
Adds deepslate iron, gold, copper ores, and copper ore to Ore Crusher

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -151,6 +151,19 @@ public class OreCrusher extends MultiBlockMachine {
                 new ItemStack(Material.DEEPSLATE_EMERALD_ORE), doubleOres.getEmerald()
             ));
             // @formatter:on
+
+            // More deepslate ores and copper ore
+            displayRecipes.add(new ItemStack(Material.DEEPSLATE_IRON_ORE));
+            displayRecipes.add(new SlimefunItemStack(SlimefunItems.IRON_DUST, isOreDoublingEnabled() ? 2 : 1));
+
+            displayRecipes.add(new ItemStack(Material.DEEPSLATE_GOLD_ORE));
+            displayRecipes.add(new SlimefunItemStack(SlimefunItems.GOLD_DUST, isOreDoublingEnabled() ? 2 : 1));
+
+            displayRecipes.add(new ItemStack(Material.DEEPSLATE_COPPER_ORE));
+            displayRecipes.add(new SlimefunItemStack(SlimefunItems.COPPER_DUST, isOreDoublingEnabled() ? 2 : 1));
+
+            displayRecipes.add(new ItemStack(Material.COPPER_ORE));
+            displayRecipes.add(new SlimefunItemStack(SlimefunItems.COPPER_DUST, isOreDoublingEnabled() ? 2 : 1));
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I suggested adding copper ore and deepslate copper ore to ore crusher in 1.17, but it is not approved yet. I also added deepslate iron and gold ores. This change allows people to crush the ores obtained with Advanced Industrial Miner.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added following recipes to Ore Crusher (supports double-ore option):
deepslate iron ore -> iron dust
deepslate gold ore -> gold dust
deepslate copper ore -> copper dust
copper ore -> copper dust

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
[discord suggestion #1400](https://discord.com/channels/565557184348422174/693130800853418055/859575052173312030)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
