### PR TITLE
Fix saddle duplication

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -20,6 +20,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Steerable;
 import org.bukkit.entity.Trident;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -196,6 +197,14 @@ public class TalismanListener implements Listener {
                 for (ItemStack item : horse.getInventory().getStorageContents()) {
                     items.remove(item);
                 }
+            }
+        }
+
+        if (entity instanceof Steerable) {
+            Steerable steerableEntity = (Steerable) entity;
+
+            if (steerableEntity.hasSaddle()) {
+                items.remove(new ItemStack(Material.SADDLE));
             }
         }
 


### PR DESCRIPTION
## Description
Fixed saddle duplication.

## Proposed changes
Added to `TalismanListener#getExtraDrops` check for `Steerable` entity which can have saddle

## Related Issues (if applicable)
Resolves #3254

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
