### PR TITLE
Fixes #3147 and related issue

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -191,6 +191,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> {
         if (itemWatcherTaskID != 0) {
             Bukkit.getScheduler().cancelTask(itemWatcherTaskID);
             itemWatcherTaskID = 0;
+            currentDisplayItem = null;
         }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -49,6 +49,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
  * 
  * @author Redemption198
  * @author TheBusyBiscuit
+ * @author StarWishsama
  *
  */
 public class AncientAltarListener implements Listener {
@@ -156,6 +157,7 @@ public class AncientAltarListener implements Listener {
             Slimefun.runSync(() -> removedItems.remove(uuid), 30L);
 
             entity.remove();
+            pedestalItem.stopWatcher();
             p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity));
             p.playSound(pedestal.getLocation(), Sound.ENTITY_ITEM_PICKUP, 1F, 1F);
         }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Added a pedestal item watcher to monitor item location

Notice:
This change only make pedestal displayed item **can** be took down after unexcepted move, **Can not** stop items from being moved.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added a pedestal item watcher to monitor item location
Stores item displaying upon pedestal to trace

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3147 #2940 #2941 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
