### PR TITLE
Fixed `Nag author: 'The Slimefun 4 Community' of 'Slimefun' about the…

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -436,6 +436,11 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         for (Player p : Bukkit.getOnlinePlayers()) {
             p.closeInventory();
         }
+
+        // FIXED
+        // Nag author: 'The Slimefun 4 Community' of 'Slimefun' about the following: This plugin is not properly shutting down its async tasks when it is being shut down.
+        // This task may throw errors during the final shutdown logs and might not complete before process dies.
+        Bukkit.getScheduler().cancelTasks(this);
     }
 
     /**


### PR DESCRIPTION
… following: This plugin is not properly shutting down its async tasks when it is being shut down. This task may throw errors during the final shutdown logs and might not complete before process dies.`

## Description
It throws error when shutting down

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I have added only one line in the last statement of onDisable() method

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
