### PR TITLE
Fix #3248

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -95,7 +95,10 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
         for (Map.Entry<Enchantment, Integer> entry : meta.getStoredEnchants().entrySet()) {
             if (entry.getKey().canEnchantItem(target)) {
                 if (isEnchantmentLevelAllowed(entry.getValue())) {
-                    enchantments.put(entry.getKey(), entry.getValue());
+                    // if needs to be nested or it will crash the enchanter
+                    if (target.getEnchantmentLevel(entry.getKey()) < entry.getValue()) {
+                        enchantments.put(entry.getKey(), entry.getValue());
+                    }
                 } else if (!menu.toInventory().getViewers().isEmpty()) {
                     showEnchantmentLevelWarning(menu);
                     return null;
@@ -139,5 +142,4 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
     public String getMachineIdentifier() {
         return "AUTO_ENCHANTER";
     }
-
 }


### PR DESCRIPTION
## Description
Fixes enchantments becoming a lower level when using books that have lower level enchants.  
This also makes it so it will not start enchanting if the books levels are lower than the items levels.

## Related Issues (if applicable)
Resolves #3248

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
