### PR TITLE
Add soul soil recipe

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
@@ -6,7 +6,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -17,7 +16,6 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.tools.GoldPan;
 import io.github.thebusybiscuit.slimefun4.implementation.items.tools.NetherGoldPan;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
@@ -28,6 +26,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
  * It also serves as a {@link NetherGoldPan}.
  * 
  * @author TheBusyBiscuit
+ * @author svr333
  * 
  * @see GoldPan
  * @see NetherGoldPan
@@ -71,7 +70,7 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
                 continue;
             }
 
-            if (goldPan.isCorrectInputMaterial(item.getType())) {
+            if (goldPan.getInputMaterials().contains(item.getType())) {
                 ItemStack output = goldPan.getRandomOutput();
 
                 MachineRecipe recipe = new MachineRecipe(3 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
@@ -80,7 +79,7 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
                     menu.consumeItem(slot);
                     return recipe;
                 }
-            } else if (netherGoldPan.isCorrectInputMaterial(item.getType())) {
+            } else if (netherGoldPan.getInputMaterials().contains(item.getType())) {
                 ItemStack output = netherGoldPan.getRandomOutput();
                 MachineRecipe recipe = new MachineRecipe(4 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
@@ -73,7 +73,7 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
             if (goldPan.isInputMaterialCorrect(item.getType())) {
                 ItemStack output = goldPan.getRandomOutput();
 
-                MachineRecipe recipe = new MachineRecipe(3 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
+                MachineRecipe recipe = new MachineRecipe(3 / getSpeed(), new ItemStack[] { item }, new ItemStack[] { output });
 
                 if (output.getType() != Material.AIR && menu.fits(output, getOutputSlots())) {
                     menu.consumeItem(slot);
@@ -81,7 +81,7 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
                 }
             } else if (netherGoldPan.isInputMaterialCorrect(item.getType())) {
                 ItemStack output = netherGoldPan.getRandomOutput();
-                MachineRecipe recipe = new MachineRecipe(4 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
+                MachineRecipe recipe = new MachineRecipe(4 / getSpeed(), new ItemStack[] { item }, new ItemStack[] { output });
 
                 if (output.getType() != Material.AIR && menu.fits(output, getOutputSlots())) {
                     menu.consumeItem(slot);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
@@ -66,11 +66,11 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
         for (int slot : getInputSlots()) {
             ItemStack item = menu.getItemInSlot(slot);
 
-            if (item == null || item.getType() == Material.AIR) {
+            if (item == null || item.getType().isAir()) {
                 continue;
             }
 
-            if (goldPan.getInputMaterials().contains(item.getType())) {
+            if (goldPan.isInputMaterialCorrect(item.getType())) {
                 ItemStack output = goldPan.getRandomOutput();
 
                 MachineRecipe recipe = new MachineRecipe(3 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
@@ -79,7 +79,7 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
                     menu.consumeItem(slot);
                     return recipe;
                 }
-            } else if (netherGoldPan.getInputMaterials().contains(item.getType())) {
+            } else if (netherGoldPan.isInputMaterialCorrect(item.getType())) {
                 ItemStack output = netherGoldPan.getRandomOutput();
                 MachineRecipe recipe = new MachineRecipe(4 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricGoldPan.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -37,9 +38,6 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
     private final GoldPan goldPan = SlimefunItems.GOLD_PAN.getItem(GoldPan.class);
     private final GoldPan netherGoldPan = SlimefunItems.NETHER_GOLD_PAN.getItem(GoldPan.class);
 
-    private final ItemStack gravel = new ItemStack(Material.GRAVEL);
-    private final ItemStack soulSand = new ItemStack(Material.SOUL_SAND);
-
     @ParametersAreNonnullByDefault
     public ElectricGoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
@@ -69,23 +67,27 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
         for (int slot : getInputSlots()) {
             ItemStack item = menu.getItemInSlot(slot);
 
-            if (SlimefunUtils.isItemSimilar(item, gravel, true, false)) {
+            if (item == null || item.getType() == Material.AIR) {
+                continue;
+            }
+
+            if (goldPan.isCorrectInputMaterial(item.getType())) {
                 ItemStack output = goldPan.getRandomOutput();
-                MachineRecipe recipe = new MachineRecipe(3 / getSpeed(), new ItemStack[] { gravel }, new ItemStack[] { output });
+
+                MachineRecipe recipe = new MachineRecipe(3 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
 
                 if (output.getType() != Material.AIR && menu.fits(output, getOutputSlots())) {
                     menu.consumeItem(slot);
                     return recipe;
                 }
-            } else if (SlimefunUtils.isItemSimilar(item, soulSand, true, false)) {
+            } else if (netherGoldPan.isCorrectInputMaterial(item.getType())) {
                 ItemStack output = netherGoldPan.getRandomOutput();
-                MachineRecipe recipe = new MachineRecipe(4 / getSpeed(), new ItemStack[] { soulSand }, new ItemStack[] { output });
+                MachineRecipe recipe = new MachineRecipe(4 / getSpeed(), new ItemStack[] { new ItemStack(item.getType()) }, new ItemStack[] { output });
 
                 if (output.getType() != Material.AIR && menu.fits(output, getOutputSlots())) {
                     menu.consumeItem(slot);
                     return recipe;
                 }
-
             }
         }
 
@@ -106,5 +108,4 @@ public class ElectricGoldPan extends AContainer implements RecipeDisplayItem {
     public String getMachineIdentifier() {
         return "ELECTRIC_GOLD_PAN";
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
@@ -63,9 +63,9 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
         ItemStack input = p.getInventory().getItemInMainHand();
         ItemStack output;
 
-        if (goldPan.getInputMaterials().contains(input.getType())) {
+        if (goldPan.isInputMaterialCorrect(input.getType())) {
             output = goldPan.getRandomOutput();
-        } else if (netherGoldPan.getInputMaterials().contains(input.getType())) {
+        } else if (netherGoldPan.isInputMaterialCorrect(input.getType())) {
             output = netherGoldPan.getRandomOutput();
         } else {
             Slimefun.getLocalization().sendMessage(p, "machines.wrong-item", true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
@@ -61,15 +61,16 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
     @Override
     public void onInteract(Player p, Block b) {
         ItemStack input = p.getInventory().getItemInMainHand();
+        boolean isGoldPanInput = goldPan.isCorrectInputMaterial(input.getType());
 
-        if (SlimefunUtils.isItemSimilar(input, new ItemStack(Material.GRAVEL), true, false) || SlimefunUtils.isItemSimilar(input, new ItemStack(Material.SOUL_SAND), true, false)) {
+        if (isGoldPanInput || netherGoldPan.isCorrectInputMaterial(input.getType())) {
             Material material = input.getType();
 
             if (p.getGameMode() != GameMode.CREATIVE) {
                 ItemUtils.consumeItem(input, false);
             }
 
-            ItemStack output = material == Material.GRAVEL ? goldPan.getRandomOutput() : netherGoldPan.getRandomOutput();
+            ItemStack output = isGoldPanInput ? goldPan.getRandomOutput() : netherGoldPan.getRandomOutput();
             TaskQueue queue = new TaskQueue();
 
             queue.thenRepeatEvery(20, 5, () -> b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, material));
@@ -95,5 +96,4 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
             Slimefun.getLocalization().sendMessage(p, "machines.wrong-item", true);
         }
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -131,7 +131,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
             if (block.isPresent()) {
                 Block b = block.get();
 
-                if (getInputMaterials().contains(b.getType()) && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), Interaction.BREAK_BLOCK)) {
+                if (isInputMaterialCorrect(b.getType()) && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), Interaction.BREAK_BLOCK)) {
                     ItemStack output = getRandomOutput();
 
                     b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -50,14 +51,12 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements RecipeDisplayItem {
 
     private final RandomizedSet<ItemStack> randomizer = new RandomizedSet<>();
-    private final Set<Material> inputMaterials = new HashSet<>();
+    private final Set<Material> inputMaterials = new HashSet<>(Arrays.asList(Material.GRAVEL));
     private final Set<GoldPanDrop> drops = new HashSet<>();
 
     @ParametersAreNonnullByDefault
     public GoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
-
-        inputMaterials.add(Material.GRAVEL);
 
         drops.addAll(getGoldPanDrops());
         addItemSetting(drops.toArray(new GoldPanDrop[0]));
@@ -179,5 +178,9 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         }
 
         return recipes;
+    }
+
+    public boolean isInputMaterialCorrect(Material material) {
+        return getInputMaterials().contains(material);
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -9,8 +9,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import com.google.common.collect.Sets;
-
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -42,6 +40,7 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
  * resources from Gravel.
  * 
  * @author TheBusyBiscuit
+ * @author svr333
  * 
  * @see NetherGoldPan
  * @see AutomatedPanningMachine
@@ -51,12 +50,14 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements RecipeDisplayItem {
 
     private final RandomizedSet<ItemStack> randomizer = new RandomizedSet<>();
-    private final Set<Material> inputMaterials = Sets.newHashSet(Material.GRAVEL);
+    private final Set<Material> inputMaterials = new HashSet<>();
     private final Set<GoldPanDrop> drops = new HashSet<>();
 
     @ParametersAreNonnullByDefault
     public GoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
+
+        inputMaterials.add(Material.GRAVEL);
 
         drops.addAll(getGoldPanDrops());
         addItemSetting(drops.toArray(new GoldPanDrop[0]));
@@ -131,7 +132,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
             if (block.isPresent()) {
                 Block b = block.get();
 
-                if (isCorrectInputMaterial(b.getType()) && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), Interaction.BREAK_BLOCK)) {
+                if (getInputMaterials().contains(b.getType()) && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), Interaction.BREAK_BLOCK)) {
                     ItemStack output = getRandomOutput();
 
                     b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
@@ -178,23 +179,5 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         }
 
         return recipes;
-    }
-
-    /**
-     * This is a helper method to determine whether the input item was a valid item.
-     *
-     * @param material
-     *              The {@link Material} that was input.
-     *
-     * @return whether or not the provided material is allowed.
-     */
-    public @Nonnull boolean isCorrectInputMaterial(Material material) {
-        for (Material m : getInputMaterials()) {
-            if (material == m) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -66,7 +66,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
     /**
      * This method returns the target {@link Material}s for this {@link GoldPan}.
      * 
-     * @return The {@link Material} this {@link GoldPan} can be used on
+     * @return The {@link Material}s this {@link GoldPan} can be used on
      */
     public @Nonnull Set<Material> getInputMaterials() {
         return inputMaterials;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.google.common.collect.Sets;
+
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -49,6 +51,7 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements RecipeDisplayItem {
 
     private final RandomizedSet<ItemStack> randomizer = new RandomizedSet<>();
+    private final Set<Material> inputMaterials = Sets.newHashSet(Material.GRAVEL);
     private final Set<GoldPanDrop> drops = new HashSet<>();
 
     @ParametersAreNonnullByDefault
@@ -66,11 +69,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
      * @return The {@link Material} this {@link GoldPan} can be used on
      */
     public @Nonnull Set<Material> getInputMaterials() {
-        Set<Material> materials = new HashSet<>();
-
-        materials.add(Material.GRAVEL);
-
-        return materials;
+        return inputMaterials;
     }
 
     protected @Nonnull Set<GoldPanDrop> getGoldPanDrops() {
@@ -191,7 +190,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
      */
     public @Nonnull boolean isCorrectInputMaterial(Material material) {
         for (Material m : getInputMaterials()) {
-            if (SlimefunUtils.isItemSimilar(new ItemStack(material), new ItemStack(m), true, false)) {
+            if (material == m) {
                 return true;
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -61,12 +61,16 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
     }
 
     /**
-     * This method returns the target {@link Material} for this {@link GoldPan}.
+     * This method returns the target {@link Material}s for this {@link GoldPan}.
      * 
      * @return The {@link Material} this {@link GoldPan} can be used on
      */
-    public @Nonnull Material getInputMaterial() {
-        return Material.GRAVEL;
+    public @Nonnull Set<Material> getInputMaterials() {
+        Set<Material> materials = new HashSet<>();
+
+        materials.add(Material.GRAVEL);
+
+        return materials;
     }
 
     protected @Nonnull Set<GoldPanDrop> getGoldPanDrops() {
@@ -128,8 +132,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
             if (block.isPresent()) {
                 Block b = block.get();
 
-                // Check the clicked block type and for protections
-                if (b.getType() == getInputMaterial() && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), Interaction.BREAK_BLOCK)) {
+                if (isCorrectInputMaterial(b.getType()) && Slimefun.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), Interaction.BREAK_BLOCK)) {
                     ItemStack output = getRandomOutput();
 
                     b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
@@ -165,8 +168,12 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         List<ItemStack> recipes = new LinkedList<>();
 
         for (GoldPanDrop drop : drops) {
-            if (drop.getValue() > 0) {
-                recipes.add(new ItemStack(getInputMaterial()));
+            if (drop.getValue() <= 0) {
+                continue;
+            }
+
+            for (Material material : getInputMaterials()) {
+                recipes.add(new ItemStack(material));
                 recipes.add(drop.getOutput());
             }
         }
@@ -174,4 +181,21 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         return recipes;
     }
 
+    /**
+     * This is a helper method to determine whether the input item was a valid item.
+     *
+     * @param material
+     *              The {@link Material} that was input.
+     *
+     * @return whether or not the provided material is allowed.
+     */
+    public @Nonnull boolean isCorrectInputMaterial(Material material) {
+        for (Material m : getInputMaterials()) {
+            if (SlimefunUtils.isItemSimilar(new ItemStack(material), new ItemStack(m), true, false)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -24,14 +25,11 @@ import io.github.thebusybiscuit.slimefun4.implementation.settings.GoldPanDrop;
  */
 public class NetherGoldPan extends GoldPan {
 
-    private final Set<Material> inputMaterials = new HashSet<>();
+    private final Set<Material> inputMaterials = new HashSet<>(Arrays.asList(Material.SOUL_SAND, Material.SOUL_SOIL));
 
     @ParametersAreNonnullByDefault
     public NetherGoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
-
-        inputMaterials.add(Material.SOUL_SAND);
-        inputMaterials.add(Material.SOUL_SOIL);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
@@ -6,8 +6,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import com.google.common.collect.Sets;
-
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -21,15 +19,19 @@ import io.github.thebusybiscuit.slimefun4.implementation.settings.GoldPanDrop;
  * which can be used on Soul Sand.
  * 
  * @author TheBusyBiscuit
+ * @author svr333
  *
  */
 public class NetherGoldPan extends GoldPan {
 
-    private final Set<Material> inputMaterials = Sets.newHashSet(Material.SOUL_SAND, Material.SOUL_SOIL);
+    private final Set<Material> inputMaterials = new HashSet<>();
 
     @ParametersAreNonnullByDefault
     public NetherGoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
+
+        inputMaterials.add(Material.SOUL_SAND);
+        inputMaterials.add(Material.SOUL_SOIL);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.google.common.collect.Sets;
+
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -23,6 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.settings.GoldPanDrop;
  */
 public class NetherGoldPan extends GoldPan {
 
+    private final Set<Material> inputMaterials = Sets.newHashSet(Material.SOUL_SAND, Material.SOUL_SOIL);
+
     @ParametersAreNonnullByDefault
     public NetherGoldPan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
@@ -30,12 +34,7 @@ public class NetherGoldPan extends GoldPan {
 
     @Override
     public @Nonnull Set<Material> getInputMaterials() {
-        Set<Material> materials = new HashSet<>();
-
-        materials.add(Material.SOUL_SAND);
-        materials.add(Material.SOUL_SOIL);
-
-        return materials;
+        return inputMaterials;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/NetherGoldPan.java
@@ -29,8 +29,13 @@ public class NetherGoldPan extends GoldPan {
     }
 
     @Override
-    public @Nonnull Material getInputMaterial() {
-        return Material.SOUL_SAND;
+    public @Nonnull Set<Material> getInputMaterials() {
+        Set<Material> materials = new HashSet<>();
+
+        materials.add(Material.SOUL_SAND);
+        materials.add(Material.SOUL_SOIL);
+
+        return materials;
     }
 
     @Override


### PR DESCRIPTION
## Description
Add soul soil as a valid input item for nether gold pan and variants.  
I had to refactor quite a bit, because it was designed for one item as input only

## Proposed changes
Add soul soil as a valid input block for the nether gold pan, automated panning machine and electric panning machine.

## Related Issues (if applicable)
[Discord approved suggestion 1614](https://discord.com/channels/565557184348422174/627048923122499584/887054754092580936)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
