### PR TITLE
Improves item comparison performance

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java
@@ -159,7 +159,7 @@ class ItemFilter implements Predicate<ItemStack> {
 
     @Override
     public boolean test(@Nonnull ItemStack item) {
-        /**
+        /*
          * An empty Filter does not need to be iterated over.
          * We can just return our default value in this scenario.
          */
@@ -201,7 +201,7 @@ class ItemFilter implements Predicate<ItemStack> {
                     /*
                      * The filter has found a match, we can return the opposite
                      * of our default value. If we exclude items, this is where we
-                     * would return false. Otherwise we return true.
+                     * would return false. Otherwise, we return true.
                      */
                     return !rejectOnMatch;
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -47,10 +47,9 @@ import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
  * This utility class holds method that are directly linked to Slimefun.
  * It provides a very crucial method for {@link ItemStack} comparison, as well as a simple method
  * to check if an {@link ItemStack} is {@link Soulbound} or not.
- * 
+ *
  * @author TheBusyBiscuit
  * @author Walshy
- *
  */
 public final class SlimefunUtils {
 
@@ -62,7 +61,7 @@ public final class SlimefunUtils {
     /**
      * This method quickly returns whether an {@link Item} was marked as "no_pickup" by
      * a Slimefun device.
-     * 
+     *
      * @param item
      *            The {@link Item} to query
      * @return Whether the {@link Item} is excluded from being picked up
@@ -74,7 +73,7 @@ public final class SlimefunUtils {
     /**
      * This will prevent the given {@link Item} from being picked up.
      * This is useful for display items which the {@link AncientPedestal} uses.
-     * 
+     *
      * @param item
      *            The {@link Item} to prevent from being picked up
      * @param context
@@ -159,7 +158,7 @@ public final class SlimefunUtils {
      *            The {@link ItemStack} you want to add/remove Soulbound from.
      * @param makeSoulbound
      *            If they item should be soulbound.
-     * 
+     *
      * @see #isSoulbound(ItemStack)
      */
     public static void setSoulbound(@Nullable ItemStack item, boolean makeSoulbound) {
@@ -197,10 +196,10 @@ public final class SlimefunUtils {
 
     /**
      * This method checks whether the given {@link ItemStack} is radioactive.
-     * 
+     *
      * @param item
      *            The {@link ItemStack} to check
-     * 
+     *
      * @return Whether this {@link ItemStack} is radioactive or not
      */
     public static boolean isRadioactive(@Nullable ItemStack item) {
@@ -210,10 +209,10 @@ public final class SlimefunUtils {
     /**
      * This method returns an {@link ItemStack} for the given texture.
      * The result will be a Player Head with this texture.
-     * 
+     *
      * @param texture
      *            The texture for this head (base64 or hash)
-     * 
+     *
      * @return An {@link ItemStack} with this Head texture
      */
     public static @Nonnull ItemStack getCustomHead(@Nonnull String texture) {
@@ -288,6 +287,19 @@ public final class SlimefunUtils {
 
                 ItemMetaSnapshot meta = ((SlimefunItemStack) sfitem).getItemMetaSnapshot();
                 return equalsItemMeta(itemMeta, meta, checkLore);
+            } else if (sfitem instanceof ItemStackWrapper && sfitem.hasItemMeta()) {
+                // Slimefun items may be ItemStackWrapper's in the context of cargo so let's try to do
+                // an ID comparison before meta comparison
+                ItemMeta possibleSfItemMeta = sfitem.getItemMeta();
+                Optional<String> possibleSfItemId = Slimefun.getItemDataService().getItemData(possibleSfItemMeta);
+                Optional<String> itemId = Slimefun.getItemDataService().getItemData(itemMeta);
+
+                if (possibleSfItemId.isPresent() && itemId.isPresent()) {
+                    return possibleSfItemId.get().equals(itemId.get());
+                } else {
+                    return equalsItemMeta(itemMeta, possibleSfItemMeta, checkLore);
+                }
+
             } else if (sfitem.hasItemMeta()) {
                 return equalsItemMeta(itemMeta, sfitem.getItemMeta(), checkLore);
             } else {
@@ -343,12 +355,12 @@ public final class SlimefunUtils {
     /**
      * This checks if the two provided lores are equal.
      * This method will ignore any lines such as the soulbound one.
-     * 
+     *
      * @param lore1
      *            The first lore
      * @param lore2
      *            The second lore
-     * 
+     *
      * @return Whether the two lores are equal
      */
     public static boolean equalsLore(@Nonnull List<String> lore1, @Nonnull List<String> lore2) {
@@ -402,14 +414,14 @@ public final class SlimefunUtils {
      * It will always return <code>true</code> for non-Slimefun items.
      * <p>
      * If you already have an instance of {@link SlimefunItem}, please use {@link SlimefunItem#canUse(Player, boolean)}.
-     * 
+     *
      * @param p
      *            The {@link Player}
      * @param item
      *            The {@link ItemStack} to check
      * @param sendMessage
      *            Whether to send a message response to the {@link Player}
-     * 
+     *
      * @return Whether the {@link Player} is able to use that item.
      */
     public static boolean canPlayerUseItem(@Nonnull Player p, @Nullable ItemStack item, boolean sendMessage) {
@@ -428,7 +440,7 @@ public final class SlimefunUtils {
      * Helper method to spawn an {@link ItemStack}.
      * This method automatically calls a {@link SlimefunItemSpawnEvent} to allow
      * other plugins to catch the item being dropped.
-     * 
+     *
      * @param loc
      *            The {@link Location} where to drop the item
      * @param item
@@ -437,7 +449,7 @@ public final class SlimefunUtils {
      *            The {@link ItemSpawnReason} why the item is being dropped
      * @param addRandomOffset
      *            Whether a random offset should be added (see {@link World#dropItemNaturally(Location, ItemStack)})
-     * 
+     *
      * @return The dropped {@link Item} (or null if the {@link SlimefunItemSpawnEvent} was cancelled)
      */
     @ParametersAreNonnullByDefault
@@ -462,14 +474,14 @@ public final class SlimefunUtils {
      * Helper method to spawn an {@link ItemStack}.
      * This method automatically calls a {@link SlimefunItemSpawnEvent} to allow
      * other plugins to catch the item being dropped.
-     * 
+     *
      * @param loc
      *            The {@link Location} where to drop the item
      * @param item
      *            The {@link ItemStack} to drop
      * @param reason
      *            The {@link ItemSpawnReason} why the item is being dropped
-     * 
+     *
      * @return The dropped {@link Item} (or null if the {@link SlimefunItemSpawnEvent} was cancelled)
      */
     @ParametersAreNonnullByDefault


### PR DESCRIPTION
## Description
There are a lot of situations where SF items are CraftItemStacks not SlimefunItemStacks

This is most obvious with cargo and has been a big bottleneck there (~60%).

This PR addresses the cargo-specific point but will probably carry over to other parts of the code here and in addons.

In Cargo we wrap the items being used for comparison, these items can still be SF items just, they look like regular Bukkit items. So, the is item similar check should account for this.

With this change, it will check if it's wrapped and if it has item meta, if it does then it will try and get IDs to compare. Otherwise, fall back to the usual item meta comparison. This improves cargo performance by about 60% when filtering SF items.

The reason this change has such a big impact is simple, the display name code is terrible. It will decode JSON and create message components just for getting the name. It's very awkward and not nice to use. The `ItemMeta#getDisplayName` alone accounts for 60% of cargos #insert processing time in the numerous Spark reports we have received.

Call stack for this:
  - [`CargoUtils#insert`](https://github.com/Slimefun/Slimefun4/blob/7ae0128ff6aa4894d2918cf4fa184e3203f2ce45/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java#L261-L262)
  - [`CargoUtils#matchesFilter`](https://github.com/Slimefun/Slimefun4/blob/7ae0128ff6aa4894d2918cf4fa184e3203f2ce45/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java#L388-L393)
  - [`ItemFilter#test`](https://github.com/Slimefun/Slimefun4/blob/7ae0128ff6aa4894d2918cf4fa184e3203f2ce45/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemFilter.java#L161-L200)
  - [`SlimefunUtils#isItemSimilar`](https://github.com/Slimefun/Slimefun4/blob/7ae0128ff6aa4894d2918cf4fa184e3203f2ce45/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java#L268-L299)

## Proposed changes
Check if an item is an `ItemStackWrapper` and try to compare IDs there too. It will only do it currently if both items are SlimefunItemStacks but that isn't the case a lot of the time.

## Related Issues (if applicable)
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

----

Requesting a review from @md5sha256 who initially introduced this wrapper code