### PR TITLE
Fix unable to get world min height when below 1.16.5

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/WorldUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/WorldUtils.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.papermc.lib.PaperLib;
 import org.apache.commons.lang.Validate;
 import org.bukkit.World;
 
@@ -23,12 +24,19 @@ public final class WorldUtils {
      *
      * @param world
      *            The world of which to get minimum Y in.
-     * 
+     *
      * @return The minimum Y of the given world.
      */
     public static int getMinHeight(@Nonnull World world) {
         Validate.notNull(world, "World cannot be null!");
 
-        return SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16) ? world.getMinHeight() : 0;
+        MinecraftVersion major = SlimefunPlugin.getMinecraftVersion();
+        int patch = PaperLib.getMinecraftPatchVersion();
+
+        if (major.isAtLeast(MinecraftVersion.MINECRAFT_1_17) || major.isMinecraftVersion(16) && patch == 5) {
+            return world.getMinHeight();
+        } else {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Fix unable to get world min height when below 1.16.5
World#getMinHeight() only present in 1.16.5+

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add a check for patch version in WorldUtils

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
