### PR TITLE
Implement Multimeter Functionality on Generators

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetProvider.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetProvider.java
@@ -18,6 +18,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AGenerator;
  * It must be implemented on any Generator or {@link Reactor}.
  * 
  * @author TheBusyBiscuit
+ * @author md5sha256
  * 
  * @see EnergyNet
  * @see EnergyNetComponent
@@ -48,6 +49,17 @@ public interface EnergyNetProvider extends EnergyNetComponent {
      */
     int getGeneratedOutput(@Nonnull Location l, @Nonnull Config data);
 
+    /**
+     * The method return how much this {@link EnergyNetProvider} is expected to provide to the {@link EnergyNet}
+     * and is not to be confused with {@link #getGeneratedOutput(Location, Config)}. This method will not
+     * consume any fuel or modify the provider in any way.
+     * @param l
+     *            The {@link Location} of this {@link EnergyNetProvider}
+     * @param data
+     *            The stored block data
+     *
+     * @return The expected generated output energy of this {@link EnergyNetProvider}.
+     */
     int peekGeneratedOutput(@Nonnull Location l, @Nonnull Config data);
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetProvider.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetProvider.java
@@ -48,6 +48,8 @@ public interface EnergyNetProvider extends EnergyNetComponent {
      */
     int getGeneratedOutput(@Nonnull Location l, @Nonnull Config data);
 
+    int peekGeneratedOutput(@Nonnull Location l, @Nonnull Config data);
+
     /**
      * This method returns whether the given {@link Location} is going to explode on the
      * next tick.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Multimeter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Multimeter.java
@@ -1,6 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.gadgets;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -26,6 +27,7 @@ import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
  * The {@link Multimeter} is used to measure charge and capacity of any {@link EnergyNetComponent}.
  * 
  * @author TheBusyBiscuit
+ * @author md5sha256
  * 
  * @see EnergyNet
  * @see EnergyNetComponent
@@ -55,18 +57,18 @@ public class Multimeter extends SimpleSlimefunItem<ItemUseHandler> {
                         Location l = e.getClickedBlock().get().getLocation();
                         String stored = NumberUtils.getCompactDouble(component.getCharge(l)) + " J";
                         String capacity = NumberUtils.getCompactDouble(component.getCapacity()) + " J";
-                        String generating;
-                        if (component instanceof EnergyNetProvider) {
-                            EnergyNetProvider provider = (EnergyNetProvider) component;
-                            Config data = BlockStorage.getLocationInfo(l);
-                            generating = NumberUtils.getCompactDouble(provider.peekGeneratedOutput(l, data)) + " J/t";
-                        } else {
-                            generating = "";
-                        }
 
                         Player p = e.getPlayer();
                         p.sendMessage("");
-                        Slimefun.getLocalization().sendMessages(p, "messages.multimeter", false, str -> str.replace("%stored%", stored).replace("%capacity%", capacity).replace("%generating%", generating));
+
+                        if (component instanceof EnergyNetProvider) {
+                            EnergyNetProvider provider = (EnergyNetProvider) component;
+                            Config data = BlockStorage.getLocationInfo(l);
+                            String generating = NumberUtils.getCompactDouble(provider.peekGeneratedOutput(l, data)) + " J/t";
+                            Slimefun.getLocalization().sendMessages(p, "messages.multimeter-generating", false, str -> str.replace("%stored%", stored).replace("%capacity%", capacity).replace("%generating%", generating));
+                        } else {
+                            Slimefun.getLocalization().sendMessage(p, "messages.multimeter", false, str -> str.replace("%stored%", stored).replace("%capacity%", capacity));
+                        }
                         p.sendMessage("");
                     }
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Multimeter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/Multimeter.java
@@ -4,6 +4,9 @@ import java.util.Optional;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetProvider;
+import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -52,10 +55,18 @@ public class Multimeter extends SimpleSlimefunItem<ItemUseHandler> {
                         Location l = e.getClickedBlock().get().getLocation();
                         String stored = NumberUtils.getCompactDouble(component.getCharge(l)) + " J";
                         String capacity = NumberUtils.getCompactDouble(component.getCapacity()) + " J";
+                        String generating;
+                        if (component instanceof EnergyNetProvider) {
+                            EnergyNetProvider provider = (EnergyNetProvider) component;
+                            Config data = BlockStorage.getLocationInfo(l);
+                            generating = NumberUtils.getCompactDouble(provider.peekGeneratedOutput(l, data)) + " J/t";
+                        } else {
+                            generating = "";
+                        }
 
                         Player p = e.getPlayer();
                         p.sendMessage("");
-                        Slimefun.getLocalization().sendMessage(p, "messages.multimeter", false, str -> str.replace("%stored%", stored).replace("%capacity%", capacity));
+                        Slimefun.getLocalization().sendMessages(p, "messages.multimeter", false, str -> str.replace("%stored%", stored).replace("%capacity%", capacity).replace("%generating%", generating));
                         p.sendMessage("");
                     }
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
@@ -27,6 +27,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
  * {@link #getNightEnergy()}.
  * 
  * @author TheBusyBiscuit
+ * @author md5sha256
  * 
  * @see EnergyNet
  * @see EnergyNetProvider

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.generators;
 
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Location;
@@ -94,6 +95,12 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
                 return isDaytime ? getDayEnergy() : getNightEnergy();
             }
         }
+    }
+
+    @Override
+    public int peekGeneratedOutput(@Nonnull Location l, @Nonnull Config data) {
+        // Solar panels will not change when generating energy
+        return getGeneratedOutput(l, data);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -299,6 +299,43 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
         }
     }
 
+    @Override
+    public int peekGeneratedOutput(@Nonnull Location l, @Nonnull Config data) {
+        BlockMenu inv = BlockStorage.getInventory(l);
+        BlockMenu accessPort = getAccessPort(l);
+        FuelOperation operation = processor.getOperation(l);
+
+        if (operation != null) {
+            return peekGenerateEnergy(l, data, inv, accessPort, operation);
+        } else {
+            return 0;
+        }
+    }
+
+    private int peekGenerateEnergy(@Nonnull Location l, @Nonnull Config data, @Nonnull BlockMenu inv, @Nullable BlockMenu accessPort, FuelOperation operation) {
+        int produced = getEnergyProduction();
+        String energyData = data.getString("energy-charge");
+        int charge = 0;
+
+        if (energyData != null) {
+            charge = Integer.parseInt(energyData);
+        }
+
+        int space = getCapacity() - charge;
+
+        if (space >= produced || getReactorMode(l) != ReactorMode.GENERATOR) {
+            if (needsCooling() && !hasEnoughCoolant(l, inv, accessPort, operation)) {
+                return 0;
+            }
+        }
+
+        if (space >= produced) {
+            return getEnergyProduction();
+        } else {
+            return 0;
+        }
+    }
+
     private int generateEnergy(@Nonnull Location l, @Nonnull Config data, @Nonnull BlockMenu inv, @Nullable BlockMenu accessPort, @Nonnull FuelOperation operation) {
         int produced = getEnergyProduction();
         String energyData = data.getString("energy-charge");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -54,6 +54,7 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
  * @author John000708
  * @author AlexLander123
  * @author TheBusyBiscuit
+ * @author md5sha256
  * 
  * @see AGenerator
  * @see NuclearReactor

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -199,6 +199,28 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
         }
     }
 
+    @Override
+    public int peekGeneratedOutput(@Nonnull Location l, @Nonnull Config data) {
+        FuelOperation operation = processor.getOperation(l);
+        if (operation != null) {
+            if (!operation.isFinished()) {
+                if (isChargeable()) {
+                    int charge = getCharge(l, data);
+                    if (getCapacity() - charge >= getEnergyProduction()) {
+                        return getEnergyProduction();
+                    }
+                    return 0;
+                } else {
+                    return getEnergyProduction();
+                }
+            } else {
+                return 0;
+            }
+        } else {
+            return 0;
+        }
+    }
+
     private boolean isBucket(@Nullable ItemStack item) {
         if (item == null) {
             return false;

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -157,7 +157,9 @@ messages:
   disabled-in-world: '&4&lThis Item has been disabled in this world'
   disabled-item: '&4&lThis Item has been disabled! How did you even get that?'
   no-tome-yourself: '&cYou cannot use the &4Tome of Knowledge &con yourself...'
-  multimeter: '&bStored Energy: &3%stored% &b/ &3%capacity%'
+  multimeter:
+  - '&bStored Energy: &3%stored% &b/ &3%capacity%'
+  - '&bGenerating: &3%generating%'
   piglin-barter: '&4You cannot barter with piglins using Slimefun items'
   bee-suit-slow-fall: '&eYour Bee Wings will help you to get back to the ground safe and slow'
 

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -157,7 +157,8 @@ messages:
   disabled-in-world: '&4&lThis Item has been disabled in this world'
   disabled-item: '&4&lThis Item has been disabled! How did you even get that?'
   no-tome-yourself: '&cYou cannot use the &4Tome of Knowledge &con yourself...'
-  multimeter:
+  multimeter: '&bStored Energy: &3%stored% &b/ &3%capacity%'
+  multimeter-generating:
   - '&bStored Energy: &3%stored% &b/ &3%capacity%'
   - '&bGenerating: &3%generating%'
   piglin-barter: '&4You cannot barter with piglins using Slimefun items'


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Implementation of #2314
**This is going to break any addons which have implementations of `EnergyNetProvider`.**
I considered two approaches to implementing this. One was the way **TheBusyBiscuit** mentioned in #2314. The alternative is to perform this breaking change.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add a new method `EnergyNetProvider#peekGeneratedEnergy`
Add a new message `messages.multimeter-generating`

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #2314

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
