### PR TITLE
Add Shift Click in Cheat Menu

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -313,7 +313,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
                         if (sfitem instanceof MultiBlockMachine) {
                             Slimefun.getLocalization().sendMessage(pl, "guide.cheat.no-multiblocks");
                         } else {
-                            if (p.isSneaking()) {
+                            if (action.isShiftClicked()) {
                                 ItemStack sfItem = sfitem.getItem().clone();
                                 sfItem.setAmount(sfItem.getMaxStackSize());
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -313,13 +313,13 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
                         if (sfitem instanceof MultiBlockMachine) {
                             Slimefun.getLocalization().sendMessage(pl, "guide.cheat.no-multiblocks");
                         } else {
+                            ItemStack clonedItem = sfitem.getItem().clone();
                             if (action.isShiftClicked()) {
-                                ItemStack sfItem = sfitem.getItem().clone();
-                                sfItem.setAmount(sfItem.getMaxStackSize());
+                                clonedItem.setAmount(clonedItem.getMaxStackSize());
 
-                                pl.getInventory().addItem(sfItem);
+                                pl.getInventory().addItem(clonedItem);
                             } else {
-                                pl.getInventory().addItem(sfitem.getItem().clone());
+                                pl.getInventory().addItem(clonedItem);
                             }
                         }
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -314,13 +314,12 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
                             Slimefun.getLocalization().sendMessage(pl, "guide.cheat.no-multiblocks");
                         } else {
                             ItemStack clonedItem = sfitem.getItem().clone();
+
                             if (action.isShiftClicked()) {
                                 clonedItem.setAmount(clonedItem.getMaxStackSize());
-
-                                pl.getInventory().addItem(clonedItem);
-                            } else {
-                                pl.getInventory().addItem(clonedItem);
                             }
+                            
+                            pl.getInventory().addItem(clonedItem);
                         }
                     }
                 } catch (Exception | LinkageError x) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -313,7 +313,14 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
                         if (sfitem instanceof MultiBlockMachine) {
                             Slimefun.getLocalization().sendMessage(pl, "guide.cheat.no-multiblocks");
                         } else {
-                            pl.getInventory().addItem(sfitem.getItem().clone());
+                            if (p.isSneaking()) {
+                                ItemStack sfItem = sfitem.getItem().clone();
+                                sfItem.setAmount(sfItem.getMaxStackSize());
+
+                                pl.getInventory().addItem(sfItem);
+                            } else {
+                                pl.getInventory().addItem(sfitem.getItem().clone());
+                            }
                         }
                     }
                 } catch (Exception | LinkageError x) {


### PR DESCRIPTION
## Description
Add a feature that if you shift left click in the Cheat guide, that it will give you a stack of that item instead of 1 (while respecting max stack size of an item).

## Proposed changes
- Add check for shift clicking while in Cheat menu

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
