### PR TITLE
Added ability to set capacity for Solar Gens, like all other gens

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
@@ -35,13 +35,20 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
 
     private final int dayEnergy;
     private final int nightEnergy;
+    private final int capacity;
 
     @ParametersAreNonnullByDefault
-    public SolarGenerator(ItemGroup itemGroup, int dayEnergy, int nightEnergy, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    public SolarGenerator(ItemGroup itemGroup, int dayEnergy, int nightEnergy, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, int capacity) {
         super(itemGroup, item, recipeType, recipe);
 
         this.dayEnergy = dayEnergy;
         this.nightEnergy = nightEnergy;
+        this.capacity = capacity;
+    }
+
+    @ParametersAreNonnullByDefault
+    public SolarGenerator(ItemGroup itemGroup, int dayEnergy, int nightEnergy, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        this(itemGroup, dayEnergy, nightEnergy, item, recipeType, recipe, 0);
     }
 
     /**
@@ -66,7 +73,7 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
 
     @Override
     public int getCapacity() {
-        return 0;
+        return capacity;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
@@ -65,7 +65,7 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
     }
 
     @Override
-    public final int getCapacity() {
+    public int getCapacity() {
         return 0;
     }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
All of the generators in Slimefun have a default capacity BUT the ability to change it, with some having it >0 by default and thus effectively also working as an energy buffer. Solar Generators, on the otherhand, had no way to do this as the capacity was hardcoded to be 0 and unchangeable. This PR increases solar gens extensibility, by making it comparable to the other generators.
## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Added a capacity member to Solar Generators
- Added capacity as a constructor parameter
- Added a constructor defaulting to the old behavior so nothing breaks
- Changed getCapacity() to return this new member instead of the hardcoded 0
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
