### PR TITLE
Hercules' Pickaxe supports 1.17 deepslate ores and copper

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -3,6 +3,8 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -25,15 +27,35 @@ public class HerculesPickaxe extends SimpleSlimefunItem<ToolUseHandler> {
     @Override
     public @Nonnull ToolUseHandler getItemHandler() {
         return (e, tool, fortune, drops) -> {
-            if (SlimefunTag.ORES.isTagged(e.getBlock().getType())) {
-                if (e.getBlock().getType() == Material.IRON_ORE) {
-                    drops.add(new CustomItemStack(SlimefunItems.IRON_DUST, 2));
-                } else if (e.getBlock().getType() == Material.GOLD_ORE) {
-                    drops.add(new CustomItemStack(SlimefunItems.GOLD_DUST, 2));
-                } else {
-                    for (ItemStack drop : e.getBlock().getDrops(tool)) {
-                        drops.add(new CustomItemStack(drop, drop.getAmount() * 2));
+            Material mat = e.getBlock().getType();
+
+            if (SlimefunTag.ORES.isTagged(mat)) {
+                if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
+                    switch(mat) {
+                        case DEEPSLATE_IRON_ORE:
+                            drops.add(new CustomItemStack(SlimefunItems.IRON_DUST, 2));
+                            break;
+                        case DEEPSLATE_GOLD_ORE:
+                            drops.add(new CustomItemStack(SlimefunItems.GOLD_DUST, 2));
+                            break;
+                        case COPPER_ORE:
+                        case DEEPSLATE_COPPER_ORE:
+                            drops.add(new CustomItemStack(SlimefunItems.COPPER_DUST, 2));
+                            break;
                     }
+                }
+
+                switch(mat) {
+                    case IRON_ORE:
+                        drops.add(new CustomItemStack(SlimefunItems.IRON_DUST, 2));
+                        break;
+                    case GOLD_ORE:
+                        drops.add(new CustomItemStack(SlimefunItems.GOLD_DUST, 2));
+                        break;
+                    default:
+                        for (ItemStack drop : e.getBlock().getDrops(tool)) {
+                            drops.add(new CustomItemStack(drop, drop.getAmount() * 2));
+                        }
                 }
             }
         };

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -58,6 +58,7 @@ public class HerculesPickaxe extends SimpleSlimefunItem<ToolUseHandler> {
                         for (ItemStack drop : e.getBlock().getDrops(tool)) {
                             drops.add(new CustomItemStack(drop, drop.getAmount() * 2));
                         }
+                        break;
                 }
             }
         };

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -3,16 +3,16 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.items.CustomItemStack;
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -42,6 +42,8 @@ public class HerculesPickaxe extends SimpleSlimefunItem<ToolUseHandler> {
                         case DEEPSLATE_COPPER_ORE:
                             drops.add(new CustomItemStack(SlimefunItems.COPPER_DUST, 2));
                             break;
+                        default:
+                            break;
                     }
                 }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The Hercules' Pickaxe should function like Ore Crusher, so the drops of mining deepslate ores or copper ores should be their corresponding dusts.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add support for Hercules' Pickaxe with 1.17 deepslate ores and copper ores.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3251

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
