### PR TITLE
Solar Generators - Return night energy in non overworld dimensions

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/generators/SolarGenerator.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -33,6 +34,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
  */
 public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
 
+    private final ItemSetting<Boolean> useNightEnergyInOtherDimensions = new ItemSetting<>(this, "other-dimensions-use-night-energy", false);
     private final int dayEnergy;
     private final int nightEnergy;
     private final int capacity;
@@ -44,6 +46,8 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
         this.dayEnergy = dayEnergy;
         this.nightEnergy = nightEnergy;
         this.capacity = capacity;
+
+        addItemSetting(useNightEnergyInOtherDimensions);
     }
 
     @ParametersAreNonnullByDefault
@@ -81,7 +85,11 @@ public class SolarGenerator extends SlimefunItem implements EnergyNetProvider {
         World world = l.getWorld();
 
         if (world.getEnvironment() != Environment.NORMAL) {
-            return getNightEnergy();
+            if (useNightEnergyInOtherDimensions.getValue()) {
+                return getNightEnergy();
+            }
+
+            return 0;
         } else {
             boolean isDaytime = isDaytime(world);
 


### PR DESCRIPTION
## Description
When using solar panels outside of the overworld, it will return 0 as power used currently.
This change makes it so it will return the night energy instead.

## Proposed changes
- Return night energy in other dimensions but overworld

## Related Issues (if applicable)
[Discord Suggestion 12](https://discord.com/channels/565557184348422174/627048923122499584/698913136673292299)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
