### PR TITLE
Fixes Talisman of anvil break main hand item in special case

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -247,9 +247,9 @@ public class TalismanListener implements Listener {
                 ((Damageable) meta).setDamage(0);
             }
 
-            int itemSlot = slot;
-
             item.setItemMeta(meta);
+
+            int itemSlot = slot;
 
             // Update the item forcefully
             SlimefunPlugin.runSync(() -> inv.setItem(itemSlot, item), 1L);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -223,20 +223,20 @@ public class TalismanListener implements Listener {
     public void onItemBreak(PlayerItemBreakEvent e) {
         if (Talisman.trigger(e, SlimefunItems.TALISMAN_ANVIL)) {
             PlayerInventory inv = e.getPlayer().getInventory();
+
             int slot = inv.getHeldItemSlot();
 
             // Did the tool in our hand break or was it an armor piece?
             if (!e.getBrokenItem().equals(inv.getItemInMainHand())) {
-                for (int s : armorSlots) {
-                    if (e.getBrokenItem().equals(inv.getItem(s))) {
-                        slot = s;
-                        break;
-                    }
-                }
-
-                // Validate broken item is on offhand.
                 if (e.getBrokenItem().equals(inv.getItemInOffHand())) {
                     slot = 40;
+                } else {
+                    for (int s : armorSlots) {
+                        if (e.getBrokenItem().equals(inv.getItem(s))) {
+                            slot = s;
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -247,9 +247,9 @@ public class TalismanListener implements Listener {
                 ((Damageable) meta).setDamage(0);
             }
 
-            item.setItemMeta(meta);
-
             int itemSlot = slot;
+
+            item.setItemMeta(meta);
 
             // Update the item forcefully
             SlimefunPlugin.runSync(() -> inv.setItem(itemSlot, item), 1L);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -224,20 +224,27 @@ public class TalismanListener implements Listener {
         if (Talisman.trigger(e, SlimefunItems.TALISMAN_ANVIL)) {
             PlayerInventory inv = e.getPlayer().getInventory();
 
-            int slot = inv.getHeldItemSlot();
+            ItemStack brokenItem = e.getBrokenItem();
+
+            int slot = -1;
 
             // Did the tool in our hand break or was it an armor piece?
-            if (!e.getBrokenItem().equals(inv.getItemInMainHand())) {
-                if (e.getBrokenItem().equals(inv.getItemInOffHand())) {
-                    slot = 40;
-                } else {
-                    for (int s : armorSlots) {
-                        if (e.getBrokenItem().equals(inv.getItem(s))) {
-                            slot = s;
-                            break;
-                        }
+            if (brokenItem.equals(inv.getItemInMainHand())) {
+                slot = inv.getHeldItemSlot();
+            } else if (brokenItem.equals(inv.getItemInOffHand())) {
+                slot = 40;
+            } else {
+                for (int s : armorSlots) {
+                    if (e.getBrokenItem().equals(inv.getItem(s))) {
+                        slot = s;
+                        break;
                     }
                 }
+            }
+
+            // No item found, just return.
+            if (slot < 0) {
+                return;
             }
 
             ItemStack item = e.getBrokenItem().clone();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -233,6 +233,11 @@ public class TalismanListener implements Listener {
                         break;
                     }
                 }
+
+                // Validate broken item is on offhand.
+                if (e.getBrokenItem().equals(inv.getItemInOffHand())) {
+                    slot = 41;
+                }
             }
 
             ItemStack item = e.getBrokenItem().clone();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -236,7 +236,7 @@ public class TalismanListener implements Listener {
 
                 // Validate broken item is on offhand.
                 if (e.getBrokenItem().equals(inv.getItemInOffHand())) {
-                    slot = 41;
+                    slot = 40;
                 }
             }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
If you hold a shield on offhand, and a sword on mainhand.
Then when shield broken, the shield fixed by talisman anvil will replace mainhand sword.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add validate for offhand slot

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
None

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
