### PR TITLE
Fix metrics not being able to download

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
@@ -44,6 +44,11 @@ public class MetricsService {
      * The Name of our repository - Version 2 of this repo (due to big breaking changes)
      */
     private static final String REPO_NAME = "MetricsModule2";
+    
+    /**
+     * The name of the metrics jar file.
+     */
+    private static final String JAR_NAME = "MetricsModule";
 
     /**
      * The URL pointing towards the /releases/ endpoint of our
@@ -90,7 +95,7 @@ public class MetricsService {
             parentFolder.mkdirs();
         }
 
-        this.metricsModuleFile = new File(parentFolder, REPO_NAME + ".jar");
+        this.metricsModuleFile = new File(parentFolder, JAR_NAME + ".jar");
     }
 
     /**
@@ -98,7 +103,7 @@ public class MetricsService {
      */
     public void start() {
         if (!metricsModuleFile.exists()) {
-            plugin.getLogger().info(REPO_NAME + " does not exist, downloading...");
+            plugin.getLogger().info(JAR_NAME + " does not exist, downloading...");
 
             if (!download(getLatestVersion())) {
                 plugin.getLogger().warning("Failed to start metrics as the file could not be downloaded.");
@@ -228,7 +233,7 @@ public class MetricsService {
             }
 
             AtomicInteger lastPercentPosted = new AtomicInteger();
-            GetRequest request = Unirest.get(DOWNLOAD_URL + "/" + version + "/" + REPO_NAME + ".jar");
+            GetRequest request = Unirest.get(DOWNLOAD_URL + "/" + version + "/" + JAR_NAME + ".jar");
 
             HttpResponse<File> response = request.downloadMonitor((b, fileName, bytesWritten, totalBytes) -> {
                 int percent = (int) (20 * (Math.round((((double) bytesWritten / totalBytes) * 100) / 20)));
@@ -240,7 +245,7 @@ public class MetricsService {
             }).asFile(file.getPath());
 
             if (response.isSuccess()) {
-                plugin.getLogger().log(Level.INFO, "Successfully downloaded {0} build: #{1}", new Object[] { REPO_NAME, version });
+                plugin.getLogger().log(Level.INFO, "Successfully downloaded {0} build: #{1}", new Object[] { JAR_NAME, version });
 
                 // Replace the metric file with the new one
                 cleanUp();


### PR DESCRIPTION
We used REPO_NAME in quite a few places which I didn't expect but here we are. Anyway, this fixes that.
