### PR TITLE
Fixes #3225 and chunk data not being saved on shutdown

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -216,12 +216,6 @@ public class BlockStorage {
     }
 
     private void loadChunks() {
-        if (chunksLoaded) {
-            return;
-        }
-
-        chunksLoaded = true;
-
         File chunks = new File(PATH_CHUNKS + "chunks.sfc");
 
         if (chunks.exists()) {
@@ -358,6 +352,7 @@ public class BlockStorage {
 
     public void saveAndRemove() {
         save();
+        saveChunks();
         isMarkedForRemoval.set(true);
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -59,7 +59,6 @@ public class BlockStorage {
     private final Map<String, Config> blocksCache = new ConcurrentHashMap<>();
 
     private static int chunkChanges = 0;
-    private static boolean chunksLoaded = false;
     private static boolean universalInventoriesLoaded = false;
 
     private int changes = 0;


### PR DESCRIPTION
## Description
We had a `chunksLoaded` boolean, not sure why this was here but removing it did not cause any unexpected changes. This was being set to true after the first world load and then the second load, it did not load due to this.

We have a world name check so this, in theory, should not be required. If there was a reason which is still valid, we will find out soon and should do a proper fix rather than this.

I also fixed the chunk data not saving on normal shutdown

## Proposed changes
* Remove `chunksLoaded` static boolean
* Run `saveChunks` on `saveAndRemove`

## Related Issues (if applicable)
Fixes #3225

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
