### PR TITLE
Unlock researches in recipe view

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -298,9 +298,17 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
             menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNoPermissionItem(), sfitem.getItemName(), message.toArray(new String[0])));
             menu.addMenuClickHandler(index, ChestMenuUtils.getEmptyClickHandler());
         } else if (isSurvivalMode() && research != null && !profile.hasUnlocked(research)) {
-            menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNotResearchedItem(), ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "",
-                    Slimefun.getLocalization().getMessage(p, "guide.unlock.click"), "",
-                    Slimefun.getLocalization().getMessage(p, "guide.unlock.cost").replace("%cost%", String.valueOf(research.getCost()))));
+            String unlockCost = Slimefun.getLocalization()
+                    .getMessage(p, "guide.unlock.cost")
+                    .replace("%cost%", String.valueOf(research.getCost()));
+            menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNotResearchedItem(),
+                    ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()),
+                    "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"),
+                    "",
+                    Slimefun.getLocalization().getMessage(p, "guide.unlock.click"),
+                    "",
+                    unlockCost
+            ));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
                 research.unlockFromGuide(this, p, profile, sfitem, itemGroup, page);
                 return false;
@@ -568,7 +576,13 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
         for (int i = 0; i < 9; i++) {
             ItemStack recipeItem = getDisplayItem(p, isSlimefunRecipe, recipe[i]);
-            menu.addItem(recipeSlots[i], recipeItem, (recipeItem instanceof UnlockableItemStack) ? lockedClickHandler : clickHandler);
+            MenuClickHandler handler;
+            if (recipeItem instanceof UnlockableItemStack) {
+                handler = lockedClickHandler;
+            } else {
+                handler = clickHandler;
+            }
+            menu.addItem(recipeSlots[i], recipeItem, handler);
 
             if (recipeItem != null && item instanceof MultiBlockMachine) {
                 for (Tag<Material> tag : MultiBlock.getSupportedTags()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -298,7 +298,9 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
             menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNoPermissionItem(), sfitem.getItemName(), message.toArray(new String[0])));
             menu.addMenuClickHandler(index, ChestMenuUtils.getEmptyClickHandler());
         } else if (isSurvivalMode() && research != null && !profile.hasUnlocked(research)) {
-            menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNotResearchedItem(), ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", "&a> Click to unlock", "", "&7Cost: &b" + research.getCost() + " Level(s)"));
+            menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNotResearchedItem(), ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "",
+                    Slimefun.getLocalization().getMessage(p, "guide.unlock.click"), "",
+                    Slimefun.getLocalization().getMessage(p, "guide.unlock.cost").replace("%cost%", String.valueOf(research.getCost()))));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
                 research.unlockFromGuide(this, p, profile, sfitem, itemGroup, page);
                 return false;
