### PR TITLE
Fixes for #3260 and removal of unnecesary parameter of method getCharge()

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetComponent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetComponent.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.core.attributes;
 import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
@@ -76,23 +77,50 @@ public interface EnergyNetComponent extends ItemAttribute {
             return 0;
         }
 
-        return getCharge(l, BlockStorage.getLocationInfo(l));
+        return getCharge(BlockStorage.getLocationInfo(l));
     }
 
     /**
-     * This returns the currently stored charge at a given {@link Location}.
+     * This returns a string-location of the Energy Regulator controlling this component
+     * @param data
+     *              The {@link Config} of the target block
+     * @return
+     *              The location of the energy regulator in string form.
+     */
+    default String getSerializedRegulatorLocation(@Nonnull Config data) {
+        Validate.notNull(data, "data was null!");
+
+        return data.getString("energy-net-location");
+    }
+
+    /**
+     * This sets the location of the Energy Regulator controlling this component
+     * @param l
+     *          {@link Location} of the component
+     * @param energyNet
+     * \        {@link Location} of the Energy Regulator to set
+     */
+    default void setRegulatorLocation(@Nonnull Location l, @Nullable Location energyNet) {
+        Validate.notNull(l, "Location was null!");
+
+        if (energyNet == null) {
+            BlockStorage.addBlockInfo(l, "energy-net-location", null);
+        } else {
+            BlockStorage.addBlockInfo(l, "energy-net-location", energyNet.toString());
+        }
+    }
+
+    /**
+     * This returns the currently stored charge at a given {@link Location} using it's {@link Config}
      * This is a more performance saving option if you already have a {@link Config}
      * object for this {@link Location}.
-     * 
-     * @param l
-     *            The target {@link Location}
+     *
      * @param data
      *            The data at this {@link Location}
      * 
      * @return The charge stored at that {@link Location}
      */
-    default int getCharge(@Nonnull Location l, @Nonnull Config data) {
-        Validate.notNull(l, "Location was null!");
+    default int getCharge(@Nonnull Config data) {
         Validate.notNull(data, "data was null!");
 
         // Emergency fallback, this cannot hold a charge, so we'll just return zero

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -163,7 +163,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
     protected void tick(@Nonnull Block b, @Nonnull Config data) {
         AbstractRecipe recipe = getSelectedRecipe(b);
 
-        if (recipe == null || !recipe.isEnabled() || getCharge(b.getLocation(), data) < getEnergyConsumption()) {
+        if (recipe == null || !recipe.isEnabled() || getCharge(data) < getEnergyConsumption()) {
             // No recipe / disabled recipe / no energy, abort...
             return;
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
@@ -46,6 +46,7 @@ public class EnergyRegulator extends SlimefunItem implements HologramOwner {
 
             @Override
             public void onBlockBreak(@Nonnull Block b) {
+                EnergyNet.getNetworkFromLocation(b.getLocation()).cleanup();
                 removeHologram(b);
             }
         };

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AbstractEntityAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AbstractEntityAssembler.java
@@ -195,7 +195,7 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
                     return;
                 }
 
-                if (lifetime % 60 == 0 && getCharge(b.getLocation(), data) >= getEnergyConsumption()) {
+                if (lifetime % 60 == 0 && getCharge(data) >= getEnergyConsumption()) {
                     BlockMenu menu = BlockStorage.getInventory(b);
 
                     boolean hasBody = findResource(menu, getBody(), bodySlots);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSTransmitter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSTransmitter.java
@@ -78,7 +78,7 @@ public abstract class GPSTransmitter extends SimpleSlimefunItem<BlockTicker> imp
 
             @Override
             public void tick(Block b, SlimefunItem item, Config data) {
-                int charge = getCharge(b.getLocation(), data);
+                int charge = getCharge(data);
                 UUID owner = UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"));
 
                 if (charge >= getEnergyConsumption()) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -159,7 +159,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
                 processor.updateProgressBar(inv, 22, operation);
 
                 if (isChargeable()) {
-                    int charge = getCharge(l, data);
+                    int charge = getCharge(data);
 
                     if (getCapacity() - charge >= getEnergyProduction()) {
                         operation.addProgress(1);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This pull request's objective is to fix the problem with energy duplication and removing an unnecessary parameter in a function.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

What this pull request does is adding a value to the BlockData
of both generators and consumers of energy that tells them which network they belong on, and allows said network
to only recieve energy and consume energy from machines within its own network

Also, removed the location parameter in getCharge() of EnergyNetComponent, since it's not needed to get the charge
of a component and it's only use is to get the underlying Config data of said component.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3260
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
