### PR TITLE
Fix other items being consumed when switching items after consuming juice

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
@@ -61,10 +61,8 @@ public class Juice extends SimpleSlimefunItem<ItemConsumptionHandler> {
              * Minecraft has been broken when it comes to Saturation potions for a long time
              */
             for (PotionEffect effect : effects) {
-                if (effect.getType().equals(PotionEffectType.SATURATION)) {
-                    p.addPotionEffect(effect);
-                    break;
-                }
+                p.addPotionEffect(effect);
+                break;
             }
 
             e.setItem(null);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
@@ -6,8 +6,6 @@ import java.util.List;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.bukkit.Material;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -19,11 +17,9 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemConsumptionHandler;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.Cooler;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.CoolerListener;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
 /**
  * This class represents a {@link SlimefunItem} that can be stored inside
@@ -71,33 +67,8 @@ public class Juice extends SimpleSlimefunItem<ItemConsumptionHandler> {
                 }
             }
 
-            removeGlassBottle(p, item);
+            e.setItem(null);
         };
-    }
-
-    /**
-     * Determines from which hand the juice is being drunk, and its amount
-     * 
-     * @param p
-     *            The {@link Player} that triggered this
-     * @param item
-     *            The {@link ItemStack} in question
-     */
-    @ParametersAreNonnullByDefault
-    private void removeGlassBottle(Player p, ItemStack item) {
-        if (SlimefunUtils.isItemSimilar(item, p.getInventory().getItemInMainHand(), true)) {
-            if (p.getInventory().getItemInMainHand().getAmount() == 1) {
-                Slimefun.runSync(() -> p.getEquipment().getItemInMainHand().setAmount(0));
-            } else {
-                Slimefun.runSync(() -> p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1)));
-            }
-        } else if (SlimefunUtils.isItemSimilar(item, p.getInventory().getItemInOffHand(), true)) {
-            if (p.getInventory().getItemInOffHand().getAmount() == 1) {
-                Slimefun.runSync(() -> p.getEquipment().getItemInOffHand().setAmount(0));
-            } else {
-                Slimefun.runSync(() -> p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1)));
-            }
-        }
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
@@ -124,7 +124,6 @@ public class CoolerListener implements Listener {
                     p.addPotionEffect(effect);
                 }
 
-                p.setSaturation(6F);
                 p.playSound(p.getLocation(), Sound.ENTITY_GENERIC_DRINK, 1F, 1F);
                 inv.setItem(slot, null);
                 backpack.markDirty();


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This fixes a bug described in #3264 and makes the cooler consistent with drinking the juice normally. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Instead of doing all the complex logic of refinding the itemstack of the juice just to remove the held item after a delay (allowing the player to switch stacks), just set the item of the consumption to nothing and apply the effects manually so that no glass bottle is created. Also makes drinking juice consistent with the cooler automatically feeding the player. 

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3264

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
