### PR TITLE
Fix smithing table listener on 1.15 and below

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -611,7 +611,6 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         new CauldronListener(this);
         new GrindstoneListener(this);
         new CartographyTableListener(this);
-        new SmithingTableListener(this);
         new ButcherAndroidListener(this);
         new MiningAndroidListener(this);
         new NetworkListener(this, networkManager);
@@ -630,6 +629,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         // Piglins were added in 1.16
         if (minecraftVersion.isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
             new PiglinListener(this);
+            new SmithingTableListener(this);
         }
 
         // Item-specific Listeners


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The smithing table had no interactive GUI on 1.15 and below, so the `SmithingTableListerner` will cause errors on 1.15 and below. Someone reported this on discord, but I think this is worth a fix.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Register SmithingTableListener only on 1.16+

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Reported on discord:
https://discord.com/channels/565557184348422174/565569196218384385/900881933226098769

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
