### PR TITLE
Fix for #3264

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/Juice.java
@@ -87,15 +87,15 @@ public class Juice extends SimpleSlimefunItem<ItemConsumptionHandler> {
     private void removeGlassBottle(Player p, ItemStack item) {
         if (SlimefunUtils.isItemSimilar(item, p.getInventory().getItemInMainHand(), true)) {
             if (p.getInventory().getItemInMainHand().getAmount() == 1) {
-                Slimefun.runSync(() -> p.getEquipment().getItemInMainHand().setAmount(0));
+                p.getEquipment().getItemInMainHand().setAmount(0);
             } else {
-                Slimefun.runSync(() -> p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1)));
+                p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1));
             }
         } else if (SlimefunUtils.isItemSimilar(item, p.getInventory().getItemInOffHand(), true)) {
             if (p.getInventory().getItemInOffHand().getAmount() == 1) {
-                Slimefun.runSync(() -> p.getEquipment().getItemInOffHand().setAmount(0));
+                p.getEquipment().getItemInOffHand().setAmount(0);
             } else {
-                Slimefun.runSync(() -> p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1)));
+                p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1));
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The issue #3264 occurs because of a race condition of one tick that occurs when a juice is drank. This gives the player 1 tick to switch items in their hotbar, giving the effects of #3264.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Removed the runSync() call on the Juice.java file. There is no real need for it.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3264

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
