### PR TITLE
Run maven build on workflows

### DIFF
--- a/.github/workflows/maven-compiler.yml
+++ b/.github/workflows/maven-compiler.yml
@@ -9,6 +9,7 @@ on:
     - 'pom.xml'
   pull_request:
     paths:
+    - '.github/workflows/**'
     - 'src/**'
     - 'pom.xml'
 


### PR DESCRIPTION
## Description
Cookie has this workflow required however it doesn't run on workflows. This means that any dep updates or workflow modifications can never pass all required status checks. Due to this, I cannot merge them in and only Cookie can. This is annoying.

## Proposed changes
Add workflows to maven-compiler.yml

## Related Issues (if applicable)
N/A

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
