### PR TITLE
Removed useless overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * Fixed #3273
 * Fixed an exploit regarding the Smithing Table
 * Fixed #3265
-* (API) Made Solar Gens able to have a capacity/energy buffer
+* `SolarGenerator` has a new constructor to accept capacity
 
 ## Release Candidate 28 (06 Sep 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * Fixed #3273
 * Fixed an exploit regarding the Smithing Table
 * Fixed #3265
-* Made Solar Gens able to have a capacity/energy buffer
+* (API) Made Solar Gens able to have a capacity/energy buffer
 
 ## Release Candidate 28 (06 Sep 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Fixed #3248
 * Fixed #3273
 * Fixed an exploit regarding the Smithing Table
+* Made Solar Gens able to have a capacity/energy buffer
 
 ## Release Candidate 28 (06 Sep 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Fixed #3248
 * Fixed #3273
 * Fixed an exploit regarding the Smithing Table
+* Fixed #3265
 * Made Solar Gens able to have a capacity/energy buffer
 
 ## Release Candidate 28 (06 Sep 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * Fixed #3273
 * Fixed an exploit regarding the Smithing Table
 * Fixed #3265
-* `SolarGenerator` has a new constructor to accept capacity
+* (API) `SolarGenerator` has a new constructor to accept capacity
 
 ## Release Candidate 28 (06 Sep 2021)
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
@@ -77,11 +77,6 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
     }
 
     @Override
-    public final boolean isChargeable() {
-        return false;
-    }
-
-    @Override
     public int getGeneratedOutput(Location l, Config data) {
         World world = l.getWorld();
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
#3288 was nice but SolarGenerators override the isChargeable method for no reason. This actually breaks the creation of solar gens with a capacity because the child method is called and that returns false no matter what.
Since the method is actually useless (the super method checks the actual capacity) I have removed it

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Removed useless override of isChargeable
- Updated changelog
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
