### PR TITLE
Allow the Industrial Miner to produce raw ores rather than ore blocks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -126,22 +126,79 @@ public class IndustrialMiner extends MultiBlockMachine {
 
         Random random = ThreadLocalRandom.current();
 
-        switch (ore) {
-            case COAL_ORE:
-                return new ItemStack(Material.COAL);
-            case DIAMOND_ORE:
-                return new ItemStack(Material.DIAMOND);
-            case EMERALD_ORE:
-                return new ItemStack(Material.EMERALD);
-            case NETHER_QUARTZ_ORE:
-                return new ItemStack(Material.QUARTZ);
-            case REDSTONE_ORE:
-                return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
-            case LAPIS_ORE:
-                return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
-            default:
-                // This includes Iron and Gold ore (and Ancient Debris)
-                return new ItemStack(ore);
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
+            // In 1.17, breaking metal ores should get raw metals. Also support deepslate ores.
+            switch (ore) {
+                case COAL_ORE:
+                case DEEPSLATE_COAL_ORE:
+                    return new ItemStack(Material.COAL);
+                case DIAMOND_ORE:
+                case DEEPSLATE_DIAMOND_ORE:
+                    return new ItemStack(Material.DIAMOND);
+                case EMERALD_ORE:
+                case DEEPSLATE_EMERALD_ORE:
+                    return new ItemStack(Material.EMERALD);
+                case REDSTONE_ORE:
+                case DEEPSLATE_REDSTONE_ORE:
+                    return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
+                case LAPIS_ORE:
+                case DEEPSLATE_LAPIS_ORE:
+                    return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
+                case NETHER_QUARTZ_ORE:
+                    return new ItemStack(Material.QUARTZ);
+                case NETHER_GOLD_ORE:
+                    return new ItemStack(Material.GOLD_NUGGET,2 + random.nextInt(4));
+                case COPPER_ORE:
+                case DEEPSLATE_COPPER_ORE:
+                    return new ItemStack(Material.RAW_COPPER);
+                case IRON_ORE:
+                case DEEPSLATE_IRON_ORE:
+                    return new ItemStack(Material.RAW_IRON);
+                case GOLD_ORE:
+                case DEEPSLATE_GOLD_ORE:
+                    return new ItemStack(Material.RAW_GOLD);
+                default:
+                    return new ItemStack(ore);
+            }
+        } else if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
+            // In 1.16, breaking nether gold ores should get gold nuggets
+            switch (ore) {
+                case COAL_ORE:
+                    return new ItemStack(Material.COAL);
+                case DIAMOND_ORE:
+                    return new ItemStack(Material.DIAMOND);
+                case EMERALD_ORE:
+                    return new ItemStack(Material.EMERALD);
+                case REDSTONE_ORE:
+                    return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
+                case LAPIS_ORE:
+                    return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
+                case NETHER_QUARTZ_ORE:
+                    return new ItemStack(Material.QUARTZ);
+                case NETHER_GOLD_ORE:
+                    return new ItemStack(Material.GOLD_NUGGET,2 + random.nextInt(4));
+                default:
+                    // This includes Iron and Gold ore (and Ancient Debris)
+                    return new ItemStack(ore);
+            }
+        } else {
+            switch (ore) {
+                case COAL_ORE:
+                    return new ItemStack(Material.COAL);
+                case DIAMOND_ORE:
+                    return new ItemStack(Material.DIAMOND);
+                case EMERALD_ORE:
+                    return new ItemStack(Material.EMERALD);
+                case REDSTONE_ORE:
+                    return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
+                case LAPIS_ORE:
+                    return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
+                case NETHER_QUARTZ_ORE:
+                    return new ItemStack(Material.QUARTZ);
+                default:
+                    // This includes Iron and Gold ore (and Ancient Debris)
+                    return new ItemStack(ore);
+            }
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -147,7 +147,7 @@ public class IndustrialMiner extends MultiBlockMachine {
                 case NETHER_QUARTZ_ORE:
                     return new ItemStack(Material.QUARTZ);
                 case NETHER_GOLD_ORE:
-                    return new ItemStack(Material.GOLD_NUGGET,2 + random.nextInt(4));
+                    return new ItemStack(Material.GOLD_NUGGET, 2 + random.nextInt(4));
                 case COPPER_ORE:
                 case DEEPSLATE_COPPER_ORE:
                     return new ItemStack(Material.RAW_COPPER);
@@ -176,7 +176,7 @@ public class IndustrialMiner extends MultiBlockMachine {
                 case NETHER_QUARTZ_ORE:
                     return new ItemStack(Material.QUARTZ);
                 case NETHER_GOLD_ORE:
-                    return new ItemStack(Material.GOLD_NUGGET,2 + random.nextInt(4));
+                    return new ItemStack(Material.GOLD_NUGGET, 2 + random.nextInt(4));
                 default:
                     // This includes Iron and Gold ore (and Ancient Debris)
                     return new ItemStack(ore);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -129,25 +129,16 @@ public class IndustrialMiner extends MultiBlockMachine {
         if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
             // In 1.17, breaking metal ores should get raw metals. Also support deepslate ores.
             switch (ore) {
-                case COAL_ORE:
                 case DEEPSLATE_COAL_ORE:
                     return new ItemStack(Material.COAL);
-                case DIAMOND_ORE:
                 case DEEPSLATE_DIAMOND_ORE:
                     return new ItemStack(Material.DIAMOND);
-                case EMERALD_ORE:
                 case DEEPSLATE_EMERALD_ORE:
                     return new ItemStack(Material.EMERALD);
-                case REDSTONE_ORE:
                 case DEEPSLATE_REDSTONE_ORE:
                     return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
-                case LAPIS_ORE:
                 case DEEPSLATE_LAPIS_ORE:
                     return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
-                case NETHER_QUARTZ_ORE:
-                    return new ItemStack(Material.QUARTZ);
-                case NETHER_GOLD_ORE:
-                    return new ItemStack(Material.GOLD_NUGGET, 2 + random.nextInt(4));
                 case COPPER_ORE:
                 case DEEPSLATE_COPPER_ORE:
                     return new ItemStack(Material.RAW_COPPER);
@@ -157,48 +148,30 @@ public class IndustrialMiner extends MultiBlockMachine {
                 case GOLD_ORE:
                 case DEEPSLATE_GOLD_ORE:
                     return new ItemStack(Material.RAW_GOLD);
-                default:
-                    return new ItemStack(ore);
             }
-        } else if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
+        }
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
             // In 1.16, breaking nether gold ores should get gold nuggets
-            switch (ore) {
-                case COAL_ORE:
-                    return new ItemStack(Material.COAL);
-                case DIAMOND_ORE:
-                    return new ItemStack(Material.DIAMOND);
-                case EMERALD_ORE:
-                    return new ItemStack(Material.EMERALD);
-                case REDSTONE_ORE:
-                    return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
-                case LAPIS_ORE:
-                    return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
-                case NETHER_QUARTZ_ORE:
-                    return new ItemStack(Material.QUARTZ);
-                case NETHER_GOLD_ORE:
-                    return new ItemStack(Material.GOLD_NUGGET, 2 + random.nextInt(4));
-                default:
-                    // This includes Iron and Gold ore (and Ancient Debris)
-                    return new ItemStack(ore);
+            if (ore == Material.NETHER_GOLD_ORE) {
+                return new ItemStack(Material.GOLD_NUGGET, 2 + random.nextInt(4));
             }
-        } else {
-            switch (ore) {
-                case COAL_ORE:
-                    return new ItemStack(Material.COAL);
-                case DIAMOND_ORE:
-                    return new ItemStack(Material.DIAMOND);
-                case EMERALD_ORE:
-                    return new ItemStack(Material.EMERALD);
-                case REDSTONE_ORE:
-                    return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
-                case LAPIS_ORE:
-                    return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
-                case NETHER_QUARTZ_ORE:
-                    return new ItemStack(Material.QUARTZ);
-                default:
-                    // This includes Iron and Gold ore (and Ancient Debris)
-                    return new ItemStack(ore);
-            }
+        }
+
+        switch (ore) {
+            case COAL_ORE:
+                return new ItemStack(Material.COAL);
+            case DIAMOND_ORE:
+                return new ItemStack(Material.DIAMOND);
+            case EMERALD_ORE:
+                return new ItemStack(Material.EMERALD);
+            case REDSTONE_ORE:
+                return new ItemStack(Material.REDSTONE, 4 + random.nextInt(2));
+            case LAPIS_ORE:
+                return new ItemStack(Material.LAPIS_LAZULI, 4 + random.nextInt(4));
+            case NETHER_QUARTZ_ORE:
+                return new ItemStack(Material.QUARTZ);
+            default:
+                return new ItemStack(ore);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -171,6 +171,7 @@ public class IndustrialMiner extends MultiBlockMachine {
             case NETHER_QUARTZ_ORE:
                 return new ItemStack(Material.QUARTZ);
             default:
+                // This includes Iron and Gold ore (and Ancient Debris)
                 return new ItemStack(ore);
         }
     }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
 I suggested that the industrial miner should produce raw metals (iron, gold, and copper) instead of ores in 1.17, but it is not approved yet. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Changed outcomes for industrial miner:
In 1.17, the basic industrial miner will produce raw metals (iron, gold, and copper) instead of metal ores.
In 1.17, the basic industrial miner will mine deepslate ores just like a pickaxe.
In 1.16, the basic industrial miner will produce gold nugget instead of nether gold ore.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
[discord suggestion #1400](https://discord.com/channels/565557184348422174/693130800853418055/859575052173312030)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
