### PR TITLE
Fix pickup delay not being set

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -81,9 +81,11 @@ public final class SlimefunUtils {
      */
     public static void markAsNoPickup(@Nonnull Item item, @Nonnull String context) {
         item.setMetadata(NO_PICKUP_METADATA, new FixedMetadataValue(SlimefunPlugin.instance(), context));
-        // Max the pickup delay - This makes it so no Player can pick up items ever without need for an event
-        // It is also one indication used by third party plugins to know if it's a custom item.
-        // Fixes #3203
+        /*
+         * Max the pickup delay - This makes it so no Player can pick up items ever without need for an event.
+         * It is also an indication used by third-party plugins to know if it's a custom item.
+         * Fixes #3203
+         */
         item.setPickupDelay(Short.MAX_VALUE);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -81,6 +81,11 @@ public final class SlimefunUtils {
      */
     public static void markAsNoPickup(@Nonnull Item item, @Nonnull String context) {
         item.setMetadata(NO_PICKUP_METADATA, new FixedMetadataValue(SlimefunPlugin.instance(), context));
+        // Max the pickup delay - This makes it so no Player can pick up items ever without need for an event
+        // It is also one indication used by third party plugins to know if it's a custom item.
+        // Fixes #3203
+        item.setPickupDelay(Short.MAX_VALUE);
+        SlimefunPlugin.instance().getLogger().info("Set pickup delay");
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -85,7 +85,6 @@ public final class SlimefunUtils {
         // It is also one indication used by third party plugins to know if it's a custom item.
         // Fixes #3203
         item.setPickupDelay(Short.MAX_VALUE);
-        SlimefunPlugin.instance().getLogger().info("Set pickup delay");
     }
 
     /**


### PR DESCRIPTION
## Description
Set a pickup delay of Short.MAX_VALUE (which in the client means "never pickup"). A lot of third-party plugins (including ones like WildStacker) check for this value to know if it's a custom item or if it should be modified/stacked. Setting this prevents a lot of third-party plugins from messing with the items.

## Proposed changes
Set the pickup delay to "never pickup" in the `markAsNoPickup` method.

## Related Issues (if applicable)
Resolves #3203

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
