### PR TITLE
Check for sneaking when breaking logs on lumber axe

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
@@ -50,7 +50,7 @@ public class LumberAxe extends SlimefunItem implements NotPlaceable {
     @Nonnull
     private ToolUseHandler onBlockBreak() {
         return (e, tool, fortune, drops) -> {
-            if (Tag.LOGS.isTagged(e.getBlock().getType())) {
+            if (!e.getPlayer().isSneaking() && Tag.LOGS.isTagged(e.getBlock().getType())) {
                 List<Block> logs = Vein.find(e.getBlock(), MAX_BROKEN, b -> Tag.LOGS.isTagged(b.getType()));
                 logs.remove(e.getBlock());
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This was an approved suggestion on the discord and I thought it would be helpful for many players.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
When breaking a log with the lumber axe, check if the player is sneaking so that it doesn't cut down all logs.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
[This suggestion on the discord](https://discord.com/channels/565557184348422174/627048923122499584/892393743133577287)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
