### PR TITLE
Rename category -> itemGroup

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/GPSNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/GPSNetwork.java
@@ -158,7 +158,7 @@ public class GPSNetwork {
         menu.addItem(4, new CustomItemStack(SlimefunItems.GPS_CONTROL_PANEL, "&7Network Info", "", "&8\u21E8 &7Status: " + (complexity > 0 ? "&2&lONLINE" : "&4&lOFFLINE"), "&8\u21E8 &7Complexity: &f" + complexity));
         menu.addMenuClickHandler(4, ChestMenuUtils.getEmptyClickHandler());
 
-        menu.addItem(6, new CustomItemStack(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.waypoints"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-category")));
+        menu.addItem(6, new CustomItemStack(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.waypoints"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
         menu.addMenuClickHandler(6, (pl, slot, item, action) -> {
             openWaypointControlPanel(pl);
             return false;
@@ -221,7 +221,7 @@ public class GPSNetwork {
                 menu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
             }
 
-            menu.addItem(2, new CustomItemStack(SlimefunItems.GPS_TRANSMITTER, "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.transmitters"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-category")));
+            menu.addItem(2, new CustomItemStack(SlimefunItems.GPS_TRANSMITTER, "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.transmitters"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
             menu.addMenuClickHandler(2, (pl, slot, item, action) -> {
                 openTransmitterControlPanel(pl);
                 return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -214,7 +214,7 @@ public class ItemGroup implements Keyed {
                 meta.setDisplayName(ChatColor.YELLOW + name);
             }
 
-            meta.setLore(Arrays.asList("", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-category")));
+            meta.setLore(Arrays.asList("", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
         });
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -202,7 +202,7 @@ public class ItemGroup implements Keyed {
     @Nonnull
     public ItemStack getItem(@Nonnull Player p) {
         return new CustomItemStack(item, meta -> {
-            String name = Slimefun.getLocalization().getCategoryName(p, getKey());
+            String name = Slimefun.getLocalization().getItemGroupName(p, getKey());
 
             if (name == null) {
                 name = item.getItemMeta().getDisplayName();
@@ -240,7 +240,7 @@ public class ItemGroup implements Keyed {
      */
     @Nonnull
     public String getDisplayName(@Nonnull Player p) {
-        String localized = Slimefun.getLocalization().getCategoryName(p, getKey());
+        String localized = Slimefun.getLocalization().getItemGroupName(p, getKey());
 
         if (localized != null) {
             return localized;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -500,7 +500,7 @@ public class SlimefunItem implements Placeable {
      * <strong>This method is for internal purposes, like {@link ItemGroup} registration only</strong>
      */
     private final void onEnable() {
-        // Register the Category too if it hasn't been registered yet
+        // Register the ItemGroup too if it hasn't been registered yet
         if (!itemGroup.isRegistered()) {
             itemGroup.register(addon);
         }
@@ -671,16 +671,16 @@ public class SlimefunItem implements Placeable {
     /**
      * This sets the {@link ItemGroup} in which this {@link SlimefunItem} will be displayed.
      * 
-     * @param category
+     * @param itemGroup
      *            The new {@link ItemGroup}
      */
-    public void setItemGroup(@Nonnull ItemGroup category) {
-        Validate.notNull(category, "The Category is not allowed to be null!");
+    public void setItemGroup(@Nonnull ItemGroup itemGroup) {
+        Validate.notNull(itemGroup, "The ItemGroup is not allowed to be null!");
 
         this.itemGroup.remove(this);
-        category.add(this);
+        itemGroup.add(this);
 
-        this.itemGroup = category;
+        this.itemGroup = itemGroup;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/FlexItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/FlexItemGroup.java
@@ -38,7 +38,7 @@ public abstract class FlexItemGroup extends ItemGroup {
 
     /**
      * This method returns whether this {@link FlexItemGroup} is visible under the given context.
-     * Implementing this method gives full flexibility over who can see the Category when and where.
+     * Implementing this method gives full flexibility over who can see the ItemGroup when and where.
      * 
      * @param p
      *            The {@link Player} who opened his {@link SlimefunGuide}
@@ -78,22 +78,22 @@ public abstract class FlexItemGroup extends ItemGroup {
 
     @Override
     public final void add(@Nonnull SlimefunItem item) {
-        throw new UnsupportedOperationException("You cannot add items to a FlexCategory!");
+        throw new UnsupportedOperationException("You cannot add items to a FlexItemGroup!");
     }
 
     @Override
     public final @Nonnull List<SlimefunItem> getItems() {
-        throw new UnsupportedOperationException("A FlexCategory has no items!");
+        throw new UnsupportedOperationException("A FlexItemGroup has no items!");
     }
 
     @Override
     public final boolean contains(SlimefunItem item) {
-        throw new UnsupportedOperationException("A FlexCategory has no items!");
+        throw new UnsupportedOperationException("A FlexItemGroup has no items!");
     }
 
     @Override
     public final void remove(@Nonnull SlimefunItem item) {
-        throw new UnsupportedOperationException("A FlexCategory has no items, so there is nothing remove!");
+        throw new UnsupportedOperationException("A FlexItemGroup has no items, so there is nothing remove!");
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/LockedItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/LockedItemGroup.java
@@ -87,9 +87,9 @@ public class LockedItemGroup extends ItemGroup {
             }
         }
 
-        for (ItemGroup category : Slimefun.getRegistry().getAllItemGroups()) {
-            if (namespacedKeys.remove(category.getKey())) {
-                addParent(category);
+        for (ItemGroup itemGroup : Slimefun.getRegistry().getAllItemGroups()) {
+            if (namespacedKeys.remove(itemGroup.getKey())) {
+                addParent(itemGroup);
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/NestedItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/NestedItemGroup.java
@@ -102,10 +102,10 @@ public class NestedItemGroup extends FlexItemGroup {
         while (target < (subGroups.size() - 1) && index < GROUP_SIZE + 9) {
             target++;
 
-            SubItemGroup category = subGroups.get(target);
-            menu.addItem(index, category.getItem(p));
+            SubItemGroup itemGroup = subGroups.get(target);
+            menu.addItem(index, itemGroup.getItem(p));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
-                SlimefunGuide.openCategory(profile, category, mode, 1);
+                SlimefunGuide.openItemGroup(profile, itemGroup, mode, 1);
                 return false;
             });
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/SeasonalItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/SeasonalItemGroup.java
@@ -57,7 +57,7 @@ public class SeasonalItemGroup extends ItemGroup {
 
     @Override
     public boolean isHidden(@Nonnull Player p) {
-        // Hide this Category if the month differs
+        // Hide this ItemGroup if the month differs
         if (month != LocalDate.now().getMonth()) {
             return true;
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
@@ -199,24 +199,24 @@ public class Research implements Keyed {
      *            The {@link PlayerProfile} of that {@link Player}.
      * @param sfItem
      *            The {@link SlimefunItem} on which the {@link Player} clicked.
-     * @param category
+     * @param itemGroup
      *            The {@link ItemGroup} where the {@link Player} was.
      * @param page
      *            The page number of where the {@link Player} was in the {@link ItemGroup};
      *
      */
     @ParametersAreNonnullByDefault
-    public void unlockFromGuide(SlimefunGuideImplementation guide, Player player, PlayerProfile profile, SlimefunItem sfItem, ItemGroup category, int page) {
+    public void unlockFromGuide(SlimefunGuideImplementation guide, Player player, PlayerProfile profile, SlimefunItem sfItem, ItemGroup itemGroup, int page) {
         if (!Slimefun.getRegistry().getCurrentlyResearchingPlayers().contains(player.getUniqueId())) {
             if (profile.hasUnlocked(this)) {
-                guide.openItemGroup(profile, category, page);
+                guide.openItemGroup(profile, itemGroup, page);
             } else {
                 PlayerPreResearchEvent event = new PlayerPreResearchEvent(player, this, sfItem);
                 Bukkit.getPluginManager().callEvent(event);
 
                 if (!event.isCancelled()) {
                     if (this.canUnlock(player)) {
-                        guide.unlockItem(player, sfItem, pl -> guide.openItemGroup(profile, category, page));
+                        guide.unlockItem(player, sfItem, pl -> guide.openItemGroup(profile, itemGroup, page));
                     } else {
                         Slimefun.getLocalization().sendMessage(player, "messages.not-enough-xp", true);
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -74,13 +74,13 @@ public class GuideHistory {
      * Should the {@link ItemGroup} already be the last element in this {@link GuideHistory},
      * then the entry will be overridden with the new page.
      * 
-     * @param category
+     * @param itemGroup
      *            The {@link ItemGroup} that should be added to this {@link GuideHistory}
      * @param page
      *            The current page of the {@link ItemGroup} that should be stored
      */
-    public void add(@Nonnull ItemGroup category, int page) {
-        refresh(category, page);
+    public void add(@Nonnull ItemGroup itemGroup, int page) {
+        refresh(itemGroup, page);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuide.java
@@ -82,8 +82,8 @@ public final class SlimefunGuide {
     }
 
     @ParametersAreNonnullByDefault
-    public static void openCategory(PlayerProfile profile, ItemGroup category, SlimefunGuideMode mode, int selectedPage) {
-        Slimefun.getRegistry().getSlimefunGuide(mode).openItemGroup(profile, category, selectedPage);
+    public static void openItemGroup(PlayerProfile profile, ItemGroup itemGroup, SlimefunGuideMode mode, int selectedPage) {
+        Slimefun.getRegistry().getSlimefunGuide(mode).openItemGroup(profile, itemGroup, selectedPage);
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -51,8 +51,8 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     protected final MultiBlock multiblock;
 
     @ParametersAreNonnullByDefault
-    protected MultiBlockMachine(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, ItemStack[] machineRecipes, BlockFace trigger) {
-        super(category, item, RecipeType.MULTIBLOCK, recipe);
+    protected MultiBlockMachine(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, ItemStack[] machineRecipes, BlockFace trigger) {
+        super(itemGroup, item, RecipeType.MULTIBLOCK, recipe);
         this.recipes = new ArrayList<>();
         this.displayRecipes = new ArrayList<>();
         this.displayRecipes.addAll(Arrays.asList(machineRecipes));
@@ -62,8 +62,8 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     }
 
     @ParametersAreNonnullByDefault
-    protected MultiBlockMachine(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, BlockFace trigger) {
-        this(category, item, recipe, new ItemStack[0], trigger);
+    protected MultiBlockMachine(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, BlockFace trigger) {
+        this(itemGroup, item, recipe, new ItemStack[0], trigger);
     }
 
     protected void registerDefaultRecipes(@Nonnull List<ItemStack> recipes) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -286,7 +286,7 @@ public abstract class SlimefunLocalization implements Keyed {
         return getStringOrNull(getLanguage(p), LanguageFile.RESEARCHES, key.getNamespace() + '.' + key.getKey());
     }
 
-    public @Nullable String getCategoryName(@Nonnull Player p, @Nonnull NamespacedKey key) {
+    public @Nullable String getItemGroupName(@Nonnull Player p, @Nonnull NamespacedKey key) {
         Validate.notNull(p, "Player must not be null.");
         Validate.notNull(key, "NamespacedKey cannot be null!");
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -224,20 +224,20 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
     @Override
     @ParametersAreNonnullByDefault
-    public void openItemGroup(PlayerProfile profile, ItemGroup category, int page) {
+    public void openItemGroup(PlayerProfile profile, ItemGroup itemGroup, int page) {
         Player p = profile.getPlayer();
 
         if (p == null) {
             return;
         }
 
-        if (category instanceof FlexItemGroup) {
-            ((FlexItemGroup) category).open(p, profile, getMode());
+        if (itemGroup instanceof FlexItemGroup) {
+            ((FlexItemGroup) itemGroup).open(p, profile, getMode());
             return;
         }
 
         if (isSurvivalMode()) {
-            profile.getGuideHistory().add(category, page);
+            profile.getGuideHistory().add(itemGroup, page);
         }
 
         ChestMenu menu = create(p);
@@ -245,14 +245,14 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
         addBackButton(menu, 1, p, profile);
 
-        int pages = (category.getItems().size() - 1) / MAX_ITEM_GROUPS + 1;
+        int pages = (itemGroup.getItems().size() - 1) / MAX_ITEM_GROUPS + 1;
 
         menu.addItem(46, ChestMenuUtils.getPreviousButton(p, page, pages));
         menu.addMenuClickHandler(46, (pl, slot, item, action) -> {
             int next = page - 1;
 
             if (next != page && next > 0) {
-                openItemGroup(profile, category, next);
+                openItemGroup(profile, itemGroup, next);
             }
 
             return false;
@@ -263,26 +263,26 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
             int next = page + 1;
 
             if (next != page && next <= pages) {
-                openItemGroup(profile, category, next);
+                openItemGroup(profile, itemGroup, next);
             }
 
             return false;
         });
 
         int index = 9;
-        int categoryIndex = MAX_ITEM_GROUPS * (page - 1);
+        int itemGroupIndex = MAX_ITEM_GROUPS * (page - 1);
 
         for (int i = 0; i < MAX_ITEM_GROUPS; i++) {
-            int target = categoryIndex + i;
+            int target = itemGroupIndex + i;
 
-            if (target >= category.getItems().size()) {
+            if (target >= itemGroup.getItems().size()) {
                 break;
             }
 
-            SlimefunItem sfitem = category.getItems().get(target);
+            SlimefunItem sfitem = itemGroup.getItems().get(target);
 
             if (!sfitem.isDisabledIn(p.getWorld())) {
-                displaySlimefunItem(menu, category, p, profile, sfitem, page, index);
+                displaySlimefunItem(menu, itemGroup, p, profile, sfitem, page, index);
                 index++;
             }
         }
@@ -290,7 +290,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         menu.open(p);
     }
 
-    private void displaySlimefunItem(ChestMenu menu, ItemGroup category, Player p, PlayerProfile profile, SlimefunItem sfitem, int page, int index) {
+    private void displaySlimefunItem(ChestMenu menu, ItemGroup itemGroup, Player p, PlayerProfile profile, SlimefunItem sfitem, int page, int index) {
         Research research = sfitem.getResearch();
 
         if (isSurvivalMode() && !hasPermission(p, sfitem)) {
@@ -300,7 +300,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         } else if (isSurvivalMode() && research != null && !profile.hasUnlocked(research)) {
             menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNotResearchedItem(), ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", "&a> Click to unlock", "", "&7Cost: &b" + research.getCost() + " Level(s)"));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
-                research.unlockFromGuide(this, p, profile, sfitem, category, page);
+                research.unlockFromGuide(this, p, profile, sfitem, itemGroup, page);
                 return false;
             });
         } else {
@@ -354,8 +354,8 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
             if (!slimefunItem.isHidden() && isSearchFilterApplicable(slimefunItem, searchTerm)) {
                 ItemStack itemstack = new CustomItemStack(slimefunItem.getItem(), meta -> {
-                    ItemGroup category = slimefunItem.getItemGroup();
-                    meta.setLore(Arrays.asList("", ChatColor.DARK_GRAY + "\u21E8 " + ChatColor.WHITE + category.getDisplayName(p)));
+                    ItemGroup itemGroup = slimefunItem.getItemGroup();
+                    meta.setLore(Arrays.asList("", ChatColor.DARK_GRAY + "\u21E8 " + ChatColor.WHITE + itemGroup.getDisplayName(p)));
                     meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_POTION_EFFECTS);
                 });
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -207,7 +207,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
             List<String> lore = new ArrayList<>();
             lore.add("");
 
-            for (String line : Slimefun.getLocalization().getMessages(p, "guide.locked-category")) {
+            for (String line : Slimefun.getLocalization().getMessages(p, "guide.locked-itemgroup")) {
                 lore.add(ChatColor.WHITE + line);
             }
 
@@ -505,7 +505,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         Optional<String> wiki = item.getWikipage();
 
         if (wiki.isPresent()) {
-            menu.addItem(8, new CustomItemStack(Material.KNOWLEDGE_BOOK, ChatColor.WHITE + Slimefun.getLocalization().getMessage(p, "guide.tooltips.wiki"), "", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-category")));
+            menu.addItem(8, new CustomItemStack(Material.KNOWLEDGE_BOOK, ChatColor.WHITE + Slimefun.getLocalization().getMessage(p, "guide.tooltips.wiki"), "", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
             menu.addMenuClickHandler(8, (pl, slot, itemstack, action) -> {
                 pl.closeInventory();
                 ChatUtils.sendURL(pl, wiki.get());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/RadioactiveItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/RadioactiveItem.java
@@ -39,7 +39,7 @@ public class RadioactiveItem extends SlimefunItem implements Radioactive, NotPla
     /**
      * This will create a new {@link RadioactiveItem} with the given level of {@link Radioactivity}
      * 
-     * @param category
+     * @param itemGroup
      *            The {@link ItemGroup} of this {@link SlimefunItem}
      * @param radioactivity
      *            the level of {@link Radioactivity}
@@ -51,14 +51,14 @@ public class RadioactiveItem extends SlimefunItem implements Radioactive, NotPla
      *            The recipe of how to craft this {@link SlimefunItem}
      */
     @ParametersAreNonnullByDefault
-    public RadioactiveItem(ItemGroup category, Radioactivity radioactivity, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        this(category, radioactivity, item, recipeType, recipe, null);
+    public RadioactiveItem(ItemGroup itemGroup, Radioactivity radioactivity, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        this(itemGroup, radioactivity, item, recipeType, recipe, null);
     }
 
     /**
      * This will create a new {@link RadioactiveItem} with the given level of {@link Radioactivity}
      * 
-     * @param category
+     * @param itemGroup
      *            The {@link ItemGroup} of this {@link SlimefunItem}
      * @param radioactivity
      *            the level of {@link Radioactivity}
@@ -72,8 +72,8 @@ public class RadioactiveItem extends SlimefunItem implements Radioactive, NotPla
      *            The recipe output
      */
     @ParametersAreNonnullByDefault
-    public RadioactiveItem(ItemGroup category, Radioactivity radioactivity, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public RadioactiveItem(ItemGroup itemGroup, Radioactivity radioactivity, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         this.radioactivity = radioactivity;
         addItemHandler(onRightClick());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/VanillaItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/VanillaItem.java
@@ -30,7 +30,7 @@ public class VanillaItem extends SlimefunItem {
      * Instantiates a new {@link VanillaItem} with the given arguments.
      *
      * @param itemGroup
-     *            the category to bind this {@link VanillaItem} to
+     *            the {@Link ItemGroup} to bind this {@link VanillaItem} to
      * @param item
      *            the item corresponding to this {@link VanillaItem}
      * @param id

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientAltar.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientAltar.java
@@ -45,8 +45,8 @@ public class AncientAltar extends SlimefunItem {
     private final ItemSetting<Integer> stepDelay = new IntRangeSetting(this, "step-delay", 0, DEFAULT_STEP_DELAY, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public AncientAltar(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AncientAltar(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(stepDelay);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -51,8 +51,8 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> {
     public static final String ITEM_PREFIX = ChatColors.color("&dALTAR &3Probe - &e");
 
     @ParametersAreNonnullByDefault
-    public AncientPedestal(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public AncientPedestal(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         addItemHandler(onBreak());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/AndroidInterface.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/AndroidInterface.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class AndroidInterface extends SimpleSlimefunItem<BlockDispenseHandler> {
 
     @ParametersAreNonnullByDefault
-    public AndroidInterface(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AndroidInterface(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(new VanillaInventoryDropHandler<>(Dispenser.class));
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ButcherAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ButcherAndroid.java
@@ -20,8 +20,8 @@ public class ButcherAndroid extends ProgrammableAndroid {
 
     private static final String METADATA_KEY = "android_killer";
 
-    public ButcherAndroid(ItemGroup category, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, tier, item, recipeType, recipe);
+    public ButcherAndroid(ItemGroup itemGroup, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, tier, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/FarmerAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/FarmerAndroid.java
@@ -23,8 +23,8 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 public class FarmerAndroid extends ProgrammableAndroid {
 
     @ParametersAreNonnullByDefault
-    public FarmerAndroid(ItemGroup category, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, tier, item, recipeType, recipe);
+    public FarmerAndroid(ItemGroup itemGroup, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, tier, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/FisherAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/FisherAndroid.java
@@ -20,8 +20,8 @@ public class FisherAndroid extends ProgrammableAndroid {
 
     private final RandomizedSet<ItemStack> fishingLoot = new RandomizedSet<>();
 
-    public FisherAndroid(ItemGroup category, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, tier, item, recipeType, recipe);
+    public FisherAndroid(ItemGroup itemGroup, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, tier, item, recipeType, recipe);
 
         // Fish
         for (Material fish : Tag.ITEMS_FISHES.getValues()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/MinerAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/MinerAndroid.java
@@ -58,8 +58,8 @@ public class MinerAndroid extends ProgrammableAndroid {
     private final ItemSetting<Boolean> applyOptimizations = new ItemSetting<>(this, "reduced-block-updates", true);
 
     @ParametersAreNonnullByDefault
-    public MinerAndroid(ItemGroup category, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, tier, item, recipeType, recipe);
+    public MinerAndroid(ItemGroup itemGroup, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, tier, item, recipeType, recipe);
 
         addItemSetting(firesEvent, applyOptimizations);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -424,10 +424,10 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         });
 
         int index = 0;
-        int itemGroupIndex = 45 * (page - 1);
+        int categoryIndex = 45 * (page - 1);
 
         for (int i = 0; i < 45; i++) {
-            int target = itemGroupIndex + i;
+            int target = categoryIndex + i;
 
             if (target >= scripts.size()) {
                 break;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -78,8 +78,8 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
     private final int tier;
 
     @ParametersAreNonnullByDefault
-    public ProgrammableAndroid(ItemGroup category, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ProgrammableAndroid(ItemGroup itemGroup, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.tier = tier;
         texture = item.getSkullTexture().orElse(null);
@@ -424,10 +424,10 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         });
 
         int index = 0;
-        int categoryIndex = 45 * (page - 1);
+        int itemGroupIndex = 45 * (page - 1);
 
         for (int i = 0; i < 45; i++) {
-            int target = categoryIndex + i;
+            int target = itemGroupIndex + i;
 
             if (target >= scripts.size()) {
                 break;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/WoodcutterAndroid.java
@@ -33,8 +33,8 @@ public class WoodcutterAndroid extends ProgrammableAndroid {
     private static final int MAX_REACH = 160;
 
     @ParametersAreNonnullByDefault
-    public WoodcutterAndroid(ItemGroup category, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, tier, item, recipeType, recipe);
+    public WoodcutterAndroid(ItemGroup itemGroup, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, tier, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/ElytraCap.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/ElytraCap.java
@@ -31,8 +31,8 @@ public class ElytraCap extends SlimefunArmorPiece implements DamageableItem, Pro
     private final NamespacedKey key;
 
     @ParametersAreNonnullByDefault
-    public ElytraCap(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe, null);
+    public ElytraCap(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe, null);
 
         key = new NamespacedKey(Slimefun.instance(), "elytra_armor");
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/EnderBoots.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/EnderBoots.java
@@ -20,8 +20,7 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 public class EnderBoots extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public EnderBoots(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public EnderBoots(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/FarmerShoes.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/FarmerShoes.java
@@ -21,8 +21,8 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 public class FarmerShoes extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public FarmerShoes(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public FarmerShoes(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/HazmatArmorPiece.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/HazmatArmorPiece.java
@@ -29,8 +29,8 @@ public class HazmatArmorPiece extends SlimefunArmorPiece implements ProtectiveAr
     private final ProtectionType[] types;
 
     @ParametersAreNonnullByDefault
-    public HazmatArmorPiece(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects) {
-        super(category, item, recipeType, recipe, effects);
+    public HazmatArmorPiece(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects) {
+        super(itemGroup, item, recipeType, recipe, effects);
 
         types = new ProtectionType[] { ProtectionType.BEES, ProtectionType.RADIATION };
         namespacedKey = new NamespacedKey(Slimefun.instance(), "hazmat_suit");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/LongFallBoots.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/LongFallBoots.java
@@ -21,8 +21,8 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 public class LongFallBoots extends SlimefunArmorPiece {
 
     @ParametersAreNonnullByDefault
-    public LongFallBoots(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects) {
-        super(category, item, recipeType, recipe, effects);
+    public LongFallBoots(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects) {
+        super(itemGroup, item, recipeType, recipe, effects);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/Parachute.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/Parachute.java
@@ -27,8 +27,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.tasks.ParachuteTask;
 public class Parachute extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public Parachute(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
+    public Parachute(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/SlimefunArmorPiece.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/SlimefunArmorPiece.java
@@ -17,8 +17,8 @@ public class SlimefunArmorPiece extends SlimefunItem {
     private final PotionEffect[] effects;
 
     @ParametersAreNonnullByDefault
-    public SlimefunArmorPiece(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable PotionEffect[] effects) {
-        super(category, item, recipeType, recipe);
+    public SlimefunArmorPiece(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable PotionEffect[] effects) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.effects = effects == null ? new PotionEffect[0] : effects;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/StomperBoots.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/StomperBoots.java
@@ -35,8 +35,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 public class StomperBoots extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public StomperBoots(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public StomperBoots(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -93,8 +93,8 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
     // @formatter:on
 
     @ParametersAreNonnullByDefault
-    protected AbstractAutoCrafter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AbstractAutoCrafter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         recipeStorageKey = new NamespacedKey(Slimefun.instance(), "recipe_key");
         recipeEnabledKey = new NamespacedKey(Slimefun.instance(), "recipe_enabled");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/ArmorAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/ArmorAutoCrafter.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks.Armor
 public class ArmorAutoCrafter extends SlimefunAutoCrafter {
 
     @ParametersAreNonnullByDefault
-    public ArmorAutoCrafter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe, RecipeType.ARMOR_FORGE);
+    public ArmorAutoCrafter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe, RecipeType.ARMOR_FORGE);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/EnhancedAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/EnhancedAutoCrafter.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.AutoCrafterLi
 public class EnhancedAutoCrafter extends SlimefunAutoCrafter {
 
     @ParametersAreNonnullByDefault
-    public EnhancedAutoCrafter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe, RecipeType.ENHANCED_CRAFTING_TABLE);
+    public EnhancedAutoCrafter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe, RecipeType.ENHANCED_CRAFTING_TABLE);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
@@ -47,8 +47,8 @@ public class SlimefunAutoCrafter extends AbstractAutoCrafter {
     private final RecipeType targetRecipeType;
 
     @ParametersAreNonnullByDefault
-    protected SlimefunAutoCrafter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, RecipeType targetRecipeType) {
-        super(category, item, recipeType, recipe);
+    protected SlimefunAutoCrafter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, RecipeType targetRecipeType) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.targetRecipeType = targetRecipeType;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaAutoCrafter.java
@@ -53,8 +53,8 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 public class VanillaAutoCrafter extends AbstractAutoCrafter {
 
     @ParametersAreNonnullByDefault
-    public VanillaAutoCrafter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public VanillaAutoCrafter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/Cooler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/Cooler.java
@@ -26,8 +26,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.CoolerListene
 public class Cooler extends SlimefunBackpack {
 
     @ParametersAreNonnullByDefault
-    public Cooler(int size, ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(size, category, item, recipeType, recipe);
+    public Cooler(int size, ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(size, itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/EnderBackpack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/EnderBackpack.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class EnderBackpack extends SimpleSlimefunItem<ItemUseHandler> implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public EnderBackpack(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public EnderBackpack(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/RestoredBackpack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/RestoredBackpack.java
@@ -28,12 +28,12 @@ public class RestoredBackpack extends SlimefunBackpack {
     /**
      * This will create a new {@link SlimefunBackpack} with the given arguments.
      *
-     * @param category
-     *            the category to bind this {@link SlimefunBackpack} to
+     * @param itemGroup
+     *            the {@Link ItemGroup} to bind this {@link SlimefunBackpack} to
      */
     @ParametersAreNonnullByDefault
-    public RestoredBackpack(@Nonnull ItemGroup category) {
-        super(54, category, SlimefunItems.RESTORED_BACKPACK, RecipeType.NULL, new ItemStack[9]);
+    public RestoredBackpack(@Nonnull ItemGroup itemGroup) {
+        super(54, itemGroup, SlimefunItems.RESTORED_BACKPACK, RecipeType.NULL, new ItemStack[9]);
 
         this.hidden = true;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/SlimefunBackpack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/SlimefunBackpack.java
@@ -33,8 +33,8 @@ public class SlimefunBackpack extends SimpleSlimefunItem<ItemUseHandler> {
     private final int size;
 
     @ParametersAreNonnullByDefault
-    public SlimefunBackpack(int size, ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SlimefunBackpack(int size, ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.size = size;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/SoulboundBackpack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/SoulboundBackpack.java
@@ -18,8 +18,8 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.Soulbound;
 public class SoulboundBackpack extends SlimefunBackpack implements Soulbound {
 
     @ParametersAreNonnullByDefault
-    public SoulboundBackpack(int size, ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(size, category, item, recipeType, recipe);
+    public SoulboundBackpack(int size, ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(size, itemGroup, item, recipeType, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/AbstractMonsterSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/AbstractMonsterSpawner.java
@@ -35,8 +35,8 @@ import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 public abstract class AbstractMonsterSpawner extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    AbstractMonsterSpawner(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    AbstractMonsterSpawner(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -56,8 +56,8 @@ public class BlockPlacer extends SlimefunItem {
     private final ItemSetting<List<String>> unplaceableBlocks = new MaterialTagSetting(this, "unplaceable-blocks", SlimefunTag.UNBREAKABLE_MATERIALS);
 
     @ParametersAreNonnullByDefault
-    public BlockPlacer(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public BlockPlacer(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(unplaceableBlocks);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BrokenSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BrokenSpawner.java
@@ -26,8 +26,8 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 public class BrokenSpawner extends AbstractMonsterSpawner implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public BrokenSpawner(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public BrokenSpawner(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onRightClick());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Composter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Composter.java
@@ -34,8 +34,8 @@ public class Composter extends SimpleSlimefunItem<BlockUseHandler> implements Re
     private final List<ItemStack> recipes;
 
     @ParametersAreNonnullByDefault
-    public Composter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public Composter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         recipes = getMachineRecipes();
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Crucible.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Crucible.java
@@ -49,8 +49,8 @@ public class Crucible extends SimpleSlimefunItem<BlockUseHandler> implements Rec
     private final List<ItemStack> recipes;
 
     @ParametersAreNonnullByDefault
-    public Crucible(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public Crucible(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         recipes = getMachineRecipes();
         addItemSetting(allowWaterInNether);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/EnhancedFurnace.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/EnhancedFurnace.java
@@ -39,8 +39,8 @@ public class EnhancedFurnace extends SimpleSlimefunItem<BlockTicker> {
     private final int efficiency;
     private final int fortuneLevel;
 
-    public EnhancedFurnace(ItemGroup category, int speed, int efficiency, int fortune, SlimefunItemStack item, ItemStack[] recipe) {
-        super(category, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
+    public EnhancedFurnace(ItemGroup itemGroup, int speed, int efficiency, int fortune, SlimefunItemStack item, ItemStack[] recipe) {
+        super(itemGroup, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
 
         this.speed = speed - 1;
         this.efficiency = efficiency - 1;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HardenedGlass.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HardenedGlass.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.WitherProof;
 public class HardenedGlass extends WitherProofBlock {
 
     @ParametersAreNonnullByDefault
-    public HardenedGlass(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public HardenedGlass(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -49,8 +49,8 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
     private static final String OFFSET_PARAMETER = "offset";
 
     @ParametersAreNonnullByDefault
-    public HologramProjector(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public HologramProjector(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         addItemHandler(onPlace(), onRightClick(), onBreak());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
@@ -50,8 +50,8 @@ public class IgnitionChamber extends SlimefunItem {
     // @formatter:on
 
     @ParametersAreNonnullByDefault
-    public IgnitionChamber(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public IgnitionChamber(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(new VanillaInventoryDropHandler<>(Dropper.class));
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
@@ -46,8 +46,8 @@ public class OutputChest extends SlimefunItem {
     // @formatter:on
 
     @ParametersAreNonnullByDefault
-    public OutputChest(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public OutputChest(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(new VanillaInventoryDropHandler<>(Chest.class));
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RainbowBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RainbowBlock.java
@@ -22,8 +22,8 @@ public class RainbowBlock extends SimpleSlimefunItem<RainbowTickHandler> {
     private final RainbowTickHandler ticker;
 
     @ParametersAreNonnullByDefault
-    public RainbowBlock(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, RainbowTickHandler ticker) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public RainbowBlock(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, RainbowTickHandler ticker) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         this.ticker = ticker;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
@@ -34,8 +34,8 @@ public class RepairedSpawner extends AbstractMonsterSpawner {
     private final ItemSetting<Boolean> allowSpawnEggs = new ItemSetting<>(this, "allow-spawn-eggs", true);
 
     @ParametersAreNonnullByDefault
-    public RepairedSpawner(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public RepairedSpawner(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(allowSpawnEggs);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/UnplaceableBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/UnplaceableBlock.java
@@ -27,13 +27,13 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class UnplaceableBlock extends SimpleSlimefunItem<ItemUseHandler> implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public UnplaceableBlock(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public UnplaceableBlock(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @ParametersAreNonnullByDefault
-    public UnplaceableBlock(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public UnplaceableBlock(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/WitherProofBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/WitherProofBlock.java
@@ -25,13 +25,13 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.WitherProof;
 public class WitherProofBlock extends SlimefunItem implements WitherProof {
 
     @ParametersAreNonnullByDefault
-    public WitherProofBlock(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public WitherProofBlock(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @ParametersAreNonnullByDefault
-    public WitherProofBlock(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public WitherProofBlock(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
@@ -41,8 +41,8 @@ abstract class AbstractCargoNode extends SimpleSlimefunItem<BlockPlaceHandler> i
     protected static final String FREQUENCY = "frequency";
 
     @ParametersAreNonnullByDefault
-    AbstractCargoNode(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    AbstractCargoNode(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         new BlockMenuPreset(getId(), ChatUtils.removeColorCodes(item.getItemMeta().getDisplayName())) {
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
@@ -39,8 +39,8 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
     private static final String FILTER_LORE = "filter-lore";
 
     @ParametersAreNonnullByDefault
-    protected AbstractFilterNode(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    protected AbstractFilterNode(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         addItemHandler(onBreak());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AdvancedCargoOutputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AdvancedCargoOutputNode.java
@@ -20,8 +20,8 @@ public class AdvancedCargoOutputNode extends AbstractFilterNode {
     private static final int[] BORDER = { 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 22, 23, 24, 26, 27, 31, 32, 33, 34, 35, 36, 40, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53 };
 
     @ParametersAreNonnullByDefault
-    public AdvancedCargoOutputNode(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe, null);
+    public AdvancedCargoOutputNode(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe, null);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoConnectorNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoConnectorNode.java
@@ -28,8 +28,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class CargoConnectorNode extends SimpleSlimefunItem<BlockUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public CargoConnectorNode(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public CargoConnectorNode(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
@@ -24,8 +24,8 @@ public class CargoInputNode extends AbstractFilterNode {
     private static final String SMART_FILL_MODE = "smart-fill";
 
     @ParametersAreNonnullByDefault
-    public CargoInputNode(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public CargoInputNode(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoManager.java
@@ -28,8 +28,8 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 public class CargoManager extends SlimefunItem implements HologramOwner {
 
     @ParametersAreNonnullByDefault
-    public CargoManager(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public CargoManager(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onBreak());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
@@ -22,8 +22,8 @@ public class CargoOutputNode extends AbstractCargoNode {
     private static final int[] BORDER = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 };
 
     @ParametersAreNonnullByDefault
-    public CargoOutputNode(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public CargoOutputNode(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
@@ -50,8 +50,8 @@ public class ReactorAccessPort extends SlimefunItem {
     private final int[] outputBorder = { 30, 31, 32, 39, 41, 48, 50 };
 
     @ParametersAreNonnullByDefault
-    public ReactorAccessPort(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ReactorAccessPort(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onBreak());
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/TrashCan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/TrashCan.java
@@ -33,8 +33,8 @@ public class TrashCan extends SlimefunItem implements InventoryBlock {
     private final ItemStack background = new CustomItemStack(Material.RED_STAINED_GLASS_PANE, " ");
 
     @ParametersAreNonnullByDefault
-    public TrashCan(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public TrashCan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         createPreset(this, this::constructMenu);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/AbstractEnergyProvider.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/AbstractEnergyProvider.java
@@ -43,8 +43,8 @@ public abstract class AbstractEnergyProvider extends SlimefunItem implements Inv
     protected final Set<MachineFuel> fuelTypes = new HashSet<>();
 
     @ParametersAreNonnullByDefault
-    protected AbstractEnergyProvider(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AbstractEnergyProvider(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/Capacitor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/Capacitor.java
@@ -30,8 +30,8 @@ public class Capacitor extends SlimefunItem implements EnergyNetComponent {
     private final int capacity;
 
     @ParametersAreNonnullByDefault
-    public Capacitor(ItemGroup category, int capacity, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public Capacitor(ItemGroup itemGroup, int capacity, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.capacity = capacity;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyConnector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyConnector.java
@@ -30,8 +30,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class EnergyConnector extends SimpleSlimefunItem<BlockUseHandler> implements EnergyNetComponent {
 
     @ParametersAreNonnullByDefault
-    public EnergyConnector(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public EnergyConnector(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
@@ -34,8 +34,8 @@ import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 public class EnergyRegulator extends SlimefunItem implements HologramOwner {
 
     @ParametersAreNonnullByDefault
-    public EnergyRegulator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public EnergyRegulator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onBreak());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/JetBoots.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/JetBoots.java
@@ -27,8 +27,8 @@ public class JetBoots extends SlimefunItem implements Rechargeable {
     private final float capacity;
 
     @ParametersAreNonnullByDefault
-    public JetBoots(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, double speed, float capacity) {
-        super(category, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
+    public JetBoots(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, double speed, float capacity) {
+        super(itemGroup, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
 
         this.speed = speed;
         this.capacity = capacity;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Jetpack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Jetpack.java
@@ -27,8 +27,8 @@ public class Jetpack extends SlimefunItem implements Rechargeable {
     private final float capacity;
 
     @ParametersAreNonnullByDefault
-    public Jetpack(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, double thrust, float capacity) {
-        super(category, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
+    public Jetpack(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, double thrust, float capacity) {
+        super(itemGroup, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
 
         this.thrust = thrust;
         this.capacity = capacity;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiTool.java
@@ -39,8 +39,8 @@ public class MultiTool extends SlimefunItem implements Rechargeable {
     private final float capacity;
 
     @ParametersAreNonnullByDefault
-    public MultiTool(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, float capacity, String... items) {
-        super(category, item, recipeType, recipe);
+    public MultiTool(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, float capacity, String... items) {
+        super(itemGroup, item, recipeType, recipe);
 
         for (int i = 0; i < items.length; i++) {
             modes.add(new MultiToolMode(this, i, items[i]));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Multimeter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Multimeter.java
@@ -31,8 +31,8 @@ import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 public class Multimeter extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public Multimeter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public Multimeter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/SolarHelmet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/SolarHelmet.java
@@ -34,8 +34,8 @@ public class SolarHelmet extends SlimefunItem {
     private final ItemSetting<Double> charge;
 
     @ParametersAreNonnullByDefault
-    public SolarHelmet(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, double defaultChargingLevel) {
-        super(category, item, recipeType, recipe);
+    public SolarHelmet(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, double defaultChargingLevel) {
+        super(itemGroup, item, recipeType, recipe);
 
         if (defaultChargingLevel <= 0) {
             throw new IllegalArgumentException("A Solar Helmet must have a positive charging level!");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/BioGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/BioGenerator.java
@@ -19,8 +19,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 public class BioGenerator extends AGenerator {
 
     @ParametersAreNonnullByDefault
-    public BioGenerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public BioGenerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/CoalGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/CoalGenerator.java
@@ -17,8 +17,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 public class CoalGenerator extends AGenerator {
 
     @ParametersAreNonnullByDefault
-    public CoalGenerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public CoalGenerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/CombustionGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/CombustionGenerator.java
@@ -16,8 +16,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 public class CombustionGenerator extends AGenerator {
 
     @ParametersAreNonnullByDefault
-    public CombustionGenerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public CombustionGenerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/LavaGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/LavaGenerator.java
@@ -15,8 +15,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 public class LavaGenerator extends AGenerator {
 
     @ParametersAreNonnullByDefault
-    public LavaGenerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public LavaGenerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/MagnesiumGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/MagnesiumGenerator.java
@@ -16,8 +16,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 public class MagnesiumGenerator extends AGenerator {
 
     @ParametersAreNonnullByDefault
-    public MagnesiumGenerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public MagnesiumGenerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
@@ -37,8 +37,8 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
     private final int nightEnergy;
 
     @ParametersAreNonnullByDefault
-    public SolarGenerator(ItemGroup category, int dayEnergy, int nightEnergy, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SolarGenerator(ItemGroup itemGroup, int dayEnergy, int nightEnergy, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.dayEnergy = dayEnergy;
         this.nightEnergy = nightEnergy;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoAnvil.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoAnvil.java
@@ -26,8 +26,8 @@ public class AutoAnvil extends AContainer {
 
     private final int repairFactor;
 
-    public AutoAnvil(ItemGroup category, int repairFactor, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AutoAnvil(ItemGroup itemGroup, int repairFactor, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.repairFactor = repairFactor;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
@@ -56,8 +56,8 @@ public class AutoBrewer extends AContainer implements NotHopperable {
     }
 
     @ParametersAreNonnullByDefault
-    public AutoBrewer(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AutoBrewer(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoDrier.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoDrier.java
@@ -31,8 +31,8 @@ public class AutoDrier extends AContainer implements RecipeDisplayItem, NotHoppe
     private List<ItemStack> recipeList;
 
     @ParametersAreNonnullByDefault
-    public AutoDrier(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AutoDrier(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CarbonPress.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CarbonPress.java
@@ -17,8 +17,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 public class CarbonPress extends AContainer implements RecipeDisplayItem {
 
     @ParametersAreNonnullByDefault
-    public CarbonPress(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public CarbonPress(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ChargingBench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ChargingBench.java
@@ -24,8 +24,8 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
  */
 public class ChargingBench extends AContainer {
 
-    public ChargingBench(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ChargingBench(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricDustWasher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricDustWasher.java
@@ -31,8 +31,8 @@ public class ElectricDustWasher extends AContainer {
     private final boolean legacyMode;
 
     @ParametersAreNonnullByDefault
-    public ElectricDustWasher(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricDustWasher(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         legacyMode = Slimefun.getCfg().getBoolean("options.legacy-dust-washer");
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricFurnace.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricFurnace.java
@@ -27,8 +27,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 public class ElectricFurnace extends AContainer implements NotHopperable {
 
     @ParametersAreNonnullByDefault
-    public ElectricFurnace(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricFurnace(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
@@ -41,8 +41,8 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
     private final ItemStack soulSand = new ItemStack(Material.SOUL_SAND);
 
     @ParametersAreNonnullByDefault
-    public ElectricGoldPan(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricGoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotFactory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotFactory.java
@@ -12,8 +12,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 
 public class ElectricIngotFactory extends AContainer implements RecipeDisplayItem {
 
-    public ElectricIngotFactory(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricIngotFactory(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
@@ -29,8 +29,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecip
  */
 public class ElectricIngotPulverizer extends AContainer implements RecipeDisplayItem, NotHopperable {
 
-    public ElectricIngotPulverizer(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricIngotPulverizer(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricOreGrinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricOreGrinder.java
@@ -16,8 +16,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 public class ElectricOreGrinder extends AContainer implements RecipeDisplayItem, NotHopperable {
 
     @ParametersAreNonnullByDefault
-    public ElectricOreGrinder(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricOreGrinder(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
@@ -26,8 +26,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 public class ElectricPress extends AContainer implements RecipeDisplayItem {
 
     @ParametersAreNonnullByDefault
-    public ElectricPress(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricPress(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricSmeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricSmeltery.java
@@ -45,8 +45,8 @@ public class ElectricSmeltery extends AContainer implements NotHopperable {
     private static final int[] outputBorder = { 14, 15, 16, 17, 23, 26, 32, 33, 34, 35 };
 
     @ParametersAreNonnullByDefault
-    public ElectricSmeltery(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectricSmeltery(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         new BlockMenuPreset(getId(), getItemName()) {
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectrifiedCrucible.java
@@ -15,8 +15,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 
 public class ElectrifiedCrucible extends AContainer {
 
-    public ElectrifiedCrucible(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ElectrifiedCrucible(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -59,8 +59,8 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
     private final ItemStack emptyBucket = ItemStackWrapper.wrap(new ItemStack(Material.BUCKET));
 
     @ParametersAreNonnullByDefault
-    public FluidPump(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public FluidPump(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onBreak());
         createPreset(this, this::constructMenu);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FoodComposter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FoodComposter.java
@@ -14,8 +14,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 
 public class FoodComposter extends AContainer implements RecipeDisplayItem {
 
-    public FoodComposter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public FoodComposter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FoodFabricator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FoodFabricator.java
@@ -13,8 +13,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 
 public class FoodFabricator extends AContainer {
 
-    public FoodFabricator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public FoodFabricator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/Freezer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/Freezer.java
@@ -17,8 +17,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecip
 
 public class Freezer extends AContainer implements RecipeDisplayItem {
 
-    public Freezer(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public Freezer(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/HeatedPressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/HeatedPressureChamber.java
@@ -29,8 +29,8 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 public class HeatedPressureChamber extends AContainer {
 
     @ParametersAreNonnullByDefault
-    public HeatedPressureChamber(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public HeatedPressureChamber(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         new BlockMenuPreset(getId(), getItemName()) {
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/Refinery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/Refinery.java
@@ -13,8 +13,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 
 public class Refinery extends AContainer implements RecipeDisplayItem {
 
-    public Refinery(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public Refinery(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AbstractGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AbstractGrowthAccelerator.java
@@ -30,8 +30,8 @@ public abstract class AbstractGrowthAccelerator extends SlimefunItem implements 
     private static final int[] BORDER = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 };
 
     @ParametersAreNonnullByDefault
-    protected AbstractGrowthAccelerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AbstractGrowthAccelerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onBreak());
         createPreset(this, this::constructMenu);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AnimalGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AnimalGrowthAccelerator.java
@@ -25,8 +25,8 @@ public class AnimalGrowthAccelerator extends AbstractGrowthAccelerator {
     // We wanna strip the Slimefun Item id here
     private static final ItemStack organicFood = ItemStackWrapper.wrap(SlimefunItems.ORGANIC_FOOD);
 
-    public AnimalGrowthAccelerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AnimalGrowthAccelerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/CropGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/CropGrowthAccelerator.java
@@ -21,8 +21,8 @@ public abstract class CropGrowthAccelerator extends AbstractGrowthAccelerator {
     // We wanna strip the Slimefun Item id here
     private static final ItemStack organicFertilizer = ItemStackWrapper.wrap(SlimefunItems.FERTILIZER);
 
-    protected CropGrowthAccelerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected CropGrowthAccelerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     public abstract int getEnergyConsumption();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/TreeGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/TreeGrowthAccelerator.java
@@ -34,8 +34,8 @@ public class TreeGrowthAccelerator extends AbstractGrowthAccelerator {
     // We wanna strip the Slimefun Item id here
     private static final ItemStack organicFertilizer = ItemStackWrapper.wrap(SlimefunItems.FERTILIZER);
 
-    public TreeGrowthAccelerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public TreeGrowthAccelerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
@@ -41,8 +41,8 @@ abstract class AbstractEnchantmentMachine extends AContainer {
     private final ItemSetting<List<String>> ignoredLores = new ItemSetting<>(this, "ignored-lores", Collections.singletonList("&7- &cCan't be used in " + this.getItemName()));
 
     @ParametersAreNonnullByDefault
-    protected AbstractEnchantmentMachine(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AbstractEnchantmentMachine(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(useLevelLimit);
         addItemSetting(levelLimit);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
@@ -44,8 +44,8 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 public class AutoDisenchanter extends AbstractEnchantmentMachine {
 
     @ParametersAreNonnullByDefault
-    public AutoDisenchanter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AutoDisenchanter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -40,8 +40,8 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 public class AutoEnchanter extends AbstractEnchantmentMachine {
 
     @ParametersAreNonnullByDefault
-    public AutoEnchanter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AutoEnchanter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
@@ -35,8 +35,8 @@ public class BookBinder extends AContainer {
     private final ItemSetting<Integer> customMaxLevel = new IntRangeSetting(this, "custom-max-level", 0, 15, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public BookBinder(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public BookBinder(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(bypassVanillaMaxLevel, hasCustomMaxLevel, customMaxLevel);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AbstractEntityAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AbstractEntityAssembler.java
@@ -67,8 +67,8 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
     private int lifetime = 0;
 
     @ParametersAreNonnullByDefault
-    protected AbstractEntityAssembler(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AbstractEntityAssembler(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         new BlockMenuPreset(getId(), item.getItemMetaSnapshot().getDisplayName().orElse("Entity Assembler")) {
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AutoBreeder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AutoBreeder.java
@@ -41,8 +41,8 @@ public class AutoBreeder extends SlimefunItem implements InventoryBlock, EnergyN
     private static final ItemStack organicFood = ItemStackWrapper.wrap(SlimefunItems.ORGANIC_FOOD);
 
     @ParametersAreNonnullByDefault
-    public AutoBreeder(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public AutoBreeder(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onBreak());
         createPreset(this, this::constructMenu);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ExpCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ExpCollector.java
@@ -47,8 +47,8 @@ public class ExpCollector extends SlimefunItem implements InventoryBlock, Energy
     private static final String DATA_KEY = "stored-exp";
 
     @ParametersAreNonnullByDefault
-    public ExpCollector(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ExpCollector(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         createPreset(this, this::constructMenu);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/IronGolemAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/IronGolemAssembler.java
@@ -30,8 +30,8 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 public class IronGolemAssembler extends AbstractEntityAssembler<IronGolem> {
 
     @ParametersAreNonnullByDefault
-    public IronGolemAssembler(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public IronGolemAssembler(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
@@ -54,8 +54,8 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
     private final Set<AnimalProduce> animalProduces = new HashSet<>();
 
     @ParametersAreNonnullByDefault
-    public ProduceCollector(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ProduceCollector(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(range);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/WitherAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/WitherAssembler.java
@@ -27,8 +27,8 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 public class WitherAssembler extends AbstractEntityAssembler<Wither> {
 
     @ParametersAreNonnullByDefault
-    public WitherAssembler(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public WitherAssembler(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/NetherStarReactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/NetherStarReactor.java
@@ -31,8 +31,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 public abstract class NetherStarReactor extends Reactor {
 
     @ParametersAreNonnullByDefault
-    protected NetherStarReactor(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected NetherStarReactor(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/NuclearReactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/NuclearReactor.java
@@ -27,8 +27,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 public abstract class NuclearReactor extends Reactor {
 
     @ParametersAreNonnullByDefault
-    protected NuclearReactor(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected NuclearReactor(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -79,8 +79,8 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
     private final MachineProcessor<FuelOperation> processor = new MachineProcessor<>(this);
 
     @ParametersAreNonnullByDefault
-    protected Reactor(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected Reactor(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         processor.setProgressBar(getProgressBar());
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/elevator/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/elevator/ElevatorPlate.java
@@ -62,8 +62,8 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
     private final Set<UUID> users = new HashSet<>();
 
     @ParametersAreNonnullByDefault
-    public ElevatorPlate(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public ElevatorPlate(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         addItemHandler(onPlace());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/BirthdayCake.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/BirthdayCake.java
@@ -20,8 +20,8 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 public class BirthdayCake extends SlimefunItem implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public BirthdayCake(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public BirthdayCake(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/DietCookie.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/DietCookie.java
@@ -27,8 +27,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class DietCookie extends SimpleSlimefunItem<ItemConsumptionHandler> {
 
     @ParametersAreNonnullByDefault
-    public DietCookie(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public DietCookie(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/FortuneCookie.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/FortuneCookie.java
@@ -29,8 +29,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class FortuneCookie extends SimpleSlimefunItem<ItemConsumptionHandler> {
 
     @ParametersAreNonnullByDefault
-    public FortuneCookie(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public FortuneCookie(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/HeavyCream.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/HeavyCream.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class HeavyCream extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public HeavyCream(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public HeavyCream(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
@@ -40,13 +40,13 @@ public class Juice extends SimpleSlimefunItem<ItemConsumptionHandler> {
     private final List<PotionEffect> effects;
 
     @ParametersAreNonnullByDefault
-    public Juice(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        this(category, item, recipeType, recipe, null);
+    public Juice(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        this(itemGroup, item, recipeType, recipe, null);
     }
 
     @ParametersAreNonnullByDefault
-    public Juice(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public Juice(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         ItemMeta meta = item.getItemMeta();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/MagicSugar.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/MagicSugar.java
@@ -27,8 +27,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class MagicSugar extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public MagicSugar(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public MagicSugar(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/MeatJerky.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/MeatJerky.java
@@ -26,8 +26,8 @@ public class MeatJerky extends SimpleSlimefunItem<ItemConsumptionHandler> {
     private final ItemSetting<Integer> saturation = new IntRangeSetting(this, "saturation-level", 0, 6, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public MeatJerky(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public MeatJerky(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(saturation);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/MonsterJerky.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/MonsterJerky.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class MonsterJerky extends SimpleSlimefunItem<ItemConsumptionHandler> {
 
     @ParametersAreNonnullByDefault
-    public MonsterJerky(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public MonsterJerky(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
@@ -68,8 +68,8 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
     private int processingSpeed = -1;
 
     @ParametersAreNonnullByDefault
-    public GEOMiner(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public GEOMiner(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         processor.setProgressBar(new ItemStack(Material.DIAMOND_PICKAXE));
         createPreset(this, getItemName(), this::constructMenu);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOScanner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOScanner.java
@@ -19,8 +19,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 
 public class GEOScanner extends SimpleSlimefunItem<BlockUseHandler> {
 
-    public GEOScanner(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public GEOScanner(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/OilPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/OilPump.java
@@ -35,8 +35,8 @@ public class OilPump extends AContainer implements RecipeDisplayItem {
     private final ItemStack emptyBucket = new ItemStack(Material.BUCKET);
 
     @ParametersAreNonnullByDefault
-    public OilPump(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public OilPump(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         oil = Slimefun.getRegistry().getGEOResources().get(new NamespacedKey(Slimefun.instance(), "oil")).orElse(null);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/PortableGEOScanner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/PortableGEOScanner.java
@@ -17,8 +17,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class PortableGEOScanner extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public PortableGEOScanner(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PortableGEOScanner(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSControlPanel.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSControlPanel.java
@@ -20,8 +20,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class GPSControlPanel extends SimpleSlimefunItem<BlockUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public GPSControlPanel(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public GPSControlPanel(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSMarkerTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSMarkerTool.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class GPSMarkerTool extends SimpleSlimefunItem<ItemUseHandler> implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public GPSMarkerTool(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public GPSMarkerTool(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSTransmitter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSTransmitter.java
@@ -32,8 +32,8 @@ public abstract class GPSTransmitter extends SimpleSlimefunItem<BlockTicker> imp
     private final int capacity;
 
     @ParametersAreNonnullByDefault
-    protected GPSTransmitter(ItemGroup category, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected GPSTransmitter(ItemGroup itemGroup, int tier, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
         this.capacity = 4 << (2 * tier);
 
         addItemHandler(onPlace(), onBreak());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/BeeWings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/BeeWings.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.tasks.BeeWingsTask;
 public class BeeWings extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public BeeWings(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public BeeWings(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfernalBonemeal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfernalBonemeal.java
@@ -29,8 +29,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class InfernalBonemeal extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public InfernalBonemeal(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public InfernalBonemeal(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedHopper.java
@@ -45,8 +45,8 @@ public class InfusedHopper extends SimpleSlimefunItem<BlockTicker> {
     private final ItemSetting<Double> radius = new DoubleRangeSetting(this, "radius", 0.1, 3.5, Double.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public InfusedHopper(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public InfusedHopper(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(silent, radius, toggleable);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedMagnet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/InfusedMagnet.java
@@ -27,8 +27,8 @@ public class InfusedMagnet extends UnplaceableBlock {
     private final ItemSetting<Double> radius = new DoubleRangeSetting(this, "pickup-radius", 0.1, 6.0, Double.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public InfusedMagnet(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public InfusedMagnet(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(radius);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/KnowledgeFlask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/KnowledgeFlask.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class KnowledgeFlask extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public KnowledgeFlask(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public KnowledgeFlask(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/KnowledgeTome.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/KnowledgeTome.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 
 public class KnowledgeTome extends SimpleSlimefunItem<ItemUseHandler> {
 
-    public KnowledgeTome(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public KnowledgeTome(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/MagicEyeOfEnder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/MagicEyeOfEnder.java
@@ -27,8 +27,8 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 public class MagicEyeOfEnder extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public MagicEyeOfEnder(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public MagicEyeOfEnder(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/MagicalZombiePills.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/MagicalZombiePills.java
@@ -43,8 +43,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class MagicalZombiePills extends SimpleSlimefunItem<EntityInteractHandler> implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public MagicalZombiePills(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public MagicalZombiePills(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         addItemHandler(onRightClick());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/SoulboundItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/SoulboundItem.java
@@ -26,8 +26,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.SoulboundList
 public class SoulboundItem extends SlimefunItem implements Soulbound, NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public SoulboundItem(ItemGroup category, SlimefunItemStack item, RecipeType type, ItemStack[] recipe) {
-        super(category, item, type, recipe);
+    public SoulboundItem(ItemGroup itemGroup, SlimefunItemStack item, RecipeType type, ItemStack[] recipe) {
+        super(itemGroup, item, type, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/TelepositionScroll.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/TelepositionScroll.java
@@ -30,8 +30,8 @@ public class TelepositionScroll extends SimpleSlimefunItem<ItemUseHandler> {
     private final ItemSetting<Integer> radius = new IntRangeSetting(this, "radius", 1, 10, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public TelepositionScroll(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public TelepositionScroll(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(radius);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/ElementalRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/ElementalRune.java
@@ -23,13 +23,13 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAlta
 public class ElementalRune extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public ElementalRune(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe) {
-        this(category, item, recipe, null);
+    public ElementalRune(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe) {
+        this(itemGroup, item, recipe, null);
     }
 
     @ParametersAreNonnullByDefault
-    public ElementalRune(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, @Nullable ItemStack recipeResult) {
-        super(category, item, RecipeType.ANCIENT_ALTAR, recipe, recipeResult);
+    public ElementalRune(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, @Nullable ItemStack recipeResult) {
+        super(itemGroup, item, RecipeType.ANCIENT_ALTAR, recipe, recipeResult);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/EnchantmentRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/EnchantmentRune.java
@@ -45,8 +45,8 @@ public class EnchantmentRune extends SimpleSlimefunItem<ItemDropHandler> {
     private final Map<Material, List<Enchantment>> applicableEnchantments = new EnumMap<>(Material.class);
 
     @ParametersAreNonnullByDefault
-    public EnchantmentRune(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public EnchantmentRune(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         for (Material mat : Material.values()) {
             List<Enchantment> enchantments = new ArrayList<>();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
@@ -41,8 +41,8 @@ public class SoulboundRune extends SimpleSlimefunItem<ItemDropHandler> {
     private static final double RANGE = 1.5;
 
     @ParametersAreNonnullByDefault
-    public SoulboundRune(ItemGroup category, SlimefunItemStack item, RecipeType type, ItemStack[] recipe) {
-        super(category, item, type, recipe);
+    public SoulboundRune(ItemGroup itemGroup, SlimefunItemStack item, RecipeType type, ItemStack[] recipe) {
+        super(itemGroup, item, type, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/VillagerRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/VillagerRune.java
@@ -31,8 +31,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class VillagerRune extends SimpleSlimefunItem<EntityInteractHandler> {
 
     @ParametersAreNonnullByDefault
-    public VillagerRune(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public VillagerRune(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/WaterStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/WaterStaff.java
@@ -23,8 +23,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class WaterStaff extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public WaterStaff(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public WaterStaff(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/WindStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/WindStaff.java
@@ -30,8 +30,8 @@ public class WindStaff extends SimpleSlimefunItem<ItemUseHandler> {
     private final ItemSetting<Integer> multiplier = new IntRangeSetting(this, "power", 1, 4, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public WindStaff(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public WindStaff(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(multiplier);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/EnderTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/EnderTalisman.java
@@ -21,11 +21,11 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
  */
 class EnderTalisman extends Talisman {
 
-    private static final LockedItemGroup ENDER_TALISMANS_CATEGORY = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "ender_talismans"), new CustomItemStack(SlimefunItems.ENDER_TALISMAN, "&7Talismans - &aTier II"), 3, Talisman.TALISMANS_CATEGORY.getKey());
+    private static final LockedItemGroup ENDER_TALISMANS_ITEMGROUP = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "ender_talismans"), new CustomItemStack(SlimefunItems.ENDER_TALISMAN, "&7Talismans - &aTier II"), 3, Talisman.TALISMANS_ITEMGROUP.getKey());
 
     @ParametersAreNonnullByDefault
     public EnderTalisman(Talisman parent, SlimefunItemStack item) {
-        super(ENDER_TALISMANS_CATEGORY, item, new ItemStack[] { SlimefunItems.ENDER_LUMP_3, null, SlimefunItems.ENDER_LUMP_3, null, parent.getItem(), null, SlimefunItems.ENDER_LUMP_3, null, SlimefunItems.ENDER_LUMP_3 }, parent.isConsumable(), parent.isEventCancelled(), parent.getMessageSuffix(), parent.getChance(), parent.getEffects());
+        super(ENDER_TALISMANS_ITEMGROUP, item, new ItemStack[] { SlimefunItems.ENDER_LUMP_3, null, SlimefunItems.ENDER_LUMP_3, null, parent.getItem(), null, SlimefunItems.ENDER_LUMP_3, null, SlimefunItems.ENDER_LUMP_3 }, parent.isConsumable(), parent.isEventCancelled(), parent.getMessageSuffix(), parent.getChance(), parent.getEffects());
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -38,7 +38,7 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
 public class Talisman extends SlimefunItem {
 
-    protected static final ItemGroup TALISMANS_CATEGORY = new ItemGroup(new NamespacedKey(Slimefun.instance(), "talismans"), new CustomItemStack(SlimefunItems.COMMON_TALISMAN, "&7Talismans - &aTier I"), 2);
+    protected static final ItemGroup TALISMANS_ITEMGROUP = new ItemGroup(new NamespacedKey(Slimefun.instance(), "talismans"), new CustomItemStack(SlimefunItems.COMMON_TALISMAN, "&7Talismans - &aTier I"), 2);
 
     private final SlimefunItemStack enderTalisman;
 
@@ -60,12 +60,12 @@ public class Talisman extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
     public Talisman(SlimefunItemStack item, ItemStack[] recipe, boolean consumable, boolean cancelEvent, @Nullable String messageSuffix, int chance, PotionEffect... effects) {
-        this(TALISMANS_CATEGORY, item, recipe, consumable, cancelEvent, messageSuffix, chance, effects);
+        this(TALISMANS_ITEMGROUP, item, recipe, consumable, cancelEvent, messageSuffix, chance, effects);
     }
 
     @ParametersAreNonnullByDefault
-    protected Talisman(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, boolean consumable, boolean cancelEvent, @Nullable String messageSuffix, int chance, PotionEffect... effects) {
-        super(category, item, RecipeType.MAGIC_WORKBENCH, recipe, new CustomItemStack(item, consumable ? 4 : 1));
+    protected Talisman(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, boolean consumable, boolean cancelEvent, @Nullable String messageSuffix, int chance, PotionEffect... effects) {
+        super(itemGroup, item, RecipeType.MAGIC_WORKBENCH, recipe, new CustomItemStack(item, consumable ? 4 : 1));
 
         this.consumable = consumable;
         this.cancel = cancelEvent;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Bandage.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Bandage.java
@@ -30,8 +30,8 @@ public class Bandage extends SimpleSlimefunItem<ItemUseHandler> {
     private final int healingLevel;
 
     @ParametersAreNonnullByDefault
-    public Bandage(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, int healingLevel) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public Bandage(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, int healingLevel) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         this.healingLevel = healingLevel;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/MedicalSupply.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/MedicalSupply.java
@@ -25,8 +25,8 @@ public abstract class MedicalSupply<T extends ItemHandler> extends SimpleSlimefu
     private final int healAmount;
 
     @ParametersAreNonnullByDefault
-    protected MedicalSupply(ItemGroup category, int healAmount, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected MedicalSupply(ItemGroup itemGroup, int healAmount, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.healAmount = healAmount;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Medicine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Medicine.java
@@ -12,8 +12,8 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemConsumptionHandler;
 public class Medicine extends MedicalSupply<ItemConsumptionHandler> {
 
     @ParametersAreNonnullByDefault
-    public Medicine(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, 8, item, recipeType, recipe);
+    public Medicine(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, 8, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Splint.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Splint.java
@@ -20,8 +20,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class Splint extends SimpleSlimefunItem<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public Splint(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public Splint(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Vitamins.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/medical/Vitamins.java
@@ -16,8 +16,8 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 public class Vitamins extends MedicalSupply<ItemUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public Vitamins(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, 8, item, recipeType, recipe);
+    public Vitamins(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, 8, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/AlloyIngot.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/AlloyIngot.java
@@ -22,8 +22,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks.Smelt
 public class AlloyIngot extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public AlloyIngot(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe) {
-        super(category, item, RecipeType.SMELTERY, recipe);
+    public AlloyIngot(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe) {
+        super(itemGroup, item, RecipeType.SMELTERY, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/BasicCircuitBoard.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/BasicCircuitBoard.java
@@ -30,8 +30,8 @@ public class BasicCircuitBoard extends SimpleSlimefunItem<ItemUseHandler> implem
     private final ItemSetting<Integer> chance = new IntRangeSetting(this, "golem-drop-chance", 0, 75, 100);
 
     @ParametersAreNonnullByDefault
-    public BasicCircuitBoard(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public BasicCircuitBoard(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(dropSetting);
         addItemSetting(chance);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/CoolantCell.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/CoolantCell.java
@@ -28,13 +28,13 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.electric.reactors
 public class CoolantCell extends UnplaceableBlock {
 
     @ParametersAreNonnullByDefault
-    public CoolantCell(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        this(category, item, recipeType, recipe, null);
+    public CoolantCell(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        this(itemGroup, item, recipeType, recipe, null);
     }
 
     @ParametersAreNonnullByDefault
-    public CoolantCell(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public CoolantCell(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/GoldIngot.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/GoldIngot.java
@@ -30,8 +30,8 @@ public class GoldIngot extends SlimefunItem {
     private final int caratRating;
 
     @ParametersAreNonnullByDefault
-    public GoldIngot(ItemGroup category, int caratRating, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public GoldIngot(ItemGroup itemGroup, int caratRating, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         Validate.isTrue(caratRating > 0, "Carat rating must be above zero.");
         Validate.isTrue(caratRating <= 24, "Carat rating cannot go above 24.");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/OrganicFertilizer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/OrganicFertilizer.java
@@ -27,8 +27,8 @@ public class OrganicFertilizer extends SlimefunItem {
     public static final int OUTPUT = 2;
 
     @ParametersAreNonnullByDefault
-    public OrganicFertilizer(ItemGroup category, SlimefunItemStack item, SlimefunItemStack ingredient) {
-        super(category, item, RecipeType.FOOD_COMPOSTER, new ItemStack[] { ingredient, null, null, null, null, null, null, null, null }, new SlimefunItemStack(item, OUTPUT));
+    public OrganicFertilizer(ItemGroup itemGroup, SlimefunItemStack item, SlimefunItemStack ingredient) {
+        super(itemGroup, item, RecipeType.FOOD_COMPOSTER, new ItemStack[] { ingredient, null, null, null, null, null, null, null, null }, new SlimefunItemStack(item, OUTPUT));
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/OrganicFood.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/OrganicFood.java
@@ -27,8 +27,7 @@ public class OrganicFood extends SlimefunItem {
     public static final int OUTPUT = 2;
 
     @ParametersAreNonnullByDefault
-    public OrganicFood(ItemGroup category, SlimefunItemStack item, Material ingredient) {
-        super(category, item, RecipeType.FOOD_FABRICATOR, new ItemStack[] { SlimefunItems.TIN_CAN, new ItemStack(ingredient), null, null, null, null, null, null, null }, new SlimefunItemStack(item, OUTPUT));
+    public OrganicFood(ItemGroup itemGroup, SlimefunItemStack item, Material ingredient) {
+        super(itemGroup, item, RecipeType.FOOD_FABRICATOR, new ItemStack[] { SlimefunItems.TIN_CAN, new ItemStack(ingredient), null, null, null, null, null, null, null }, new SlimefunItemStack(item, OUTPUT));
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/SteelThruster.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/SteelThruster.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 public class SteelThruster extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public SteelThruster(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SteelThruster(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onRightClickBlock(), onRightClickEntity());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/StrangeNetherGoo.java
@@ -44,8 +44,8 @@ public class StrangeNetherGoo extends SimpleSlimefunItem<ItemUseHandler> impleme
     private final ItemSetting<Integer> chance = new IntRangeSetting(this, "barter-chance", 0, 7, 100);
 
     @ParametersAreNonnullByDefault
-    public StrangeNetherGoo(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public StrangeNetherGoo(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(chance);
         addItemHandler(onRightClickEntity());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/SyntheticEmerald.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/SyntheticEmerald.java
@@ -23,8 +23,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.VillagerTradi
 public class SyntheticEmerald extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    public SyntheticEmerald(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SyntheticEmerald(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         setUseableInWorkbench(true);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractCraftingTable.java
@@ -43,8 +43,8 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 abstract class AbstractCraftingTable extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
-    AbstractCraftingTable(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, BlockFace trigger) {
-        super(category, item, recipe, trigger);
+    AbstractCraftingTable(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, BlockFace trigger) {
+        super(itemGroup, item, recipe, trigger);
     }
 
     protected @Nonnull Inventory createVirtualInventory(@Nonnull Inventory inv) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractSmeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractSmeltery.java
@@ -32,8 +32,8 @@ import io.papermc.lib.PaperLib;
 abstract class AbstractSmeltery extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
-    protected AbstractSmeltery(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe, BlockFace trigger) {
-        super(category, item, recipe, trigger);
+    protected AbstractSmeltery(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, BlockFace trigger) {
+        super(itemGroup, item, recipe, trigger);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -25,8 +25,8 @@ import io.papermc.lib.PaperLib;
 
 public class ArmorForge extends AbstractCraftingTable {
 
-    public ArmorForge(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.ANVIL), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
+    public ArmorForge(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.ANVIL), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
@@ -44,8 +44,8 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
     private final NetherGoldPan netherGoldPan = SlimefunItems.NETHER_GOLD_PAN.getItem(NetherGoldPan.class);
 
     @ParametersAreNonnullByDefault
-    public AutomatedPanningMachine(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.OAK_TRAPDOOR), null, null, new ItemStack(Material.CAULDRON), null }, BlockFace.SELF);
+    public AutomatedPanningMachine(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.OAK_TRAPDOOR), null, null, new ItemStack(Material.CAULDRON), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -28,8 +28,8 @@ import io.papermc.lib.PaperLib;
 public class Compressor extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
-    public Compressor(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.PISTON), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.PISTON) }, BlockFace.SELF);
+    public Compressor(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.PISTON), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.PISTON) }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
@@ -27,8 +27,8 @@ import io.papermc.lib.PaperLib;
 public class EnhancedCraftingTable extends AbstractCraftingTable {
 
     @ParametersAreNonnullByDefault
-    public EnhancedCraftingTable(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.CRAFTING_TABLE), null, null, new ItemStack(Material.DISPENSER), null }, BlockFace.SELF);
+    public EnhancedCraftingTable(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.CRAFTING_TABLE), null, null, new ItemStack(Material.DISPENSER), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -30,8 +30,8 @@ import io.papermc.lib.PaperLib;
 public class GrindStone extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
-    public GrindStone(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.OAK_FENCE), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
+    public GrindStone(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.OAK_FENCE), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Juicer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Juicer.java
@@ -39,8 +39,8 @@ import io.papermc.lib.PaperLib;
 public class Juicer extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
-    public Juicer(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, new ItemStack(Material.GLASS), null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
+    public Juicer(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.GLASS), null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -28,8 +28,8 @@ import io.papermc.lib.PaperLib;
 public class MagicWorkbench extends AbstractCraftingTable {
 
     @ParametersAreNonnullByDefault
-    public MagicWorkbench(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, null, null, null, null, null, new ItemStack(Material.BOOKSHELF), new ItemStack(Material.CRAFTING_TABLE), new ItemStack(Material.DISPENSER) }, BlockFace.UP);
+    public MagicWorkbench(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, null, null, new ItemStack(Material.BOOKSHELF), new ItemStack(Material.CRAFTING_TABLE), new ItemStack(Material.DISPENSER) }, BlockFace.UP);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MakeshiftSmeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MakeshiftSmeltery.java
@@ -29,8 +29,8 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 public class MakeshiftSmeltery extends AbstractSmeltery {
 
     @ParametersAreNonnullByDefault
-    public MakeshiftSmeltery(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, new ItemStack(Material.OAK_FENCE), null, new ItemStack(Material.BRICKS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
+    public MakeshiftSmeltery(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.OAK_FENCE), null, new ItemStack(Material.BRICKS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -42,8 +42,8 @@ public class OreCrusher extends MultiBlockMachine {
     private final DoubleOreSetting doubleOres = new DoubleOreSetting(this);
 
     @ParametersAreNonnullByDefault
-    public OreCrusher(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.IRON_BARS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.IRON_BARS) }, BlockFace.SELF);
+    public OreCrusher(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.IRON_BARS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.IRON_BARS) }, BlockFace.SELF);
 
         addItemSetting(doubleOres);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreWasher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreWasher.java
@@ -54,9 +54,9 @@ public class OreWasher extends MultiBlockMachine {
     private final boolean legacyMode;
 
     @ParametersAreNonnullByDefault
-    public OreWasher(ItemGroup category, SlimefunItemStack item) {
+    public OreWasher(ItemGroup itemGroup, SlimefunItemStack item) {
         // @formatter:off
-        super(category, item, new ItemStack[] {
+        super(itemGroup, item, new ItemStack[] {
             null, new ItemStack(Material.DISPENSER), null,
             null, new ItemStack(Material.OAK_FENCE), null,
             null, new ItemStack(Material.CAULDRON), null

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -28,8 +28,8 @@ import io.papermc.lib.PaperLib;
 public class PressureChamber extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
-    public PressureChamber(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { new ItemStack(Material.SMOOTH_STONE_SLAB), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing down)"), new ItemStack(Material.SMOOTH_STONE_SLAB), new ItemStack(Material.PISTON), new ItemStack(Material.GLASS), new ItemStack(Material.PISTON), new ItemStack(Material.PISTON), new ItemStack(Material.CAULDRON), new ItemStack(Material.PISTON) }, BlockFace.UP);
+    public PressureChamber(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { new ItemStack(Material.SMOOTH_STONE_SLAB), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing down)"), new ItemStack(Material.SMOOTH_STONE_SLAB), new ItemStack(Material.PISTON), new ItemStack(Material.GLASS), new ItemStack(Material.PISTON), new ItemStack(Material.PISTON), new ItemStack(Material.CAULDRON), new ItemStack(Material.PISTON) }, BlockFace.UP);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
@@ -49,8 +49,8 @@ public class Smeltery extends AbstractSmeltery {
     private final ItemSetting<Integer> fireBreakingChance = new IntRangeSetting(this, "fire-breaking-chance", 0, 34, 100);
 
     @ParametersAreNonnullByDefault
-    public Smeltery(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.NETHER_BRICKS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.NETHER_BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
+    public Smeltery(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.NETHER_BRICKS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.NETHER_BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
 
         addItemSetting(fireBreakingChance);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/AdvancedIndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/AdvancedIndustrialMiner.java
@@ -21,8 +21,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
  */
 public class AdvancedIndustrialMiner extends IndustrialMiner {
 
-    public AdvancedIndustrialMiner(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, Material.DIAMOND_BLOCK, true, 5);
+    public AdvancedIndustrialMiner(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, Material.DIAMOND_BLOCK, true, 5);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -57,8 +57,8 @@ public class IndustrialMiner extends MultiBlockMachine {
     private final int range;
 
     @ParametersAreNonnullByDefault
-    public IndustrialMiner(ItemGroup category, SlimefunItemStack item, Material baseMaterial, boolean silkTouch, int range) {
-        super(category, item, new ItemStack[] { null, null, null, new CustomItemStack(Material.PISTON, "Piston (facing up)"), new ItemStack(Material.CHEST), new CustomItemStack(Material.PISTON, "Piston (facing up)"), new ItemStack(baseMaterial), new ItemStack(Material.BLAST_FURNACE), new ItemStack(baseMaterial) }, BlockFace.UP);
+    public IndustrialMiner(ItemGroup itemGroup, SlimefunItemStack item, Material baseMaterial, boolean silkTouch, int range) {
+        super(itemGroup, item, new ItemStack[] { null, null, null, new CustomItemStack(Material.PISTON, "Piston (facing up)"), new ItemStack(Material.CHEST), new CustomItemStack(Material.PISTON, "Piston (facing up)"), new ItemStack(baseMaterial), new ItemStack(Material.BLAST_FURNACE), new ItemStack(baseMaterial) }, BlockFace.UP);
 
         this.range = range;
         this.silkTouch = silkTouch;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/ChristmasPresent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/ChristmasPresent.java
@@ -35,8 +35,8 @@ public class ChristmasPresent extends SimpleSlimefunItem<ItemUseHandler> impleme
     private final ItemStack[] gifts;
 
     @ParametersAreNonnullByDefault
-    public ChristmasPresent(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack... gifts) {
-        super(category, item, recipeType, recipe);
+    public ChristmasPresent(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack... gifts) {
+        super(itemGroup, item, recipeType, recipe);
 
         this.gifts = gifts;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/EasterEgg.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/EasterEgg.java
@@ -35,8 +35,8 @@ public class EasterEgg extends SimpleSlimefunItem<ItemUseHandler> {
     private final ItemStack[] gifts;
 
     @ParametersAreNonnullByDefault
-    public EasterEgg(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, ItemStack... gifts) {
-        super(category, item, recipeType, recipe, recipeOutput);
+    public EasterEgg(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, ItemStack... gifts) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput);
 
         this.gifts = gifts;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/package-info.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/package-info.java
@@ -1,6 +1,6 @@
 /**
- * This package holds implementations of {@link me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem}
- * that can be encountered in a {@link io.github.thebusybiscuit.slimefun4.core.categories.SeasonalCategory}.
+ * This package holds implementations of {@link io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem}
+ * that can be encountered in a {@link io.github.thebusybiscuit.slimefun4.api.items.groups.SeasonalItemGroup}.
  * These items only show up at a certain time of the year.
  */
 package io.github.thebusybiscuit.slimefun4.implementation.items.seasonal;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/AbstractTeleporterPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/AbstractTeleporterPlate.java
@@ -29,8 +29,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.TeleporterLis
 public abstract class AbstractTeleporterPlate extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    protected AbstractTeleporterPlate(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AbstractTeleporterPlate(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/PersonalActivationPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/PersonalActivationPlate.java
@@ -27,8 +27,8 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 public class PersonalActivationPlate extends AbstractTeleporterPlate {
 
     @ParametersAreNonnullByDefault
-    public PersonalActivationPlate(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PersonalActivationPlate(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onPlace());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/PortableTeleporter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/PortableTeleporter.java
@@ -33,8 +33,8 @@ public class PortableTeleporter extends SimpleSlimefunItem<ItemUseHandler> imple
     private final ItemSetting<Integer> cost = new IntRangeSetting(this, "teleportation-cost", 0, DEFAULT_COST, CAPACITY);
 
     @ParametersAreNonnullByDefault
-    public PortableTeleporter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PortableTeleporter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(cost);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/SharedActivationPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/SharedActivationPlate.java
@@ -22,8 +22,8 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 public class SharedActivationPlate extends AbstractTeleporterPlate {
 
     @ParametersAreNonnullByDefault
-    public SharedActivationPlate(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SharedActivationPlate(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/Teleporter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/Teleporter.java
@@ -30,8 +30,8 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 public class Teleporter extends SimpleSlimefunItem<BlockPlaceHandler> {
 
     @ParametersAreNonnullByDefault
-    public Teleporter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public Teleporter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/TeleporterPylon.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/teleporter/TeleporterPylon.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.RainbowBlo
 public class TeleporterPylon extends RainbowBlock {
 
     @ParametersAreNonnullByDefault
-    public TeleporterPylon(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        super(category, item, recipeType, recipe, recipeOutput, new RainbowTickHandler(Material.CYAN_STAINED_GLASS, Material.PURPLE_STAINED_GLASS));
+    public TeleporterPylon(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(itemGroup, item, recipeType, recipe, recipeOutput, new RainbowTickHandler(Material.CYAN_STAINED_GLASS, Material.PURPLE_STAINED_GLASS));
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ClimbingPick.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ClimbingPick.java
@@ -65,8 +65,8 @@ public class ClimbingPick extends SimpleSlimefunItem<ItemUseHandler> implements 
     private final Set<UUID> users = new HashSet<>();
 
     @ParametersAreNonnullByDefault
-    public ClimbingPick(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ClimbingPick(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
         addItemSetting(dualWielding, damageOnUse);
         addDefaultSurfaces();
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosivePickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosivePickaxe.java
@@ -22,8 +22,8 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 public class ExplosivePickaxe extends ExplosiveTool {
 
     @ParametersAreNonnullByDefault
-    public ExplosivePickaxe(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ExplosivePickaxe(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
@@ -26,8 +26,8 @@ import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 public class ExplosiveShovel extends ExplosiveTool {
 
     @ParametersAreNonnullByDefault
-    public ExplosiveShovel(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ExplosiveShovel(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -48,8 +48,8 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
     private final ItemSetting<Boolean> callExplosionEvent = new ItemSetting<>(this, "call-explosion-event", false);
 
     @ParametersAreNonnullByDefault
-    public ExplosiveTool(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public ExplosiveTool(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(damageOnUse, callExplosionEvent);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -52,8 +52,8 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
     private final Set<GoldPanDrop> drops = new HashSet<>();
 
     @ParametersAreNonnullByDefault
-    public GoldPan(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public GoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         drops.addAll(getGoldPanDrops());
         addItemSetting(drops.toArray(new GoldPanDrop[0]));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
@@ -44,8 +44,8 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
     private final ItemSetting<Integer> despawnTicks = new IntRangeSetting(this, "despawn-seconds", 0, 60, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public GrapplingHook(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public GrapplingHook(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(despawnTicks);
         addItemSetting(consumeOnUse);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -18,8 +18,8 @@ import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 public class HerculesPickaxe extends SimpleSlimefunItem<ToolUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public HerculesPickaxe(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public HerculesPickaxe(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
@@ -41,8 +41,8 @@ public class LumberAxe extends SlimefunItem implements NotPlaceable {
     private static final int MAX_STRIPPED = 20;
 
     @ParametersAreNonnullByDefault
-    public LumberAxe(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public LumberAxe(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemHandler(onBlockBreak(), onItemUse());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.settings.GoldPanDrop;
 public class NetherGoldPan extends GoldPan {
 
     @ParametersAreNonnullByDefault
-    public NetherGoldPan(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public NetherGoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
@@ -39,8 +39,8 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 public class PickaxeOfContainment extends SimpleSlimefunItem<ToolUseHandler> {
 
     @ParametersAreNonnullByDefault
-    public PickaxeOfContainment(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PickaxeOfContainment(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfTheSeeker.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfTheSeeker.java
@@ -32,8 +32,8 @@ public class PickaxeOfTheSeeker extends SimpleSlimefunItem<ItemUseHandler> imple
     private final ItemSetting<Integer> maxRange = new IntRangeSetting(this, "max-range", 1, 5, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public PickaxeOfTheSeeker(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PickaxeOfTheSeeker(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(maxRange);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
@@ -38,8 +38,8 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<ToolUseHandler> {
     private final ItemSetting<Integer> maxBlocks = new IntRangeSetting(this, "max-blocks", 1, 16, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public PickaxeOfVeinMining(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PickaxeOfVeinMining(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
         addItemSetting(maxBlocks);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PortableCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PortableCrafter.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class PortableCrafter extends SimpleSlimefunItem<ItemUseHandler> implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public PortableCrafter(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PortableCrafter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PortableDustbin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PortableDustbin.java
@@ -29,8 +29,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 public class PortableDustbin extends SimpleSlimefunItem<ItemUseHandler> implements NotPlaceable {
 
     @ParametersAreNonnullByDefault
-    public PortableDustbin(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public PortableDustbin(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/SmeltersPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/SmeltersPickaxe.java
@@ -30,8 +30,8 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 public class SmeltersPickaxe extends SimpleSlimefunItem<ToolUseHandler> implements DamageableItem {
 
     @ParametersAreNonnullByDefault
-    public SmeltersPickaxe(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SmeltersPickaxe(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TapeMeasure.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TapeMeasure.java
@@ -40,8 +40,8 @@ public class TapeMeasure extends SimpleSlimefunItem<ItemUseHandler> implements N
     private final DecimalFormat format = new DecimalFormat("##.###");
 
     @ParametersAreNonnullByDefault
-    public TapeMeasure(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public TapeMeasure(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -38,8 +38,8 @@ public class ExplosiveBow extends SlimefunBow {
     private final ItemSetting<Integer> range = new IntRangeSetting(this, "explosion-range", 1, 3, Integer.MAX_VALUE);
 
     @ParametersAreNonnullByDefault
-    public ExplosiveBow(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe) {
-        super(category, item, recipe);
+    public ExplosiveBow(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe) {
+        super(itemGroup, item, recipe);
 
         addItemSetting(range);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/IcyBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/IcyBow.java
@@ -28,8 +28,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 public class IcyBow extends SlimefunBow {
 
     @ParametersAreNonnullByDefault
-    public IcyBow(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe) {
-        super(category, item, recipe);
+    public IcyBow(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe) {
+        super(itemGroup, item, recipe);
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SeismicAxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SeismicAxe.java
@@ -53,8 +53,8 @@ public class SeismicAxe extends SimpleSlimefunItem<ItemUseHandler> implements No
     private static final int RANGE = 10;
 
     @ParametersAreNonnullByDefault
-    public SeismicAxe(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SeismicAxe(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SlimefunBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SlimefunBow.java
@@ -23,8 +23,8 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.BowShootHandler;
 public abstract class SlimefunBow extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
-    protected SlimefunBow(ItemGroup category, SlimefunItemStack item, ItemStack[] recipe) {
-        super(category, item, RecipeType.MAGIC_WORKBENCH, recipe);
+    protected SlimefunBow(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe) {
+        super(itemGroup, item, RecipeType.MAGIC_WORKBENCH, recipe);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
@@ -44,8 +44,8 @@ public class SwordOfBeheading extends SimpleSlimefunItem<EntityKillHandler> {
     private final ItemSetting<Integer> chancePlayer = new IntRangeSetting(this, "chance.PLAYER", 0, 70, 100);
 
     @ParametersAreNonnullByDefault
-    public SwordOfBeheading(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public SwordOfBeheading(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(chanceZombie, chanceSkeleton, chanceWitherSkeleton, chanceCreeper, chancePlayer);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/VampireBlade.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/VampireBlade.java
@@ -33,8 +33,8 @@ public class VampireBlade extends SimpleSlimefunItem<WeaponUseHandler> {
     private final ItemSetting<Integer> chance = new IntRangeSetting(this, "chance", 0, 45, 100);
 
     @ParametersAreNonnullByDefault
-    public VampireBlade(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    public VampireBlade(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(chance);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -2633,7 +2633,7 @@ public final class SlimefunItemSetup {
     }
 
     @ParametersAreNonnullByDefault
-    private static void registerArmorSet(ItemGroup category, ItemStack baseComponent, ItemStack[] items, String idSyntax, boolean vanilla, PotionEffect[][] effects, SlimefunAddon addon) {
+    private static void registerArmorSet(ItemGroup itemGroup, ItemStack baseComponent, ItemStack[] items, String idSyntax, boolean vanilla, PotionEffect[][] effects, SlimefunAddon addon) {
         String[] components = new String[] { "_HELMET", "_CHESTPLATE", "_LEGGINGS", "_BOOTS" };
         List<ItemStack[]> recipes = new ArrayList<>();
 
@@ -2644,11 +2644,11 @@ public final class SlimefunItemSetup {
 
         for (int i = 0; i < 4; i++) {
             if (vanilla) {
-                new VanillaItem(category, items[i], idSyntax + components[i], RecipeType.ARMOR_FORGE, recipes.get(i)).register(addon);
+                new VanillaItem(itemGroup, items[i], idSyntax + components[i], RecipeType.ARMOR_FORGE, recipes.get(i)).register(addon);
             } else if (i < effects.length && effects[i].length > 0) {
-                new SlimefunArmorPiece(category, new SlimefunItemStack(idSyntax + components[i], items[i]), RecipeType.ARMOR_FORGE, recipes.get(i), effects[i]).register(addon);
+                new SlimefunArmorPiece(itemGroup, new SlimefunItemStack(idSyntax + components[i], items[i]), RecipeType.ARMOR_FORGE, recipes.get(i), effects[i]).register(addon);
             } else {
-                new SlimefunItem(category, new SlimefunItemStack(idSyntax + components[i], items[i]), RecipeType.ARMOR_FORGE, recipes.get(i)).register(addon);
+                new SlimefunItem(itemGroup, new SlimefunItemStack(idSyntax + components[i], items[i]), RecipeType.ARMOR_FORGE, recipes.get(i)).register(addon);
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChestMenuUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChestMenuUtils.java
@@ -74,7 +74,7 @@ public final class ChestMenuUtils {
     }
 
     public static @Nonnull ItemStack getMenuButton(@Nonnull Player p) {
-        return new CustomItemStack(MENU_BUTTON, ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "guide.title.settings"), "", "&7\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-category"));
+        return new CustomItemStack(MENU_BUTTON, ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "guide.title.settings"), "", "&7\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup"));
     }
 
     public static @Nonnull ItemStack getSearchButton(@Nonnull Player p) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -60,8 +60,8 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
     private int processingSpeed = -1;
 
     @ParametersAreNonnullByDefault
-    protected AContainer(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AContainer(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         processor.setProgressBar(getProgressBar());
         createPreset(this, getInventoryTitle(), this::constructMenu);
@@ -89,8 +89,8 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
     }
 
     @ParametersAreNonnullByDefault
-    protected AContainer(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-        this(category, item, recipeType, recipe);
+    protected AContainer(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        this(itemGroup, item, recipeType, recipe);
         this.recipeOutput = recipeOutput;
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -54,8 +54,8 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
     private int energyCapacity = -1;
 
     @ParametersAreNonnullByDefault
-    protected AGenerator(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(category, item, recipeType, recipe);
+    protected AGenerator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
 
         processor.setProgressBar(getProgressBar());
 

--- a/src/main/resources/languages/ar/messages.yml
+++ b/src/main/resources/languages/ar/messages.yml
@@ -15,7 +15,7 @@ commands:
     reset-target: '&cتم تصفير أبحاثك'
 guide:
   locked: 'مغلق'
-  locked-category:
+  locked-itemgroup:
     - 'لفتح هذه الفئة يجب'
     - 'أن تفتح كل العناصر في'
     - 'الفئات التالية'
@@ -25,7 +25,7 @@ guide:
     tooltip: '&bانقر للبحث عن عنصر'
     inventory: 'البحث عن: %item%'
   tooltips:
-    open-category: 'اضغط للفتح'
+    open-itemgroup: 'اضغط للفتح'
     versions-notice: 'هذه القيم مهمة جدا أثناء الإبلاغ عن أخطاء!'
     wiki: 'عرض هذا العنصر في الويكي الرسمي لسلايم فان'
     recipes:

--- a/src/main/resources/languages/bg/messages.yml
+++ b/src/main/resources/languages/bg/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: 'ЗАКЛЮЧЕНО'
   work-in-progress: 'Тази функция не е завършена все още!'
-  locked-category:
+  locked-itemgroup:
     - 'За да отключите тази категория'
     - 'ще трябва да отключите всички предмети от'
     - 'следните категории'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&bНатисни, за да търсиш предмет'
     inventory: 'Търсене за: %item%'
   tooltips:
-    open-category: 'Натиснете, за да отворите'
+    open-itemgroup: 'Натиснете, за да отворите'
     versions-notice: 'Тези са много важни, когато докладвате бъгове!'
     wiki: 'Вижте този Предмет в официалното Уики на Slimefun'
     recipes:

--- a/src/main/resources/languages/cs/messages.yml
+++ b/src/main/resources/languages/cs/messages.yml
@@ -28,7 +28,7 @@ placeholderapi:
 guide:
   locked: 'ZAMČENO'
   work-in-progress: 'Tato funkce ještě není zcela dokončena!'
-  locked-category:
+  locked-itemgroup:
     - 'Chceš-li odemknout tuto kategorii,'
     - 'je potřeba odemknout všechny předměty'
     - 'z předchozích kategorií'
@@ -38,7 +38,7 @@ guide:
     tooltip: '&bKlikni pro vyhledání předmětu'
     inventory: 'Hledání: %item%'
   tooltips:
-    open-category: 'Klikni pro otevření'
+    open-itemgroup: 'Klikni pro otevření'
     versions-notice: 'To jsou velmi důležité při hlášení chyb!'
     wiki: 'Zobrazit tento předmět na oficiální Slimefun Wiki'
     recipes:

--- a/src/main/resources/languages/de/messages.yml
+++ b/src/main/resources/languages/de/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: 'GESPERRT'
   work-in-progress: 'Dieses Feature befindet sich noch in der Testphase!'
-  locked-category:
+  locked-itemgroup:
     - 'Um diese Kategorie freizuschalten,'
     - 'müssen zuerst sämtliche Items der'
     - 'folgenden Kategorien freigeschaltet werden'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&bKlicke um die Suche zu starten'
     inventory: 'Suche nach: %item%'
   tooltips:
-    open-category: 'Klicke zum Öffnen'
+    open-itemgroup: 'Klicke zum Öffnen'
     versions-notice: 'Dies ist sehr wichtig bei Fehlermeldungen!'
     wiki: 'Besuche das offizielle Slimefun-Wiki'
     recipes:

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -39,7 +39,7 @@ guide:
   locked: 'LOCKED'
   work-in-progress: 'This feature is not fully finished yet!'
 
-  locked-category:
+  locked-itemgroup:
   - 'To unlock this category you will'
   - 'need to unlock all items from the'
   - 'following categories'
@@ -51,7 +51,7 @@ guide:
     inventory: 'Searching for: %item%'
 
   tooltips:
-    open-category: 'Click to open'
+    open-itemgroup: 'Click to open'
     versions-notice: 'These are very important when reporting bugs!'
     wiki: 'View this Item on the official Slimefun Wiki'
 

--- a/src/main/resources/languages/es/messages.yml
+++ b/src/main/resources/languages/es/messages.yml
@@ -31,7 +31,7 @@ commands:
 guide:
   locked: 'BLOQUEADO'
   work-in-progress: '¡¡¡Esta característica no está completamente terminada todavía!!'
-  locked-category:
+  locked-itemgroup:
     - 'Para desbloquear esta categoría deberás'
     - 'desbloquear todos los objetos de las'
     - 'siguientes categorías'
@@ -41,7 +41,7 @@ guide:
     tooltip: '&bCliquea para buscar un objeto'
     inventory: 'Buscando: %item%'
   tooltips:
-    open-category: 'Cliquea para abrir'
+    open-itemgroup: 'Cliquea para abrir'
     versions-notice: '¡Esto es muy importante cuando se reportan bugs!'
     wiki: 'Ve este objeto en la wiki oficial de Slimefun'
     recipes:

--- a/src/main/resources/languages/fr/messages.yml
+++ b/src/main/resources/languages/fr/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: 'VERROUILLÉ'
   work-in-progress: 'Cette fonctionnalité n''est pas encore complètement terminée !'
-  locked-category:
+  locked-itemgroup:
     - 'Pour déverrouiller cette catégorie, vous devrez'
     - 'déverrouiller tous les objets des'
     - 'catégories suivantes'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&bCliquez pour rechercher un objet'
     inventory: 'Rechercher: %item%'
   tooltips:
-    open-category: 'Cliquez pour ouvrir'
+    open-itemgroup: 'Cliquez pour ouvrir'
     versions-notice: 'Ces informations sont très importantes lorsque vous rapportez des bugs !'
     wiki: 'Voir cet objet sur le wiki officiel de Slimefun'
     recipes:

--- a/src/main/resources/languages/he/messages.yml
+++ b/src/main/resources/languages/he/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: 'נעול'
   work-in-progress: 'תכונה זו עדיין לא הושלמה במלואה!'
-  locked-category:
+  locked-itemgroup:
     - 'כדי לבטל את הנעילה של קטגוריה זו'
     - 'צריך לפתוח את כל הפריטים מה '
     - 'הקטגוריות הבאות'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&b לחץ לחפש פריט'
     inventory: '%item% מחפש עבור: '
   tooltips:
-    open-category: 'לחץ לפתיחה'
+    open-itemgroup: 'לחץ לפתיחה'
     versions-notice: 'אלה חשובים מאוד כשמדווחים על באגים!'
     wiki: 'ראה פריט זה באתר הרשימי של סליים פאן ויקי'
     recipes:

--- a/src/main/resources/languages/hu/messages.yml
+++ b/src/main/resources/languages/hu/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: 'LEZÁRVA'
   work-in-progress: 'Ez a funkció még nem készült el teljesen!'
-  locked-category:
+  locked-itemgroup:
     - 'Ennek a kategóriának a feloldásához'
     - 'fel kell oldanod az összes tárgyat'
     - 'a következő kategóriákból'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&bKlikk egy tárgy kereséséhez'
     inventory: 'Keresés erre: %item%'
   tooltips:
-    open-category: 'Kattints a megnyitáshoz'
+    open-itemgroup: 'Kattints a megnyitáshoz'
     versions-notice: 'Ezek nagyon fontosak a hibák jelentésekor!'
     wiki: 'Tekintsd meg ezt a tárgyat a hivatalos Slimefun Wikin'
     recipes:

--- a/src/main/resources/languages/id/messages.yml
+++ b/src/main/resources/languages/id/messages.yml
@@ -21,7 +21,7 @@ commands:
     restored-backpack-given: '&a Backpack Anda telah di tambahkan ke inventory Anda!'
 guide:
   locked: 'TERKUNCI'
-  locked-category:
+  locked-itemgroup:
     - 'Untuk membuka kategori ini anda'
     - 'harus membuka semua barang dari'
     - 'kategori berikut'
@@ -31,7 +31,7 @@ guide:
     tooltip: '&bKlik untuk mencari sebuah barang'
     inventory: 'Hasil pencarian: %item%'
   tooltips:
-    open-category: 'Klik untuk membuka'
+    open-itemgroup: 'Klik untuk membuka'
     versions-notice: 'Melaporkan kesalahan program sangatlah penting!'
     wiki: 'Lihat benda ini di wiki resmi Slimefun'
     recipes:

--- a/src/main/resources/languages/it/messages.yml
+++ b/src/main/resources/languages/it/messages.yml
@@ -15,7 +15,7 @@ commands:
     reset-target: '&cLa tua conoscenza è stata resettata'
 guide:
   locked: 'BLOCCATO'
-  locked-category:
+  locked-itemgroup:
     - 'Per sbloccare questa categoria'
     - 'è necessario sbloccare tutti gli elementi dalle'
     - 'seguenti categorie'
@@ -25,7 +25,7 @@ guide:
     tooltip: '&bClicca per cercare un elemento'
     inventory: 'Ricerca di: %item%'
   tooltips:
-    open-category: 'Clicca per aprire'
+    open-itemgroup: 'Clicca per aprire'
     versions-notice: 'Questi sono molto importanti quando stai reportando dei bugs!'
     wiki: 'Visualizza questo elemento sulla Wiki ufficiale di Slimefun'
     recipes:

--- a/src/main/resources/languages/ja/messages.yml
+++ b/src/main/resources/languages/ja/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: 'ロック中'
   work-in-progress: 'まだこの項目は未完成です！'
-  locked-category:
+  locked-itemgroup:
     - 'このカテゴリを開放するには'
     - '以下のカテゴリの全アイテムを'
     - 'リサーチしてください'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&bクリックでアイテムの検索'
     inventory: '検索結果: %item%'
   tooltips:
-    open-category: 'クリックで開く'
+    open-itemgroup: 'クリックで開く'
     versions-notice: 'バグ報告をお願いします！'
     wiki: 'このアイテムを公式Wikiで確認する'
     recipes:

--- a/src/main/resources/languages/ko/messages.yml
+++ b/src/main/resources/languages/ko/messages.yml
@@ -21,7 +21,7 @@ commands:
     restored-backpack-given: '&a배낭이 복원되어 인벤토리에 추가되었습니다!'
 guide:
   locked: '잠금'
-  locked-category:
+  locked-itemgroup:
     - '이 카테고리의 잠금을 해제하려면'
     - '에서 모든 아이템의 잠금을 해제할 필요가 있다.'
     - '다음 카테고리'
@@ -31,7 +31,7 @@ guide:
     tooltip: '&b아이템을 검색하려면 클릭하십시오.'
     inventory: '검색중: %item%'
   tooltips:
-    open-category: '열려면 클릭하십시오. '
+    open-itemgroup: '열려면 클릭하십시오. '
     versions-notice: '이것들은 버그를 보고할 때 매우 중요하다! '
     wiki: '공식 Slimefun Wiki에서 이 항목보기'
     recipes:

--- a/src/main/resources/languages/nl/messages.yml
+++ b/src/main/resources/languages/nl/messages.yml
@@ -28,7 +28,7 @@ placeholderapi:
 guide:
   locked: 'VERGRENDELD'
   work-in-progress: 'Dit is nog niet helemaal klaar!'
-  locked-category:
+  locked-itemgroup:
     - 'Om deze categorie te ontgrendelen zul je'
     - 'alle items moeten ontgrendelen van de'
     - 'volgende categorieën'
@@ -38,7 +38,7 @@ guide:
     tooltip: '&bKlik om naar een item te zoeken'
     inventory: 'Zoeken naar: %item%'
   tooltips:
-    open-category: 'Klik om te openen'
+    open-itemgroup: 'Klik om te openen'
     versions-notice: 'Deze zijn erg belangrijk voor het rapporteren van fouten!'
     wiki: 'Bekijk dit voorwerp op de officiële Slimefun Wiki'
     recipes:

--- a/src/main/resources/languages/pl/messages.yml
+++ b/src/main/resources/languages/pl/messages.yml
@@ -15,7 +15,7 @@ commands:
     reset-target: '&c Twoja wiedza została zresetowana'
 guide:
   locked: 'Zablokowany'
-  locked-category:
+  locked-itemgroup:
     - 'Aby odblokować tę kategorię, będziesz'
     - 'Musisz odblokować wszystkie przedmioty z'
     - 'Następujące kategorie'
@@ -25,7 +25,7 @@ guide:
     tooltip: '&bKliknij, aby wyszukać przedmiot'
     inventory: 'Wyszukiwanie dla: % item%'
   tooltips:
-    open-category: 'Kliknij, aby otworzyć'
+    open-itemgroup: 'Kliknij, aby otworzyć'
     versions-notice: 'Jest to bardzo ważne przy zgłaszaniu błędów!'
     wiki: 'Zobacz ten przedmiot na oficjalnej stronie Wiki Slimefun'
     recipes:

--- a/src/main/resources/languages/pt-BR/messages.yml
+++ b/src/main/resources/languages/pt-BR/messages.yml
@@ -26,7 +26,7 @@ commands:
 guide:
   locked: 'BLOQUEADO'
   work-in-progress: 'Este recurso não está totalmente concluído ainda!'
-  locked-category:
+  locked-itemgroup:
     - 'Para desbloquear esta categoria, você'
     - 'precisa desbloquear todos os itens das'
     - 'seguintes categorias'
@@ -36,7 +36,7 @@ guide:
     tooltip: '&bClique para procurar um item'
     inventory: 'Procurando por: %item%'
   tooltips:
-    open-category: 'Clique aqui para abrir'
+    open-itemgroup: 'Clique aqui para abrir'
     versions-notice: 'Isso é muito importante ao relatar erros!'
     wiki: 'Veja mais sobre esse item na Wiki oficial do Slimefun'
     recipes:

--- a/src/main/resources/languages/ru/messages.yml
+++ b/src/main/resources/languages/ru/messages.yml
@@ -26,7 +26,7 @@ commands:
 guide:
   locked: 'ЗАБЛОКИРОВАНО'
   work-in-progress: 'Эта функция ещё не полностью завершена!'
-  locked-category:
+  locked-itemgroup:
     - 'Для начала Вы должны'
     - 'разблокировать все предметы'
     - 'из следующих категорий'
@@ -36,7 +36,7 @@ guide:
     tooltip: '&bНажмите для поиска предмета'
     inventory: 'Поиск: %item%'
   tooltips:
-    open-category: 'Нажмите, чтобы открыть'
+    open-itemgroup: 'Нажмите, чтобы открыть'
     versions-notice: 'Это очень важно, когда Вы сообщаете об ошибках!'
     wiki: 'Просмотреть этот предмет на официальной Slimefun Вики'
     recipes:

--- a/src/main/resources/languages/sk/messages.yml
+++ b/src/main/resources/languages/sk/messages.yml
@@ -15,7 +15,7 @@ commands:
     reset-target: '&cTvoja znalosť bola resetnutá'
 guide:
   locked: 'ZAMKNUTÉ'
-  locked-category:
+  locked-itemgroup:
     - 'Pre odomknutie tejto kategórie'
     - 'budeš musieť odomknúť všetky itemy'
     - 'z nasledujúcich kategórií'
@@ -25,7 +25,7 @@ guide:
     tooltip: '&bKlikni pre hľadanie itemu'
     inventory: 'Hľadám: %item%'
   tooltips:
-    open-category: 'Klikni pre otvorenie'
+    open-itemgroup: 'Klikni pre otvorenie'
     versions-notice: 'Toto je veľmi dôležité pri nahlasovaní bugov!'
     wiki: 'Pozri si tento item na oficiálnej wiki slimefunu'
     recipes:

--- a/src/main/resources/languages/sv/messages.yml
+++ b/src/main/resources/languages/sv/messages.yml
@@ -15,7 +15,7 @@ commands:
     reset-target: '&cDin kunskap har blivit återställd'
 guide:
   locked: 'LÅST'
-  locked-category:
+  locked-itemgroup:
     - 'För att låsa upp denna kategori måste du'
     - 'låsa upp alla föremål från de'
     - 'följande kategorierna'
@@ -25,7 +25,7 @@ guide:
     tooltip: '&bKlicka här för att söka efter ett föremål'
     inventory: 'Söker efter: %item%'
   tooltips:
-    open-category: 'Klicka här för att öppna'
+    open-itemgroup: 'Klicka här för att öppna'
     versions-notice: 'Dessa är väldigt viktiga när det kommer till att rapportera buggar!'
     wiki: 'Visar detta föremål på den Officiella Slimefun Wikin'
     recipes:

--- a/src/main/resources/languages/th/messages.yml
+++ b/src/main/resources/languages/th/messages.yml
@@ -15,7 +15,7 @@ commands:
     reset-target: '&cความรู้ของคุณได้รับการรีเซ็ตแล้ว'
 guide:
   locked: 'ล็อค'
-  locked-category:
+  locked-itemgroup:
     - 'เพื่อที่จะปลดล็อครายการนี้'
     - 'คุณจะต้องปลดล็อคไอเท็มทั้งหมด'
     - 'ในหน้านี้ก่อน'
@@ -25,7 +25,7 @@ guide:
     tooltip: '&bคลิกเพื่อค้นหาไอเทม'
     inventory: 'ค้นหา: %item%'
   tooltips:
-    open-category: 'คลิกเพื่อเปิด'
+    open-itemgroup: 'คลิกเพื่อเปิด'
     versions-notice: 'มันสำคัญมาก ที่จะรายงานบัค!'
     wiki: 'ตรวจสอบไอเท็มนี้บน Slimefun Wiki'
     recipes:

--- a/src/main/resources/languages/tl/messages.yml
+++ b/src/main/resources/languages/tl/messages.yml
@@ -26,7 +26,7 @@ commands:
 guide:
   locked: 'NAKAKANDADO'
   work-in-progress: 'Ang feature na ito ay hindi pa tapos!'
-  locked-category:
+  locked-itemgroup:
     - 'Upang i-unlock ang kategoryang ito,'
     - 'kailangang i-unlock ang lahat ng mga item mula sa'
     - 'sumusunod na kategorya.'
@@ -36,7 +36,7 @@ guide:
     tooltip: '&bI-click ito upang maghanap para sa isang item.'
     inventory: 'Naghahanap para sa: %item%'
   tooltips:
-    open-category: 'I-click ito para buksan.'
+    open-itemgroup: 'I-click ito para buksan.'
     versions-notice: 'Napakahalaga ng mga ito kapag nag-uulat ng mga bug!'
     wiki: 'Tingnan ang item na ito sa opisyal na Slimefun Wiki.'
     recipes:

--- a/src/main/resources/languages/tr/messages.yml
+++ b/src/main/resources/languages/tr/messages.yml
@@ -26,7 +26,7 @@ commands:
 guide:
   locked: 'KİLİTLİ'
   work-in-progress: 'Bu özellik henüz tamamlanmadı!'
-  locked-category:
+  locked-itemgroup:
     - 'Bu kategoriyi açmak için'
     - 'aşağıdaki kategorilerde bulunan'
     - 'bütün eşyaları açın'
@@ -36,7 +36,7 @@ guide:
     tooltip: '&bBir eşyayı aramak için tıklayın'
     inventory: 'Eşya aranıyor: %item%'
   tooltips:
-    open-category: 'Açmak için tıklayın'
+    open-itemgroup: 'Açmak için tıklayın'
     versions-notice: 'Hata bildirirken bunlar çok önemlidir!'
     wiki: 'Bu eşyayı Slimefun Wikisinde görüntüle'
     recipes:

--- a/src/main/resources/languages/uk/messages.yml
+++ b/src/main/resources/languages/uk/messages.yml
@@ -21,7 +21,7 @@ commands:
     restored-backpack-given: '&aРюкзак відновлено та додано в Ваш інвентар!'
 guide:
   locked: 'ЗАКРИТО'
-  locked-category:
+  locked-itemgroup:
     - 'Для розблокування цієї категорії'
     - 'спочатку відкрийте всі предмети'
     - 'з категорій нижче'
@@ -31,7 +31,7 @@ guide:
     tooltip: '&bНатисніть для пошуку предмету'
     inventory: 'Пошук: %item%'
   tooltips:
-    open-category: 'Натисніть, що відкрити'
+    open-itemgroup: 'Натисніть, що відкрити'
     versions-notice: 'Це дуже важливо, коли Ви повідомляєте про помилки!'
     wiki: 'Переглянути цей предмет на офіційній Slimefun Вікі'
     recipes:

--- a/src/main/resources/languages/vi/messages.yml
+++ b/src/main/resources/languages/vi/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: 'ĐÃ KHÓA'
   work-in-progress: 'Tính năng này vẫn chưa hoàn thành!'
-  locked-category:
+  locked-itemgroup:
     - 'Để mở khóa danh mục này, bạn'
     - 'cần phải mở khóa các vật phẩm trong'
     - 'danh mục sau'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&bBấm để tìm vật phẩm'
     inventory: 'Đang tìm: %item%'
   tooltips:
-    open-category: 'Nhấn vào đây để mở'
+    open-itemgroup: 'Nhấn vào đây để mở'
     versions-notice: 'Đây là rất quan trọng khi báo cáo lỗi!'
     wiki: 'Xem vật phẩm này trên trang wiki chính thức của Slimefun'
     recipes:

--- a/src/main/resources/languages/zh-CN/messages.yml
+++ b/src/main/resources/languages/zh-CN/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: '已锁定'
   work-in-progress: '该功能暂未推出!'
-  locked-category:
+  locked-itemgroup:
     - '为了解锁这一类别'
     - '你需要先解锁以下'
     - '类别里的所有物品'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&b单击搜索物品'
     inventory: '正在搜索: %item%'
   tooltips:
-    open-category: '单击打开'
+    open-itemgroup: '单击打开'
     versions-notice: '在反馈问题时这些很重要!'
     wiki: '在官方 Slimefun 维基上查看此物品'
     recipes:

--- a/src/main/resources/languages/zh-TW/messages.yml
+++ b/src/main/resources/languages/zh-TW/messages.yml
@@ -33,7 +33,7 @@ placeholderapi:
 guide:
   locked: '已鎖定'
   work-in-progress: '此功能尚未開發完成！'
-  locked-category:
+  locked-itemgroup:
     - '要解鎖此分類'
     - '必須先解鎖下列分類'
     - '的所有物品'
@@ -43,7 +43,7 @@ guide:
     tooltip: '&b點擊以尋找物品'
     inventory: '搜尋：%item%'
   tooltips:
-    open-category: '點擊開啟'
+    open-itemgroup: '點擊開啟'
     versions-notice: '這些在回報錯誤時非常重要！'
     wiki: '在Slimefun官方Wiki上查看此物品'
     recipes:

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
@@ -114,23 +114,23 @@ class TestGuideHistory {
     }
 
     @Test
-    @DisplayName("Test adding a Category to Guide History")
-    void testCategory() throws InterruptedException {
+    @DisplayName("Test adding an ItemGroup to Guide History")
+    void testItemGroup() throws InterruptedException {
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
         GuideHistory history = profile.getGuideHistory();
 
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "category_guide_history"), new CustomItemStack(Material.BEDROCK, "&4Can't touch this"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "category_guide_history"), new CustomItemStack(Material.BEDROCK, "&4Can't touch this"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> history.add((ItemGroup) null, 1));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> history.add(category, -20));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> history.add(itemGroup, -20));
 
         Assertions.assertEquals(0, history.size());
-        history.add(category, 1);
+        history.add(itemGroup, 1);
         Assertions.assertEquals(1, history.size());
 
         // This should not add a new entry but rather only update the page
-        history.add(category, 2);
+        history.add(itemGroup, 2);
         Assertions.assertEquals(1, history.size());
     }
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
@@ -120,7 +120,7 @@ class TestGuideHistory {
         PlayerProfile profile = TestUtilities.awaitProfile(player);
         GuideHistory history = profile.getGuideHistory();
 
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "category_guide_history"), new CustomItemStack(Material.BEDROCK, "&4Can't touch this"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "itemgroup_guide_history"), new CustomItemStack(Material.BEDROCK, "&4Can't touch this"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> history.add((ItemGroup) null, 1));
         Assertions.assertThrows(IllegalArgumentException.class, () -> history.add(itemGroup, -20));

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestChargeCommand.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestChargeCommand.java
@@ -40,9 +40,9 @@ class TestChargeCommand {
     @Test
     @DisplayName("Test if /sf charge charges the item the player is holding")
     void testCommand() {
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "rechargeable");
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "rechargeable");
         SlimefunItemStack RECHARGEABLE_ITEM = new SlimefunItemStack("SF_CHARGE_TEST_ITEM", Material.REDSTONE_BLOCK, "Rechargeable Item", "This isn't real", LoreBuilder.powerCharged(0, 100));
-        new RechargeableMock(category, RECHARGEABLE_ITEM, RecipeType.NULL, new ItemStack[9]).register(plugin);
+        new RechargeableMock(itemGroup, RECHARGEABLE_ITEM, RecipeType.NULL, new ItemStack[9]).register(plugin);
 
         Player player = server.addPlayer();
         player.setOp(true);
@@ -62,8 +62,8 @@ class TestChargeCommand {
 
     private class RechargeableMock extends SlimefunItem implements Rechargeable {
 
-        public RechargeableMock(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-            super(category, item, recipeType, recipe);
+        public RechargeableMock(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+            super(itemGroup, item, recipeType, recipe);
         }
 
         @Override

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
@@ -62,7 +62,7 @@ class TestGuideOpening {
     @Test
     @DisplayName("Test if an ItemGroup can be opened from the History")
     void testOpenItemGroup() throws InterruptedException {
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "history_category"), new CustomItemStack(Material.BLUE_TERRACOTTA, "&9Testy test"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "history_itemgroup"), new CustomItemStack(Material.BLUE_TERRACOTTA, "&9Testy test"));
 
         SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);
         PlayerProfile profile = prepare(guide, history -> history.add(itemGroup, 1));

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
@@ -60,13 +60,13 @@ class TestGuideOpening {
     }
 
     @Test
-    @DisplayName("Test if a Category can be opened from the History")
-    void testOpenCategory() throws InterruptedException {
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "history_category"), new CustomItemStack(Material.BLUE_TERRACOTTA, "&9Testy test"));
+    @DisplayName("Test if an ItemGroup can be opened from the History")
+    void testOpenItemGroup() throws InterruptedException {
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "history_category"), new CustomItemStack(Material.BLUE_TERRACOTTA, "&9Testy test"));
 
         SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);
-        PlayerProfile profile = prepare(guide, history -> history.add(category, 1));
-        Mockito.verify(guide).openItemGroup(profile, category, 1);
+        PlayerProfile profile = prepare(guide, history -> history.add(itemGroup, 1));
+        Mockito.verify(guide).openItemGroup(profile, itemGroup, 1);
     }
 
     @Test

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestDamageableItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestDamageableItem.java
@@ -41,14 +41,14 @@ class TestDamageableItem {
     }
 
     public static MockDamageable getDummyItem(String id, boolean damageable, @Nullable Enchantment enchantment, @Nullable Integer enchantmentLevel) {
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "damageable_item_test");
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "damageable_item_test");
         SlimefunItemStack stack = new SlimefunItemStack("DAMAGEABLE_PICKAXE_" + id, Material.DIAMOND_PICKAXE, "&4This pickaxe can break", "&6It appears, it breaks, but most importantly, it tests.");
         if (enchantment != null && enchantmentLevel != null) {
             ItemMeta im = stack.getItemMeta();
             im.addEnchant(enchantment, enchantmentLevel, true);
             stack.setItemMeta(im);
         }
-        MockDamageable item = new MockDamageable(category, stack, RecipeType.NULL, new ItemStack[9], damageable);
+        MockDamageable item = new MockDamageable(itemGroup, stack, RecipeType.NULL, new ItemStack[9], damageable);
         item.register(plugin);
         return item;
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestRadioactiveItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestRadioactiveItem.java
@@ -37,9 +37,9 @@ class TestRadioactiveItem {
     @EnumSource(value = Radioactivity.class)
     @DisplayName("Test radioactive items being radioactive")
     void testWikiPages(Radioactivity radioactivity) {
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "radioactivity_test");
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "radioactivity_test");
         SlimefunItemStack stack = new SlimefunItemStack("RADIOACTIVE_" + radioactivity.name(), Material.EMERALD, "&4Radioactive!!!", "Imagine dragons");
-        RadioactiveItem item = new RadioactiveItem(category, radioactivity, stack, RecipeType.NULL, new ItemStack[9]);
+        RadioactiveItem item = new RadioactiveItem(itemGroup, radioactivity, stack, RecipeType.NULL, new ItemStack[9]);
 
         Assertions.assertEquals(radioactivity, item.getRadioactivity());
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/MockBeeProtectionSuit.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/MockBeeProtectionSuit.java
@@ -13,8 +13,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.armor.SlimefunArm
 
 class MockBeeProtectionSuit extends SlimefunArmorPiece implements ProtectiveArmor {
 
-    public MockBeeProtectionSuit(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, RecipeType.NULL, new ItemStack[9], new PotionEffect[0]);
+    public MockBeeProtectionSuit(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, RecipeType.NULL, new ItemStack[9], new PotionEffect[0]);
     }
 
     @Override

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBackpackListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBackpackListener.java
@@ -86,8 +86,8 @@ class TestBackpackListener {
         PlayerBackpack backpack = profile.createBackpack(size);
         listener.setBackpackId(player, item, 2, backpack.getId());
 
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "test_backpacks"), new CustomItemStack(Material.CHEST, "&4Test Backpacks"));
-        SlimefunBackpack slimefunBackpack = new SlimefunBackpack(size, category, item, RecipeType.NULL, new ItemStack[9]);
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test_backpacks"), new CustomItemStack(Material.CHEST, "&4Test Backpacks"));
+        SlimefunBackpack slimefunBackpack = new SlimefunBackpack(size, itemGroup, item, RecipeType.NULL, new ItemStack[9]);
         slimefunBackpack.register(plugin);
 
         listener.openBackpack(player, item, slimefunBackpack);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBeeListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBeeListener.java
@@ -49,9 +49,9 @@ class TestBeeListener {
         PlayerProfile profile = TestUtilities.awaitProfile(player);
 
         if (hasArmor) {
-            ItemGroup category = TestUtilities.getItemGroup(plugin, "bee_suit_test");
+            ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "bee_suit_test");
             SlimefunItemStack chestplate = new SlimefunItemStack("MOCK_BEE_SUIT", Material.LEATHER_CHESTPLATE, "&cBee Suit Prototype");
-            MockBeeProtectionSuit armor = new MockBeeProtectionSuit(category, chestplate);
+            MockBeeProtectionSuit armor = new MockBeeProtectionSuit(itemGroup, chestplate);
             armor.register(plugin);
 
             player.getInventory().setChestplate(chestplate.clone());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
@@ -67,9 +67,9 @@ class TestCargoNodeListener {
         Block b = l.getBlock();
         Block against = b.getRelative(BlockFace.DOWN);
 
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "cargo_test");
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "cargo_test");
         SlimefunItemStack item = new SlimefunItemStack("MOCK_CARGO_NODE", new CustomItemStack(Material.PLAYER_HEAD, "&4Cargo node!"));
-        CargoInputNode node = new CargoInputNode(category, item, RecipeType.NULL, new ItemStack[9], null);
+        CargoInputNode node = new CargoInputNode(itemGroup, item, RecipeType.NULL, new ItemStack[9], null);
         node.register(plugin);
 
         BlockPlaceEvent event = new BlockPlaceEvent(b, b.getState(), against, item, player, true, EquipmentSlot.HAND);
@@ -86,9 +86,9 @@ class TestCargoNodeListener {
         Block b = l.getBlock();
         b.setType(Material.GRASS);
 
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "cargo_test");
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "cargo_test");
         SlimefunItemStack item = new SlimefunItemStack("MOCK_CARGO_NODE_2", new CustomItemStack(Material.PLAYER_HEAD, "&4Cargo node!"));
-        CargoInputNode node = new CargoInputNode(category, item, RecipeType.NULL, new ItemStack[9], null);
+        CargoInputNode node = new CargoInputNode(itemGroup, item, RecipeType.NULL, new ItemStack[9], null);
         node.register(plugin);
 
         BlockPlaceEvent event = new BlockPlaceEvent(b, b.getState(), b, item, player, true, EquipmentSlot.HAND);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCoolerListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCoolerListener.java
@@ -42,13 +42,13 @@ class TestCoolerListener {
         server = MockBukkit.mock();
         Slimefun plugin = MockBukkit.load(Slimefun.class);
 
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "cooler_test"), new CustomItemStack(Material.SNOWBALL, "Mr. Freeze"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "cooler_test"), new CustomItemStack(Material.SNOWBALL, "Mr. Freeze"));
         SlimefunItemStack item = new SlimefunItemStack("TEST_COOLER", Material.SNOWBALL, "&6Test Cooler", "", "&7ID: <ID>");
-        cooler = new Cooler(18, category, item, RecipeType.NULL, new ItemStack[9]);
+        cooler = new Cooler(18, itemGroup, item, RecipeType.NULL, new ItemStack[9]);
         cooler.register(plugin);
 
         SlimefunItemStack juiceItem = new SlimefunItemStack("TEST_JUICE", Color.RED, new PotionEffect(PotionEffectType.HEALTH_BOOST, 6, 0), "&4Test Juice");
-        juice = new Juice(category, juiceItem, RecipeType.NULL, new ItemStack[9]);
+        juice = new Juice(itemGroup, juiceItem, RecipeType.NULL, new ItemStack[9]);
         juice.register(plugin);
 
         listener = new CoolerListener(plugin, cooler);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestVillagerTradingListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestVillagerTradingListener.java
@@ -86,9 +86,9 @@ class TestVillagerTradingListener {
 
     @Test
     void testTradingWithSyntheticEmerald() {
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "shiny_emeralds");
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "shiny_emeralds");
         SlimefunItemStack stack = new SlimefunItemStack("FAKE_EMERALD", Material.EMERALD, "&aTrade me");
-        SyntheticEmerald item = new SyntheticEmerald(category, stack, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[9]);
+        SyntheticEmerald item = new SyntheticEmerald(itemGroup, stack, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[9]);
         item.register(plugin);
 
         InventoryClickEvent event = mockClickEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
@@ -49,35 +49,35 @@ class TestItemGroups {
     @Test
     @DisplayName("Test the Getters for ItemGroup")
     void testItemGroupGetters() {
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "getter_test"), new CustomItemStack(Material.DIAMOND_AXE, "&6Testing"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "getter_test"), new CustomItemStack(Material.DIAMOND_AXE, "&6Testing"));
 
-        Assertions.assertEquals(3, category.getTier());
-        Assertions.assertEquals(new NamespacedKey(Slimefun.instance(), "getter_test"), category.getKey());
-        Assertions.assertEquals("Testing", category.getUnlocalizedName());
-        Assertions.assertEquals(0, category.getItems().size());
+        Assertions.assertEquals(3, itemGroup.getTier());
+        Assertions.assertEquals(new NamespacedKey(Slimefun.instance(), "getter_test"), itemGroup.getKey());
+        Assertions.assertEquals("Testing", itemGroup.getUnlocalizedName());
+        Assertions.assertEquals(0, itemGroup.getItems().size());
 
-        Assertions.assertNull(category.getAddon());
-        category.register(plugin);
-        Assertions.assertEquals(plugin, category.getAddon());
+        Assertions.assertNull(itemGroup.getAddon());
+        itemGroup.register(plugin);
+        Assertions.assertEquals(plugin, itemGroup.getAddon());
     }
 
     @Test
     @DisplayName("Test adding an item to a ItemGroup")
     void testAddItem() {
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "items_test"), new CustomItemStack(Material.DIAMOND_AXE, "&6Testing"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "items_test"), new CustomItemStack(Material.DIAMOND_AXE, "&6Testing"));
         SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_GROUPS_TEST_ITEM", new CustomItemStack(Material.BAMBOO, "&6Test Bamboo"));
-        item.setItemGroup(category);
+        item.setItemGroup(itemGroup);
         item.register(plugin);
         item.load();
 
-        Assertions.assertTrue(category.getItems().contains(item));
-        Assertions.assertEquals(1, category.getItems().size());
+        Assertions.assertTrue(itemGroup.getItems().contains(item));
+        Assertions.assertEquals(1, itemGroup.getItems().size());
 
         // Size must still be 1 since we disallow duplicates
-        item.setItemGroup(category);
+        item.setItemGroup(itemGroup);
 
-        Assertions.assertEquals(1, category.getItems().size());
-        Assertions.assertThrows(IllegalArgumentException.class, () -> category.add(null));
+        Assertions.assertEquals(1, itemGroup.getItems().size());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> itemGroup.add(null));
     }
 
     @Test
@@ -190,7 +190,7 @@ class TestItemGroups {
     @Test
     @DisplayName("Test a seasonal ItemGroup")
     void ItemGroups() {
-        // Category with current Month
+        // ItemGroup with current Month
         Month month = LocalDate.now().getMonth();
         SeasonalItemGroup group = new SeasonalItemGroup(new NamespacedKey(plugin, "seasonal"), month, 1, new CustomItemStack(Material.NETHER_STAR, "&cSeasonal Test"));
         SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "SEASONAL_ITEM", new CustomItemStack(Material.NETHER_STAR, "&dSeasonal Test Star"));
@@ -203,14 +203,14 @@ class TestItemGroups {
         Assertions.assertEquals(month, group.getMonth());
         Assertions.assertFalse(group.isHidden(player));
 
-        // Category with future Month
-        SeasonalItemGroup category2 = new SeasonalItemGroup(group.getKey(), month.plus(6), 1, new CustomItemStack(Material.MILK_BUCKET, "&dSeasonal Test"));
-        Assertions.assertTrue(category2.isHidden(player));
+        // ItemGroup with future Month
+        SeasonalItemGroup itemGroup2 = new SeasonalItemGroup(group.getKey(), month.plus(6), 1, new CustomItemStack(Material.MILK_BUCKET, "&dSeasonal Test"));
+        Assertions.assertTrue(itemGroup2.isHidden(player));
     }
 
     @Test
     @DisplayName("Test the FlexItemGroup")
-    void testFlexCategory() {
+    void testFlexItemGroup() {
         FlexItemGroup group = new FlexItemGroup(new NamespacedKey(plugin, "flex"), new CustomItemStack(Material.REDSTONE, "&4Weird flex but ok")) {
 
             @Override

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
@@ -170,7 +170,7 @@ class TestItemGroups {
         // No Items, so it should be unlocked
         Assertions.assertTrue(locked.hasUnlocked(player, profile));
 
-        SlimefunItem item = new SlimefunItem(group, new SlimefunItemStack("LOCKED_CATEGORY_TEST", new CustomItemStack(Material.LANTERN, "&6Test Item for locked categories")), RecipeType.NULL, new ItemStack[9]);
+        SlimefunItem item = new SlimefunItem(group, new SlimefunItemStack("LOCKED_ITEMGROUP_TEST", new CustomItemStack(Material.LANTERN, "&6Test Item for locked categories")), RecipeType.NULL, new ItemStack[9]);
         item.register(plugin);
         item.load();
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemSetup.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemSetup.java
@@ -72,13 +72,13 @@ class TestItemSetup {
 
     @Test
     @Order(value = 4)
-    @DisplayName("Test whether every Category is added to the translation files")
-    void testCategoryTranslations() throws IOException {
+    @DisplayName("Test whether every ItemGroup is added to the translation files")
+    void testItemGroupTranslations() throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream("/languages/en/categories.yml"), StandardCharsets.UTF_8))) {
             FileConfiguration config = YamlConfiguration.loadConfiguration(reader);
 
-            for (ItemGroup category : Slimefun.getRegistry().getAllItemGroups()) {
-                String path = category.getKey().getNamespace() + '.' + category.getKey().getKey();
+            for (ItemGroup itemGroup : Slimefun.getRegistry().getAllItemGroups()) {
+                String path = itemGroup.getKey().getNamespace() + '.' + itemGroup.getKey().getKey();
                 Assertions.assertTrue(config.contains(path));
             }
         }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRechargeableItems.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRechargeableItems.java
@@ -121,16 +121,16 @@ class TestRechargeableItems {
     }
 
     private RechargeableMock mock(String id, float capacity) {
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "rechargeable");
-        return new RechargeableMock(category, new SlimefunItemStack(id, new CustomItemStack(Material.REDSTONE_LAMP, "&3" + id)), capacity);
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "rechargeable");
+        return new RechargeableMock(itemGroup, new SlimefunItemStack(id, new CustomItemStack(Material.REDSTONE_LAMP, "&3" + id)), capacity);
     }
 
     private class RechargeableMock extends SlimefunItem implements Rechargeable {
 
         private final float capacity;
 
-        protected RechargeableMock(ItemGroup category, SlimefunItemStack item, float capacity) {
-            super(category, item, RecipeType.NULL, new ItemStack[9]);
+        protected RechargeableMock(ItemGroup itemGroup, SlimefunItemStack item, float capacity) {
+            super(itemGroup, item, RecipeType.NULL, new ItemStack[9]);
             this.capacity = capacity;
         }
 
@@ -138,7 +138,5 @@ class TestRechargeableItems {
         public float getMaxItemCharge(ItemStack item) {
             return capacity;
         }
-
     }
-
 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
@@ -86,8 +86,8 @@ class TestSlimefunItemRegistration {
     }
 
     @Test
-    @DisplayName("Test Category registration when registering an item")
-    void testCategoryRegistration() {
+    @DisplayName("Test ItemGroup registration when registering an item")
+    void testItemGroupRegistration() {
         SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CATEGORY_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
         item.register(plugin);
         item.load();
@@ -95,17 +95,17 @@ class TestSlimefunItemRegistration {
         // null should not be a valid argument
         Assertions.assertThrows(IllegalArgumentException.class, () -> item.setItemGroup(null));
 
-        ItemGroup category = item.getItemGroup();
-        ItemGroup category2 = new ItemGroup(new NamespacedKey(plugin, "test2"), new CustomItemStack(Material.OBSIDIAN, "&6Test 2"));
+        ItemGroup itemGroup = item.getItemGroup();
+        ItemGroup itemGroup2 = new ItemGroup(new NamespacedKey(plugin, "test2"), new CustomItemStack(Material.OBSIDIAN, "&6Test 2"));
 
-        Assertions.assertTrue(category.contains(item));
-        Assertions.assertFalse(category2.contains(item));
-        Assertions.assertEquals(category, item.getItemGroup());
+        Assertions.assertTrue(itemGroup.contains(item));
+        Assertions.assertFalse(itemGroup2.contains(item));
+        Assertions.assertEquals(itemGroup, item.getItemGroup());
 
-        item.setItemGroup(category2);
-        Assertions.assertFalse(category.contains(item));
-        Assertions.assertTrue(category2.contains(item));
-        Assertions.assertEquals(category2, item.getItemGroup());
+        item.setItemGroup(itemGroup2);
+        Assertions.assertFalse(itemGroup.contains(item));
+        Assertions.assertTrue(itemGroup2.contains(item));
+        Assertions.assertEquals(itemGroup2, item.getItemGroup());
     }
 
     @Test
@@ -116,25 +116,25 @@ class TestSlimefunItemRegistration {
         item.register(plugin);
         item.load();
 
-        ItemGroup category = item.getItemGroup();
+        ItemGroup itemGroup = item.getItemGroup();
 
         Assertions.assertTrue(item.isHidden());
-        Assertions.assertFalse(category.contains(item));
-        Assertions.assertEquals(category, item.getItemGroup());
+        Assertions.assertFalse(itemGroup.contains(item));
+        Assertions.assertEquals(itemGroup, item.getItemGroup());
 
         item.setHidden(false);
         Assertions.assertFalse(item.isHidden());
-        Assertions.assertTrue(category.contains(item));
-        Assertions.assertEquals(category, item.getItemGroup());
+        Assertions.assertTrue(itemGroup.contains(item));
+        Assertions.assertEquals(itemGroup, item.getItemGroup());
 
         item.setHidden(true);
         Assertions.assertTrue(item.isHidden());
-        Assertions.assertFalse(category.contains(item));
-        Assertions.assertEquals(category, item.getItemGroup());
+        Assertions.assertFalse(itemGroup.contains(item));
+        Assertions.assertEquals(itemGroup, item.getItemGroup());
 
         // Do nothing if the value hasn't changed
         item.setHidden(true);
         Assertions.assertTrue(item.isHidden());
-        Assertions.assertFalse(category.contains(item));
+        Assertions.assertFalse(itemGroup.contains(item));
     }
 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
@@ -88,7 +88,7 @@ class TestSlimefunItemRegistration {
     @Test
     @DisplayName("Test ItemGroup registration when registering an item")
     void testItemGroupRegistration() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CATEGORY_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEMGROUP_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
         item.register(plugin);
         item.load();
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TestArmorTask.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TestArmorTask.java
@@ -80,16 +80,16 @@ class TestArmorTask {
         // Setting the time to noon, to exclude the Solar Helmet check
         player.getWorld().setTime(16000);
 
-        ItemGroup category = TestUtilities.getItemGroup(plugin, "hazmat_suit_test");
+        ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "hazmat_suit_test");
         SlimefunItemStack item = new SlimefunItemStack("MOCK_URANIUM_" + String.valueOf(hazmat).toUpperCase(Locale.ROOT) + "_" + String.valueOf(radioactiveFire).toUpperCase(Locale.ROOT), Material.EMERALD, "&aHi, I am deadly");
-        new RadioactiveItem(category, Radioactivity.VERY_DEADLY, item, RecipeType.NULL, new ItemStack[9]).register(plugin);
+        new RadioactiveItem(itemGroup, Radioactivity.VERY_DEADLY, item, RecipeType.NULL, new ItemStack[9]).register(plugin);
 
         player.getInventory().setItemInMainHand(item.clone());
         player.getInventory().setItemInOffHand(new ItemStack(Material.EMERALD_ORE));
 
         if (hazmat) {
             SlimefunItemStack chestplate = new SlimefunItemStack("MOCK_HAZMAT_SUIT_" + String.valueOf(radioactiveFire).toUpperCase(Locale.ROOT), Material.LEATHER_CHESTPLATE, "&4Hazmat Prototype");
-            MockHazmatSuit armor = new MockHazmatSuit(category, chestplate);
+            MockHazmatSuit armor = new MockHazmatSuit(itemGroup, chestplate);
             armor.register(plugin);
 
             player.getInventory().setChestplate(chestplate.clone());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
@@ -44,20 +44,20 @@ public final class TestUtilities {
 
     @ParametersAreNonnullByDefault
     public static @Nonnull ItemGroup getItemGroup(Plugin plugin, String name) {
-        return new ItemGroup(new NamespacedKey(plugin, name), new CustomItemStack(Material.NETHER_STAR, "&4Test Category"));
+        return new ItemGroup(new NamespacedKey(plugin, name), new CustomItemStack(Material.NETHER_STAR, "&4Test ItemGroup"));
     }
 
     @ParametersAreNonnullByDefault
     public static @Nonnull SlimefunItem mockSlimefunItem(Plugin plugin, String id, ItemStack item) {
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "test"), new CustomItemStack(Material.EMERALD, "&4Test Category"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test"), new CustomItemStack(Material.EMERALD, "&4Test ItemGroup"));
 
-        return new MockSlimefunItem(category, item, id);
+        return new MockSlimefunItem(itemGroup, item, id);
     }
 
     @ParametersAreNonnullByDefault
     public static @Nonnull VanillaItem mockVanillaItem(Plugin plugin, Material type, boolean enabled) {
-        ItemGroup category = new ItemGroup(new NamespacedKey(plugin, "test"), new CustomItemStack(Material.EMERALD, "&4Test Category"));
-        VanillaItem item = new VanillaItem(category, new ItemStack(type), type.name(), RecipeType.NULL, new ItemStack[9]);
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test"), new CustomItemStack(Material.EMERALD, "&4Test ItemGroup"));
+        VanillaItem item = new VanillaItem(itemGroup, new ItemStack(type), type.name(), RecipeType.NULL, new ItemStack[9]);
         Slimefun.getItemCfg().setValue(type.name() + ".enabled", enabled);
         return item;
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/mocks/MockDamageable.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/mocks/MockDamageable.java
@@ -18,8 +18,8 @@ public class MockDamageable extends SlimefunItem implements DamageableItem {
     private final boolean itemDamageable;
 
     @ParametersAreNonnullByDefault
-    public MockDamageable(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, boolean damageable) {
-        super(category, item, recipeType, recipe);
+    public MockDamageable(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, boolean damageable) {
+        super(itemGroup, item, recipeType, recipe);
         itemDamageable = damageable;
     }
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/mocks/MockHazmatSuit.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/mocks/MockHazmatSuit.java
@@ -16,8 +16,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.armor.SlimefunArm
 public class MockHazmatSuit extends SlimefunArmorPiece implements ProtectiveArmor {
 
     @ParametersAreNonnullByDefault
-    public MockHazmatSuit(ItemGroup category, SlimefunItemStack item) {
-        super(category, item, RecipeType.NULL, new ItemStack[9], new PotionEffect[0]);
+    public MockHazmatSuit(ItemGroup itemGroup, SlimefunItemStack item) {
+        super(itemGroup, item, RecipeType.NULL, new ItemStack[9], new PotionEffect[0]);
     }
 
     @Override

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/mocks/MockSlimefunItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/mocks/MockSlimefunItem.java
@@ -9,8 +9,8 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 
 public class MockSlimefunItem extends SlimefunItem {
 
-    public MockSlimefunItem(ItemGroup category, ItemStack item, String id) {
-        super(category, new SlimefunItemStack(id, item), RecipeType.NULL, new ItemStack[9]);
+    public MockSlimefunItem(ItemGroup itemGroup, ItemStack item, String id) {
+        super(itemGroup, new SlimefunItemStack(id, item), RecipeType.NULL, new ItemStack[9]);
     }
 
 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
@@ -89,8 +89,8 @@ class TestSoulboundItem {
 
     private class SoulboundMock extends SlimefunItem implements Soulbound {
 
-        public SoulboundMock(ItemGroup category) {
-            super(category, new SlimefunItemStack("MOCK_SOULBOUND", Material.REDSTONE, "&4Almighty Redstone"), RecipeType.NULL, new ItemStack[9]);
+        public SoulboundMock(ItemGroup itemGroup) {
+            super(itemGroup, new SlimefunItemStack("MOCK_SOULBOUND", Material.REDSTONE, "&4Almighty Redstone"), RecipeType.NULL, new ItemStack[9]);
         }
 
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
@@ -81,7 +81,7 @@ class TestSoulboundItem {
     @Test
     @DisplayName("Test that soulbound Slimefun Items are soulbound")
     void testSoulboundSlimefunItem() {
-        SlimefunItem item = new SoulboundMock(new ItemGroup(new NamespacedKey(plugin, "soulbound_category"), new CustomItemStack(Material.REDSTONE, "&4Walshrus forever")));
+        SlimefunItem item = new SoulboundMock(new ItemGroup(new NamespacedKey(plugin, "soulbound_itemgroup"), new CustomItemStack(Material.REDSTONE, "&4Walshrus forever")));
         item.register(plugin);
 
         Assertions.assertTrue(SlimefunUtils.isSoulbound(item.getItem()));


### PR DESCRIPTION
## Description
This is a follow up to #3139, a lot of comments and variables and error messages needed to be updated still.
This is what that does

Two more follow up questions:
- in `wiki.json`, `Christmas-Seasonal-Category` is mentioned, change to `Christmas-Seasonal-ItemGroup`?
- do I update `messages.yml` (and other files) keys? (eg: `guide.tooltips.open-category` -> `guide.tooltips.open-itemgroup`)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