@@ -539,10 +541,22 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
     private void displayItem(ChestMenu menu, PlayerProfile profile, Player p, Object item, ItemStack output, RecipeType recipeType, ItemStack[] recipe, AsyncRecipeChoiceTask task) {
         addBackButton(menu, 0, p, profile);
 
-        MenuClickHandler clickHandler = (pl, slot, itemstack, action) -> {
+        MenuClickHandler clickHandler = (pl, slot, itemStack, action) -> {
             try {
-                if (itemstack != null && itemstack.getType() != Material.BARRIER) {
-                    displayItem(profile, itemstack, 0, true);
+                if (itemStack != null && itemStack.getType() != Material.BARRIER) {
+                    displayItem(profile, itemStack, 0, true);
+                }
+            } catch (Exception | LinkageError x) {
+                printErrorMessage(pl, x);
+            }
+            return false;
+        };
+
+        MenuClickHandler lockedClickHandler = (pl, slot, itemStack, action) -> {
+            try {
+                SlimefunItem sfItem = SlimefunItem.getByItem(itemStack);
+                if (sfItem != null) {
+                    this.unlockItem(pl, sfItem, player -> displayItem(profile, itemStack, 0, true));
                 }
             } catch (Exception | LinkageError x) {
                 printErrorMessage(pl, x);
@@ -554,7 +568,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
         for (int i = 0; i < 9; i++) {
             ItemStack recipeItem = getDisplayItem(p, isSlimefunRecipe, recipe[i]);
-            menu.addItem(recipeSlots[i], recipeItem, clickHandler);
+            menu.addItem(recipeSlots[i], recipeItem, (recipeItem instanceof UnlockableItemStack) ? lockedClickHandler : clickHandler);
 
             if (recipeItem != null && item instanceof MultiBlockMachine) {
                 for (Tag<Material> tag : MultiBlock.getSupportedTags()) {
@@ -632,12 +646,19 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         if (isSlimefunRecipe) {
             SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
 
-            if (slimefunItem == null) {
+            if (slimefunItem == null || slimefunItem.canUse(p, false)) {
+                // Just return the item if it is usable or isn't a Slimefun item
                 return item;
             }
 
-            String lore = hasPermission(p, slimefunItem) ? "&fNeeds to be unlocked in " + slimefunItem.getItemGroup().getDisplayName(p) : "&fNo Permission";
-            return slimefunItem.canUse(p, false) ? item : new CustomItemStack(Material.BARRIER, ItemUtils.getItemName(item), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", lore);
+            if (!Slimefun.getPermissionsService().hasPermission(p, slimefunItem)) {
+                return new CustomItemStack(Material.BARRIER, ItemUtils.getItemName(item), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", Slimefun.getLocalization().getMessage(p, "guide.no-permission"));
+            } else {
+                if (!slimefunItem.getItem().hasItemMeta()) {
+                    return new CustomItemStack(Material.BARRIER, ItemUtils.getItemName(item));
+                }
+                return new UnlockableItemStack(slimefunItem.getId(), slimefunItem.getItem(), p);
+            }
         } else {
             return item;
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -576,12 +576,8 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
         for (int i = 0; i < 9; i++) {
             ItemStack recipeItem = getDisplayItem(p, isSlimefunRecipe, recipe[i]);
-            MenuClickHandler handler;
-            if (recipeItem instanceof UnlockableItemStack) {
-                handler = lockedClickHandler;
-            } else {
-                handler = clickHandler;
-            }
+            MenuClickHandler handler = (recipeItem instanceof UnlockableItemStack) ? lockedClickHandler : clickHandler;
+
             menu.addItem(recipeSlots[i], recipeItem, handler);
 
             if (recipeItem != null && item instanceof MultiBlockMachine) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/UnlockableItemStack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/UnlockableItemStack.java
@@ -1,0 +1,36 @@
+package io.github.thebusybiscuit.slimefun4.implementation.guide;
+
+import io.github.bakedlibs.dough.common.ChatColors;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An extension of {@link ItemStack} that indicates the item is unlockable in the guide
+ *
+ * @author RobotHanzo
+ */
+public class UnlockableItemStack extends SlimefunItemStack {
+    public UnlockableItemStack(@Nonnull String id, @Nonnull ItemStack item, @Nonnull Player player) {
+        super(id, item);
+
+        ItemMeta resultMeta = this.getItemMeta();
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.DARK_RED + ChatColor.BOLD.toString() + Slimefun.getLocalization().getMessage(player, "guide.locked"));
+        lore.add("");
+        lore.add(ChatColors.color(Slimefun.getLocalization().getMessage(player, "guide.unlock.click")));
+        lore.add("");
+        lore.add(ChatColors.color(Slimefun.getLocalization().getMessage(player, "guide.unlock.cost").replace("%cost%", String.valueOf(this.getItem().getResearch().getCost()))));
+        resultMeta.setLore(lore);
+        this.setItemMeta(resultMeta);
+        this.setType(Material.BARRIER);
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/UnlockableItemStack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/UnlockableItemStack.java
@@ -18,7 +18,7 @@ import java.util.List;
  *
  * @author RobotHanzo
  */
-public class UnlockableItemStack extends SlimefunItemStack {
+class UnlockableItemStack extends SlimefunItemStack {
     public UnlockableItemStack(@Nonnull String id, @Nonnull ItemStack item, @Nonnull Player player) {
         super(id, item);
 

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -27,7 +27,7 @@ commands:
     not-rechargeable: This item can not be charged!
 
   timings:
-    description: Timings for Slimefun and its addon
+    description: 'Timings for Slimefun and its addon'
     please-wait: '&ePlease wait a second... The results are coming in!'
     verbose-player: '&4The verbose flag cannot be used by a Player!'
     unknown-flag: '&4Unknown flag: &c%flag%'
@@ -37,7 +37,12 @@ placeholderapi:
 
 guide:
   locked: 'LOCKED'
+  no-permission: '&fNo Permission'
   work-in-progress: 'This feature is not fully finished yet!'
+
+  unlock:
+    click: '&a> Click to unlock'
+    cost: '&7Cost: &b%cost% level(s)'
 
   locked-itemgroup:
   - 'To unlock this category you will'


### PR DESCRIPTION
## Description
A newer and improved version of #2912 (Implemented suggestion 972, offers the ability to unlock items within the recipe book)
With the ability to translate strings related to it

## Demonstration
https://youtu.be/wtYmTkPmMlc

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
