### PR TITLE
Fix explosive bow knockback being way too high if close to the entity

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -60,9 +60,13 @@ public class ExplosiveBow extends SlimefunBow {
                 distanceVector.setY(distanceVector.getY() + 0.6);
 
                 Vector velocity = entity.getVelocity();
+                System.out.println("velocity: " + velocity);
+                System.out.println(e.getDamage());
 
                 double distanceSquared = distanceVector.lengthSquared();
+                System.out.println("distanceSq: " + distanceSquared);
                 double damage = e.getDamage() * (1 - (distanceSquared / (2 * range.getValue() * range.getValue())));
+                System.out.println("damage: " + damage);
 
                 if (!entity.getUniqueId().equals(target.getUniqueId())) {
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(e.getDamager(), entity, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, damage);
@@ -70,7 +74,8 @@ public class ExplosiveBow extends SlimefunBow {
 
                     if (!event.isCancelled()) {
                         // Velocity is in meters PER TICK, so we divide by 4 to make it reasonable
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/(4 * e.getDamage())));
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/(e.getDamage())));
+                        System.out.println("Knockback: " + knockback);
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -69,7 +69,7 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/2));
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply(2 * damage/e.getDamage()));
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -69,8 +69,8 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        // Velocity is in meters PER TICK, so we divide by 10 to make it reasonable
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/(10 * e.getDamage())));
+                        // Velocity is in meters PER TICK, so we divide by 4 to make it reasonable
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/(4 * e.getDamage())));
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -77,7 +77,7 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply((int) (damage / e.getDamage())));
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage));
                         System.out.println("Knockback: " + knockback);
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -69,7 +69,8 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/e.getDamage()));
+                        // Velocity is in meters PER TICK, so we divide by 10 to make it reasonable
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/(10 * e.getDamage())));
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -62,14 +62,14 @@ public class ExplosiveBow extends SlimefunBow {
                 Vector velocity = entity.getVelocity();
 
                 double distanceSquared = distanceVector.lengthSquared();
-                double damage = Math.max(2, e.getDamage() * (1 - (distanceSquared / (range.getValue() * range.getValue()))));
+                double damage = e.getDamage() * (1 - (distanceSquared / (2 * range.getValue() * range.getValue())));
 
                 if (!entity.getUniqueId().equals(target.getUniqueId())) {
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(e.getDamager(), entity, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, damage);
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply(2 * damage/e.getDamage()));
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/e.getDamage()));
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -57,28 +57,19 @@ public class ExplosiveBow extends SlimefunBow {
                 LivingEntity entity = (LivingEntity) nearby;
 
                 Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector());
-                System.out.println("Distance vector: " + distanceVector);
                 distanceVector.setY(distanceVector.getY() + 0.6);
-                System.out.println("New distance vector: " + distanceVector);
 
                 Vector velocity = entity.getVelocity();
-                System.out.println("Velocity: " + velocity);
 
                 double distanceSquared = distanceVector.lengthSquared();
-                System.out.println("Distance sq: " + distanceSquared);
-                System.out.println(e.getDamage());
-                System.out.println(distanceSquared / (range.getValue() * range.getValue()));
-                System.out.println(e.getDamage() * (1 - (distanceSquared / (range.getValue() * range.getValue()))));
-                double damage = Math.max(1, e.getDamage() * (1 - (distanceSquared / (range.getValue() * range.getValue()))));
-                System.out.println("Damage: " + damage);
+                double damage = Math.max(2, e.getDamage() * (1 - (distanceSquared / (range.getValue() * range.getValue()))));
 
                 if (!entity.getUniqueId().equals(target.getUniqueId())) {
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(e.getDamager(), entity, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, damage);
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage));
-                        System.out.println("Knockback: " + knockback);
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/2));
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -57,7 +57,6 @@ public class ExplosiveBow extends SlimefunBow {
                 LivingEntity entity = (LivingEntity) nearby;
 
                 Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector());
-                distanceVector.setY(distanceVector.getY() + 0.6);
 
                 Vector velocity = entity.getVelocity();
 
