### PR TITLE
Smithing table listener

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -101,6 +101,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.Cart
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.CauldronListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.CraftingTableListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.GrindstoneListener;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.SmithingTableListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.BeeListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.EntityInteractionListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.FireworksListener;
@@ -610,6 +611,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         new CauldronListener(this);
         new GrindstoneListener(this);
         new CartographyTableListener(this);
+        new SmithingTableListener(this);
         new ButcherAndroidListener(this);
         new MiningAndroidListener(this);
         new NetworkListener(this, networkManager);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
@@ -30,7 +30,7 @@ public class SmithingTableListener implements SlimefunCraftingListener {
         if (e.getInventory().getType() == InventoryType.SMITHING && e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player) {
             ItemStack materialItem = e.getInventory().getContents()[1];
 
-            // Checks if the Item in the Material/Netherite slot is allowed to be used.
+            // Checks if the item in the Material/Netherite slot is allowed to be used.
             if (isUnallowed(materialItem)) {
                 e.setResult(Result.DENY);
                 Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "smithing_table.not-working", true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
@@ -15,7 +15,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 /**
  * This {@link Listener} prevents any {@link SlimefunItem} from being used in a
- * cartography table.
+ * smithing table.
  * 
  * @author Sefiraat
  */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
@@ -27,7 +27,7 @@ public class SmithingTableListener implements SlimefunCraftingListener {
 
     @EventHandler(ignoreCancelled = true)
     public void onSmith(InventoryClickEvent e) {
-        if (e.getInventory().getType() == InventoryType.SMITHING && e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player &&) {
+        if (e.getInventory().getType() == InventoryType.SMITHING && e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player) {
             ItemStack itemStack = e.getInventory().getContents()[1];
 
             if (isUnallowed(itemStack)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
@@ -28,9 +28,10 @@ public class SmithingTableListener implements SlimefunCraftingListener {
     @EventHandler(ignoreCancelled = true)
     public void onSmith(InventoryClickEvent e) {
         if (e.getInventory().getType() == InventoryType.SMITHING && e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player) {
-            ItemStack itemStack = e.getInventory().getContents()[1];
+            ItemStack materialItem = e.getInventory().getContents()[1];
 
-            if (isUnallowed(itemStack)) {
+            // Checks if the Item in the Material/Netherite slot is allowed to be used.
+            if (isUnallowed(materialItem)) {
                 e.setResult(Result.DENY);
                 Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "smithing_table.not-working", true);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
@@ -18,7 +18,6 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
  * cartography table.
  * 
  * @author Sefiraat
- *
  */
 public class SmithingTableListener implements SlimefunCraftingListener {
 
@@ -28,7 +27,7 @@ public class SmithingTableListener implements SlimefunCraftingListener {
 
     @EventHandler(ignoreCancelled = true)
     public void onSmith(InventoryClickEvent e) {
-        if (e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player && e.getInventory().getType() == InventoryType.SMITHING) {
+        if (e.getInventory().getType() == InventoryType.SMITHING && e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player &&) {
             ItemStack itemStack = e.getInventory().getContents()[1];
 
             if (isUnallowed(itemStack)) {
@@ -36,7 +35,5 @@ public class SmithingTableListener implements SlimefunCraftingListener {
                 Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "smithing_table.not-working", true);
             }
         }
-
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/SmithingTableListener.java
@@ -1,0 +1,42 @@
+package io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting;
+
+import javax.annotation.Nonnull;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event.Result;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+/**
+ * This {@link Listener} prevents any {@link SlimefunItem} from being used in a
+ * cartography table.
+ * 
+ * @author Sefiraat
+ *
+ */
+public class SmithingTableListener implements SlimefunCraftingListener {
+
+    public SmithingTableListener(@Nonnull Slimefun plugin) {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onSmith(InventoryClickEvent e) {
+        if (e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player && e.getInventory().getType() == InventoryType.SMITHING) {
+            ItemStack itemStack = e.getInventory().getContents()[1];
+
+            if (isUnallowed(itemStack)) {
+                e.setResult(Result.DENY);
+                Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "smithing_table.not-working", true);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/package-info.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/package-info.java
@@ -1,5 +1,5 @@
 /**
  * This package holds every {@link org.bukkit.event.Listener} which is responsible for preventing that a
- * {@link me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem} is used in an unallowed crafting operation
+ * {@link io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem} is used in an unallowed crafting operation
  */
 package io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting;

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -330,7 +330,7 @@ cartography_table:
   not-working: '&4You cannot use Slimefun items in a cartography table!'
 
 smithing_table:
-    not-working: '&4You cannot use Slimefun items as a smithing material!'
+    not-working: '&4You cannot use a Slimefun item as a smithing material!'
 
 villagers:
   no-trading: '&4You cannot trade Slimefun items with Villagers!'

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -329,6 +329,9 @@ brewing_stand:
 cartography_table:
   not-working: '&4You cannot use Slimefun items in a cartography table!'
 
+smithing_table:
+    not-working: '&4You cannot use Slimefun items as a smithing material!'
+
 villagers:
   no-trading: '&4You cannot trade Slimefun items with Villagers!'
 

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -330,7 +330,7 @@ cartography_table:
   not-working: '&4You cannot use Slimefun items in a cartography table!'
 
 smithing_table:
-    not-working: '&4You cannot use a Slimefun item as a smithing material!'
+  not-working: '&4You cannot use a Slimefun item as a smithing material!'
 
 villagers:
   no-trading: '&4You cannot trade Slimefun items with Villagers!'

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSmithingTableListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSmithingTableListener.java
@@ -1,0 +1,135 @@
+package io.github.thebusybiscuit.slimefun4.implementation.listeners;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event.Result;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import io.github.bakedlibs.dough.items.CustomItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.SmithingTableListener;
+import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+
+class TestSmithingTableListener {
+
+    private static SmithingTableListener listener;
+    private static ServerMock server;
+
+    private static SlimefunItem slimefunIngot;
+    private static SlimefunItem slimefunTool;
+    private static VanillaItem vanillaIngot;
+    private static VanillaItem vanillaTool;
+
+    @BeforeAll
+    public static void load() {
+        server = MockBukkit.mock();
+        Slimefun plugin = MockBukkit.load(Slimefun.class);
+        listener = new SmithingTableListener(plugin);
+
+        slimefunTool = TestUtilities.mockSlimefunItem(plugin, "MOCK_DIAMOND_SWORD", new CustomItemStack(Material.DIAMOND_SWORD, "&6Mock"));
+        slimefunIngot = TestUtilities.mockSlimefunItem(plugin, "MOCK_NETHERITE_INGOT", new CustomItemStack(Material.NETHERITE_INGOT, "&6Mock"));
+        vanillaTool = TestUtilities.mockVanillaItem(plugin, Material.DIAMOND_SWORD, true);
+        vanillaIngot = TestUtilities.mockVanillaItem(plugin, Material.NETHERITE_INGOT, true);
+
+        slimefunTool.register(plugin);
+        slimefunIngot.register(plugin);
+        vanillaTool.register(plugin);
+        vanillaIngot.register(plugin);
+    }
+
+    @AfterAll
+    public static void unload() {
+        MockBukkit.unmock();
+    }
+
+    private InventoryClickEvent mockSmithingEvent(ItemStack tool, ItemStack material) {
+        Player player = server.addPlayer();
+        Inventory inv = TestUtilities.mockInventory(InventoryType.SMITHING, tool, material, null);
+        InventoryView view = player.openInventory(inv);
+        InventoryClickEvent event = new InventoryClickEvent(view, SlotType.CONTAINER, 2, ClickType.LEFT, InventoryAction.PICKUP_ONE);
+
+        listener.onSmith(event);
+        return event;
+    }
+
+    @Test
+    @DisplayName("Test that vanilla is unchanged (ItemStack tool x ItemStack material)")
+    void testSmithingTableWithItemStacks() {
+        InventoryClickEvent event = mockSmithingEvent(new ItemStack(Material.DIAMOND_SWORD), new ItemStack(Material.NETHERITE_INGOT));
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that SlimefunItem material doesn't work (ItemStack tool x SlimefunItem material)")
+    void testSmithingTableWithItemStackAndSlimefunItem() {
+        InventoryClickEvent event = mockSmithingEvent(new ItemStack(Material.DIAMOND_SWORD), slimefunIngot.getItem());
+        Assertions.assertEquals(Result.DENY, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that VanillaItem material works (ItemStack tool x VanillaItem material)")
+    void testSmithingTableWithItemStackAndVanillaItem() {
+        InventoryClickEvent event = mockSmithingEvent(new ItemStack(Material.DIAMOND_SWORD), vanillaIngot.getItem());
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that SlimefunItems can upgrade with vanilla (SlimefunItem tool x ItemStack material)")
+    void testSmithingTableWithSlimefunItemAndItemStack() {
+        InventoryClickEvent event = mockSmithingEvent(slimefunTool.getItem(), new ItemStack(Material.NETHERITE_INGOT));
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that SlimefunItems can't upgrade with SlimefunItem materials (SlimefunItem tool x SlimefunItem material)")
+    void testSmithingTableWithSlimefunItems() {
+        InventoryClickEvent event = mockSmithingEvent(slimefunTool.getItem(), slimefunIngot.getItem());
+        Assertions.assertEquals(Result.DENY, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that SlimefunItems can upgrade with VanillaItems (SlimefunItem tool x VanillaItem material)")
+    void testSmithingTableWithSlimefunItemAndVanillaItem() {
+        InventoryClickEvent event = mockSmithingEvent(slimefunTool.getItem(), vanillaIngot.getItem());
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that SlimefunItems can upgrade with vanilla (SlimefunItem tool x ItemStack material)")
+    void testSmithingTableWithVanillaItemAndItemStack() {
+        InventoryClickEvent event = mockSmithingEvent(vanillaTool.getItem(), new ItemStack(Material.NETHERITE_INGOT));
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that SlimefunItems can't upgrade with SlimefunItem materials (SlimefunItem tool x SlimefunItem material)")
+    void testSmithingTableWithVanillaItemAndSlimefunItem() {
+        InventoryClickEvent event = mockSmithingEvent(vanillaTool.getItem(), slimefunIngot.getItem());
+        Assertions.assertEquals(Result.DENY, event.getResult());
+    }
+
+    @Test
+    @DisplayName("Test that SlimefunItems can upgrade with VanillaItems (SlimefunItem tool x VanillaItem material)")
+    void testSmithingTableWithVanillaItemAndVanillaItem() {
+        InventoryClickEvent event = mockSmithingEvent(vanillaTool.getItem(), vanillaIngot.getItem());
+        Assertions.assertEquals(Result.DEFAULT, event.getResult());
+    }
+
+}


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The Smithing Table currently allows SlimefunItems to be used as the material (currently only Netherite). Given netherite is a nice looking martial for other possible items, this can allow very early access to Netherite tools unintentionally. The current examples are Zamak 1, 2 and 3 in SimpleStorage and Void Ingots in InfintyExpansion. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
New listener to deny SlimefunItems being used in the material slot. I have not modified the behavior to upgrade SlimefunItem tools from Diamond to Netherite asuming this is current both known and intended.

Tests for all 9 possible combinations of SlimefunItem, ItemStack and VanillaItem added

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves https://github.com/Sefiraat/Simple-Storage/issues/8

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
