### PR TITLE
Fixes #3206

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
@@ -53,7 +53,7 @@ public class EnhancedCraftingTable extends AbstractCraftingTable {
                 }
             }
 
-            if (inv.isEmpty()) {
+            if (SlimefunUtils.isInventoryEmpty(inv)) {
                 SlimefunPlugin.getLocalization().sendMessage(p, "machines.inventory-empty", true);
             } else {
                 SlimefunPlugin.getLocalization().sendMessage(p, "machines.pattern-not-found", true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -475,4 +475,23 @@ public final class SlimefunUtils {
         return spawnItem(loc, item, reason, false);
     }
 
+    /**
+     * Helper method to check if an Inventory is empty (has no items in "storage"). If the MC version is 1.16 or above
+     * this will call {@link Inventory#isEmpty()} (Which calls MC code resulting in a faster method).
+     *
+     * @param inventory The {@link Inventory} to check.
+     * @return True if the inventory is empty and false otherwise
+     */
+    public static boolean isInventoryEmpty(@Nonnull Inventory inventory) {
+        if (SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
+            return inventory.isEmpty();
+        } else {
+            for (ItemStack is : inventory.getStorageContents()) {
+                if (is != null && !is.getType().isAir()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
## Description
Spigot 1.16 introduced Inventory#isEmpty. Since we support 1.14 and 1.15 we don't want to call this on those versions. This introduces a small util method and fixes a place where Inventory#isEmpty was called.

## Proposed changes
This introduces a small util method and fixes a place where Inventory#isEmpty was called.

## Related Issues (if applicable)
Resolves #3206 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