@@ -69,7 +68,7 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply((int) (e.getDamage() / damage)));
+                        Vector knockback = velocity.add(distanceVector.normalize().multiply((int) (damage / e.getDamage())));
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }
@@ -83,12 +82,8 @@ public class ExplosiveBow extends SlimefunBow {
     }
 
     private double calculateDamage(double distanceSquared, double originalDamage) {
-        if (distanceSquared <= 0.05) {
-            return originalDamage;
-        }
-
         double damage = originalDamage * (1 - (distanceSquared / (range.getValue() * range.getValue())));
-        return Math.min(Math.max(1, damage), originalDamage);
+        return Math.max(1, damage);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -57,24 +57,17 @@ public class ExplosiveBow extends SlimefunBow {
                 LivingEntity entity = (LivingEntity) nearby;
 
                 Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector());
-                distanceVector.setY(distanceVector.getY() + 0.6);
-
-                Vector velocity = entity.getVelocity();
-                System.out.println("velocity: " + velocity);
-                System.out.println(e.getDamage());
 
                 double distanceSquared = distanceVector.lengthSquared();
-                System.out.println("distanceSq: " + distanceSquared);
                 double damage = e.getDamage() * (1 - (distanceSquared / (2 * range.getValue() * range.getValue())));
-                System.out.println("damage: " + damage);
 
                 if (!entity.getUniqueId().equals(target.getUniqueId())) {
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(e.getDamager(), entity, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, damage);
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
+                        distanceVector.setY(Math.min(distanceVector.getY(), 0.5));
                         Vector knockback = distanceVector.normalize().multiply(2);
-                        System.out.println("Knockback: " + knockback);
                         entity.setVelocity(entity.getVelocity().add(knockback));
                         entity.damage(event.getDamage());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -73,7 +73,7 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        Vector knockback = distanceVector.normalize().multiply(4 * damage/(e.getDamage()));
+                        Vector knockback = distanceVector.normalize().multiply(2);
                         System.out.println("Knockback: " + knockback);
                         entity.setVelocity(entity.getVelocity().add(knockback));
                         entity.damage(event.getDamage());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -73,10 +73,9 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        // Velocity is in meters PER TICK, so we divide by 4 to make it reasonable
-                        Vector knockback = velocity.add(distanceVector.normalize().multiply(damage/(e.getDamage())));
+                        Vector knockback = distanceVector.normalize().multiply(4 * damage/(e.getDamage()));
                         System.out.println("Knockback: " + knockback);
-                        entity.setVelocity(knockback);
+                        entity.setVelocity(entity.getVelocity().add(knockback));
                         entity.damage(event.getDamage());
                     }
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -56,7 +56,8 @@ public class ExplosiveBow extends SlimefunBow {
             for (Entity nearby : entites) {
                 LivingEntity entity = (LivingEntity) nearby;
 
-                Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector())
+                Vector distanceVector = entity.getLocation().toVector()
+                    .subtract(target.getLocation().toVector())
                     .add(new Vector(0, 0.75, 0));
 
                 double distanceSquared = distanceVector.lengthSquared();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -57,11 +57,12 @@ public class ExplosiveBow extends SlimefunBow {
                 LivingEntity entity = (LivingEntity) nearby;
 
                 Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector());
+                distanceVector.setY(distanceVector.getY() + 0.6);
 
                 Vector velocity = entity.getVelocity();
 
                 double distanceSquared = distanceVector.lengthSquared();
-                double damage = calculateDamage(distanceSquared, e.getDamage());
+                double damage = Math.max(1, e.getDamage() * (1 - (distanceSquared / (range.getValue() * range.getValue()))));
 
                 if (!entity.getUniqueId().equals(target.getUniqueId())) {
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(e.getDamager(), entity, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, damage);
@@ -79,11 +80,6 @@ public class ExplosiveBow extends SlimefunBow {
 
     private boolean canDamage(@Nonnull Entity n) {
         return n instanceof LivingEntity && !(n instanceof ArmorStand) && n.isValid();
-    }
-
-    private double calculateDamage(double distanceSquared, double originalDamage) {
-        double damage = originalDamage * (1 - (distanceSquared / (range.getValue() * range.getValue())));
-        return Math.max(1, damage);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -56,7 +56,8 @@ public class ExplosiveBow extends SlimefunBow {
             for (Entity nearby : entites) {
                 LivingEntity entity = (LivingEntity) nearby;
 
-                Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector());
+                Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector())
+                    .add(new Vector(0, 0.75, 0));
 
                 double distanceSquared = distanceVector.lengthSquared();
                 double damage = e.getDamage() * (1 - (distanceSquared / (2 * range.getValue() * range.getValue())));
@@ -66,7 +67,7 @@ public class ExplosiveBow extends SlimefunBow {
                     Bukkit.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        distanceVector.setY(Math.min(distanceVector.getY(), 0.5));
+                        distanceVector.setY(0.75);
                         Vector knockback = distanceVector.normalize().multiply(2);
                         entity.setVelocity(entity.getVelocity().add(knockback));
                         entity.damage(event.getDamage());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/ExplosiveBow.java
@@ -57,12 +57,20 @@ public class ExplosiveBow extends SlimefunBow {
                 LivingEntity entity = (LivingEntity) nearby;
 
                 Vector distanceVector = entity.getLocation().toVector().subtract(target.getLocation().toVector());
+                System.out.println("Distance vector: " + distanceVector);
                 distanceVector.setY(distanceVector.getY() + 0.6);
+                System.out.println("New distance vector: " + distanceVector);
 
                 Vector velocity = entity.getVelocity();
+                System.out.println("Velocity: " + velocity);
 
                 double distanceSquared = distanceVector.lengthSquared();
+                System.out.println("Distance sq: " + distanceSquared);
+                System.out.println(e.getDamage());
+                System.out.println(distanceSquared / (range.getValue() * range.getValue()));
+                System.out.println(e.getDamage() * (1 - (distanceSquared / (range.getValue() * range.getValue()))));
                 double damage = Math.max(1, e.getDamage() * (1 - (distanceSquared / (range.getValue() * range.getValue()))));
+                System.out.println("Damage: " + damage);
 
                 if (!entity.getUniqueId().equals(target.getUniqueId())) {
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(e.getDamager(), entity, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, damage);
@@ -70,6 +78,7 @@ public class ExplosiveBow extends SlimefunBow {
 
                     if (!event.isCancelled()) {
                         Vector knockback = velocity.add(distanceVector.normalize().multiply((int) (damage / e.getDamage())));
+                        System.out.println("Knockback: " + knockback);
                         entity.setVelocity(knockback);
                         entity.damage(event.getDamage());
                     }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
As the code is now, the Explosive Bow seems to work fine as long as there is enough distance from the impact point and nearby entities, especially if they are on the same level. When shooting an entity from close by though, especially if directly above, you get shot in the air even 40-60 blocks up which is definitely not supposed to happen.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Cleaned up the extra redundant calculations
- Modified knockback calculation to achieve reasonable pushes
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
