### PR TITLE
Added option to allow slimefun Items to be useable without research

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -1066,8 +1066,8 @@ public class SlimefunItem implements Placeable {
      * @param sendMessage
      *            Whether to send that {@link Player} a message response.
      * @param forceResearch
-     *            If you should the research is required even if require-research-on-use is false
-     * 
+     *            Whether the research is required even if require-research-on-use is false
+     *
      * @return Whether this {@link Player} is able to use this {@link SlimefunItem}.
      */
     public boolean canUse(@Nonnull Player p, boolean sendMessage, boolean forceResearch) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -1021,6 +1021,7 @@ public class SlimefunItem implements Placeable {
         }
     }
 
+	
     /**
      * This method checks if the given {@link Player} is able to use this {@link SlimefunItem}.
      * A {@link Player} can use it if the following conditions apply:
@@ -1043,6 +1044,33 @@ public class SlimefunItem implements Placeable {
      * @return Whether this {@link Player} is able to use this {@link SlimefunItem}.
      */
     public boolean canUse(@Nonnull Player p, boolean sendMessage) {
+    	return this.canUse(p, sendMessage, false);
+    }
+    
+    /**
+     * This method checks if the given {@link Player} is able to use this {@link SlimefunItem}.
+     * A {@link Player} can use it if the following conditions apply:
+     * 
+     * <ul>
+     * <li>The {@link SlimefunItem} is not disabled
+     * <li>The {@link SlimefunItem} was not disabled for that {@link Player}'s {@link World}.
+     * <li>The {@link Player} has the required {@link Permission} (if present)
+     * <li>The {@link Player} has unlocked the required {@link Research} (if present)
+     * </ul>
+     * 
+     * If any of these conditions evaluate to <code>false</code>, then an optional message will be
+     * sent to the {@link Player}.
+     * 
+     * @param p
+     *            The {@link Player} to check
+     * @param sendMessage
+     *            Whether to send that {@link Player} a message response.
+     * @param forceResearch
+     *            If you should have the reasearch even if dont-need-research-to-use is true
+     * 
+     * @return Whether this {@link Player} is able to use this {@link SlimefunItem}.
+     */
+    public boolean canUse(@Nonnull Player p, boolean sendMessage, boolean forceResearch) {
         Validate.notNull(p, "The Player cannot be null!");
 
         if (getState() == ItemState.VANILLA_FALLBACK) {
@@ -1069,7 +1097,7 @@ public class SlimefunItem implements Placeable {
             }
 
             return false;
-        } else if (hasResearch()) {
+        } else if ((forceResearch || !Slimefun.getCfg().getBoolean("researches.dont-need-research-to-use")) && hasResearch()) {
             Optional<PlayerProfile> profile = PlayerProfile.find(p);
 
             if (!profile.isPresent()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -1066,7 +1066,7 @@ public class SlimefunItem implements Placeable {
      * @param sendMessage
      *            Whether to send that {@link Player} a message response.
      * @param forceResearch
-     *            If you should have the reasearch even if require-research-on-use is true
+     *            If you should the research is required even if require-research-on-use is false
      * 
      * @return Whether this {@link Player} is able to use this {@link SlimefunItem}.
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -1066,7 +1066,7 @@ public class SlimefunItem implements Placeable {
      * @param sendMessage
      *            Whether to send that {@link Player} a message response.
      * @param forceResearch
-     *            If you should have the reasearch even if dont-need-research-to-use is true
+     *            If you should have the reasearch even if require-research-on-use is true
      * 
      * @return Whether this {@link Player} is able to use this {@link SlimefunItem}.
      */
@@ -1097,7 +1097,7 @@ public class SlimefunItem implements Placeable {
             }
 
             return false;
-        } else if ((forceResearch || !Slimefun.getCfg().getBoolean("researches.dont-need-research-to-use")) && hasResearch()) {
+        } else if ((forceResearch || Slimefun.getCfg().getBoolean("researches.require-research-on-use")) && hasResearch()) {
             Optional<PlayerProfile> profile = PlayerProfile.find(p);
 
             if (!profile.isPresent()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -117,7 +117,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     protected @Nonnull MultiBlockInteractionHandler getInteractionHandler() {
         return (p, mb, b) -> {
             if (mb.equals(getMultiBlock())) {
-                if (canUse(p, true) && Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK)) {
+                if (canUse(p, true, true) && Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK)) {
                     onInteract(p, b);
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -643,7 +643,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
             }
 
             String lore = hasPermission(p, slimefunItem) ? "&fNeeds to be unlocked in " + slimefunItem.getItemGroup().getDisplayName(p) : "&fNo Permission";
-            return slimefunItem.canUse(p, false) ? item : new CustomItemStack(Material.BARRIER, ItemUtils.getItemName(item), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", lore);
+            return slimefunItem.canUse(p, false, false) ? item : new CustomItemStack(Material.BARRIER, ItemUtils.getItemName(item), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", lore);
         } else {
             return item;
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
@@ -84,7 +84,7 @@ public class SlimefunAutoCrafter extends AbstractAutoCrafter {
 
         if (item != null && item.getRecipeType().equals(targetRecipeType)) {
             // Fixes #1161
-            if (item.canUse(p, true)) {
+            if (item.canUse(p, true, true)) {
                 AbstractRecipe recipe = AbstractRecipe.of(item, targetRecipeType);
 
                 if (recipe != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/EnchantmentRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/EnchantmentRune.java
@@ -69,7 +69,7 @@ public class EnchantmentRune extends SimpleSlimefunItem<ItemDropHandler> {
     public ItemDropHandler getItemHandler() {
         return (e, p, item) -> {
             if (isItem(item.getItemStack())) {
-                if (canUse(p, true)) {
+                if (canUse(p, true, false)) {
                     Slimefun.runSync(() -> {
                         try {
                             addRandomEnchantment(p, item);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
@@ -50,7 +50,7 @@ public class SoulboundRune extends SimpleSlimefunItem<ItemDropHandler> {
         return (e, p, item) -> {
             if (isItem(item.getItemStack())) {
 
-                if (!canUse(p, true)) {
+                if (!canUse(p, true, false)) {
                     return true;
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -179,7 +179,7 @@ public class Talisman extends SlimefunItem {
         ItemStack talismanItem = talisman.getItem();
 
         if (SlimefunUtils.containsSimilarItem(p.getInventory(), talismanItem, true)) {
-            if (talisman.canUse(p, true)) {
+            if (talisman.canUse(p, true, false)) {
                 activateTalisman(e, p, p.getInventory(), talisman, talismanItem, sendMessage);
                 return true;
             } else {
@@ -189,7 +189,7 @@ public class Talisman extends SlimefunItem {
             ItemStack enderTalisman = talisman.getEnderVariant();
 
             if (SlimefunUtils.containsSimilarItem(p.getEnderChest(), enderTalisman, true)) {
-                if (talisman.canUse(p, true)) {
+                if (talisman.canUse(p, true, false)) {
                     activateTalisman(e, p, p.getEnderChest(), talisman, enderTalisman, sendMessage);
                     return true;
                 } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -110,7 +110,7 @@ public class AncientAltarListener implements Listener {
             e.cancel();
             usePedestal(b, p);
         } else if (id.equals(altarItem.getId())) {
-            if (!altarItem.canUse(p, true) || altarsInUse.contains(b.getLocation())) {
+            if (!altarItem.canUse(p, true, false) || altarsInUse.contains(b.getLocation())) {
                 e.cancel();
                 return;
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
@@ -128,7 +128,7 @@ public class BackpackListener implements Listener {
     @ParametersAreNonnullByDefault
     public void openBackpack(Player p, ItemStack item, SlimefunBackpack backpack) {
         if (item.getAmount() == 1) {
-            if (backpack.canUse(p, true) && !PlayerProfile.get(p, profile -> openBackpack(p, item, profile, backpack.getSize()))) {
+            if (backpack.canUse(p, true, false) && !PlayerProfile.get(p, profile -> openBackpack(p, item, profile, backpack.getSize()))) {
                 Slimefun.getLocalization().sendMessage(p, "messages.opening-backpack");
             }
         } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BeeWingsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BeeWingsListener.java
@@ -43,7 +43,7 @@ public class BeeWingsListener implements Listener {
         Player player = (Player) e.getEntity();
         ItemStack chestplate = player.getInventory().getChestplate();
 
-        if (wings.isItem(chestplate) && wings.canUse(player, true)) {
+        if (wings.isItem(chestplate) && wings.canUse(player, true, false)) {
             new BeeWingsTask(player).scheduleRepeating(3, 1);
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -82,7 +82,7 @@ public class BlockListener implements Listener {
         SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
         if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
-            if (!sfItem.canUse(e.getPlayer(), true)) {
+            if (!sfItem.canUse(e.getPlayer(), true, false)) {
                 e.setCancelled(true);
             } else {
                 if (Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
@@ -134,7 +134,7 @@ public class BlockListener implements Listener {
         SlimefunItem tool = SlimefunItem.getByItem(item);
 
         if (tool != null) {
-            if (tool.canUse(e.getPlayer(), true)) {
+            if (tool.canUse(e.getPlayer(), true, false)) {
                 tool.callItemHandler(ToolUseHandler.class, handler -> handler.onToolUse(e, item, fortune, drops));
             } else {
                 e.setCancelled(true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
@@ -73,7 +73,7 @@ public class CoolerListener implements Listener {
 
         for (ItemStack item : p.getInventory().getContents()) {
             if (cooler.isItem(item)) {
-                if (cooler.canUse(p, true)) {
+                if (cooler.canUse(p, true, false)) {
                     takeJuiceFromCooler(p, item);
                 } else {
                     return;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ElytraImpactListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ElytraImpactListener.java
@@ -56,7 +56,7 @@ public class ElytraImpactListener implements Listener {
                 if (helmet.isPresent()) {
                     SlimefunItem item = helmet.get();
 
-                    if (item.canUse(p, true) && profile.hasFullProtectionAgainst(ProtectionType.FLYING_INTO_WALL)) {
+                    if (item.canUse(p, true, false) && profile.hasFullProtectionAgainst(ProtectionType.FLYING_INTO_WALL)) {
                         e.setDamage(0);
                         p.playSound(p.getLocation(), Sound.BLOCK_STONE_HIT, 20, 1);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GadgetsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/GadgetsListener.java
@@ -58,7 +58,7 @@ public class GadgetsListener implements Listener {
             if (SlimefunUtils.containsSimilarItem(p.getInventory(), SlimefunItems.INFUSED_MAGNET, true)) {
                 InfusedMagnet magnet = (InfusedMagnet) SlimefunItems.INFUSED_MAGNET.getItem();
 
-                if (magnet.canUse(p, true)) {
+                if (magnet.canUse(p, true, false)) {
                     new InfusedMagnetTask(p, magnet.getRadius()).scheduleRepeating(0, 8);
                 }
             }
@@ -66,7 +66,7 @@ public class GadgetsListener implements Listener {
     }
 
     private void handleChestplate(@Nonnull Player p, @Nullable SlimefunItem chestplate) {
-        if (chestplate == null || !chestplate.canUse(p, true)) {
+        if (chestplate == null || !chestplate.canUse(p, true, false)) {
             return;
         }
 
@@ -82,7 +82,7 @@ public class GadgetsListener implements Listener {
     }
 
     private void handleBoots(@Nonnull Player p, @Nullable SlimefunItem boots) {
-        if (boots instanceof JetBoots && boots.canUse(p, true)) {
+        if (boots instanceof JetBoots && boots.canUse(p, true, false)) {
             double speed = ((JetBoots) boots).getSpeed();
 
             if (speed > 0.2) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunBootsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunBootsListener.java
@@ -52,7 +52,7 @@ public class SlimefunBootsListener implements Listener {
             Player p = (Player) e.getEntity();
             SlimefunItem boots = SlimefunItem.getByItem(p.getInventory().getBoots());
 
-            if (boots instanceof EnderBoots && boots.canUse(p, true)) {
+            if (boots instanceof EnderBoots && boots.canUse(p, true, false)) {
                 e.setCancelled(true);
             }
         }
@@ -64,7 +64,7 @@ public class SlimefunBootsListener implements Listener {
 
         if (boots != null) {
             // Check if the boots were researched
-            if (!boots.canUse(p, true)) {
+            if (!boots.canUse(p, true, false)) {
                 return;
             }
 
@@ -90,7 +90,7 @@ public class SlimefunBootsListener implements Listener {
                 Player p = e.getPlayer();
                 SlimefunItem boots = SlimefunItem.getByItem(p.getInventory().getBoots());
 
-                if (boots instanceof FarmerShoes && boots.canUse(p, true)) {
+                if (boots instanceof FarmerShoes && boots.canUse(p, true, false)) {
                     e.setCancelled(true);
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemConsumeListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemConsumeListener.java
@@ -32,7 +32,7 @@ public class SlimefunItemConsumeListener implements Listener {
         SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
         if (sfItem != null) {
-            if (sfItem.canUse(p, true)) {
+            if (sfItem.canUse(p, true, false)) {
                 sfItem.callItemHandler(ItemConsumptionHandler.class, handler -> handler.onConsume(e, p, item));
             } else {
                 e.setCancelled(true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemHitListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemHitListener.java
@@ -39,7 +39,7 @@ public class SlimefunItemHitListener implements Listener {
         if (!item.getType().isAir()) {
             SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
-            if (sfItem != null && sfItem.canUse(p, true)) {
+            if (sfItem != null && sfItem.canUse(p, true, false)) {
                 sfItem.callItemHandler(WeaponUseHandler.class, handler -> handler.onHit(e, p, item));
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemInteractListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemInteractListener.java
@@ -96,7 +96,7 @@ public class SlimefunItemInteractListener implements Listener {
         if (optional.isPresent()) {
             SlimefunItem sfItem = optional.get();
 
-            if (sfItem.canUse(e.getPlayer(), true)) {
+            if (sfItem.canUse(e.getPlayer(), true, false)) {
                 return sfItem.callItemHandler(ItemUseHandler.class, handler -> handler.onRightClick(event));
             } else {
                 event.setUseItem(Result.DENY);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TeleporterListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TeleporterListener.java
@@ -56,7 +56,7 @@ public class TeleporterListener implements Listener {
         Player p = e.getPlayer();
 
         // Fixes #2966 - Check if Players can use these
-        if (item == null || !item.canUse(p, true)) {
+        if (item == null || !item.canUse(p, true, false)) {
             return;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/EntityInteractionListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/EntityInteractionListener.java
@@ -47,7 +47,7 @@ public class EntityInteractionListener implements Listener {
         SlimefunItem sfItem = SlimefunItem.getByItem(itemStack);
 
         if (sfItem != null) {
-            if (sfItem.canUse(e.getPlayer(), true)) {
+            if (sfItem.canUse(e.getPlayer(), true, false)) {
                 sfItem.callItemHandler(EntityInteractHandler.class, handler -> handler.onInteract(e, itemStack, e.getHand() == EquipmentSlot.OFF_HAND));
             } else if (sfItem.getState() != ItemState.VANILLA_FALLBACK) {
                 /*

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/MobDropListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/MobDropListener.java
@@ -54,7 +54,7 @@ public class MobDropListener implements Listener {
             if (item.getType() != Material.AIR) {
                 SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
-                if (sfItem != null && sfItem.canUse(p, true)) {
+                if (sfItem != null && sfItem.canUse(p, true, false)) {
                     sfItem.callItemHandler(EntityKillHandler.class, handler -> handler.onKill(e, e.getEntity(), p, item));
                 }
             }
@@ -66,7 +66,7 @@ public class MobDropListener implements Listener {
 
         if (sfItem == null) {
             return true;
-        } else if (sfItem.canUse(p, true)) {
+        } else if (sfItem.canUse(p, true, false)) {
             if (sfItem instanceof RandomMobDrop) {
                 int random = ThreadLocalRandom.current().nextInt(100);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/ArmorTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/ArmorTask.java
@@ -116,7 +116,7 @@ public class ArmorTask implements Runnable {
                 Slimefun.runSync(() -> {
                     SlimefunArmorPiece slimefunArmor = armorpiece.getItem().get();
 
-                    if (slimefunArmor.canUse(p, true)) {
+                    if (slimefunArmor.canUse(p, true, false)) {
                         for (PotionEffect effect : slimefunArmor.getPotionEffects()) {
                             p.removePotionEffect(effect.getType());
                             p.addPotionEffect(effect);
@@ -137,7 +137,7 @@ public class ArmorTask implements Runnable {
 
         SlimefunItem item = SlimefunItem.getByItem(helmet);
 
-        if (item instanceof SolarHelmet && item.canUse(p, true)) {
+        if (item instanceof SolarHelmet && item.canUse(p, true, false)) {
             ((SolarHelmet) item).rechargeItems(p);
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -426,7 +426,7 @@ public final class SlimefunUtils {
     /**
      * This checks whether the {@link Player} is able to use the given {@link ItemStack}.
      * It will always return <code>true</code> for non-Slimefun items.
-     * Since this is used to determine if a player can make something it ignores your dont-need-research-to-use setting
+     * Since this is used to determine if a player can make something it ignores your require-research-on-use setting
      * <p>
      * If you already have an instance of {@link SlimefunItem}, please use {@link SlimefunItem#canUse(Player, boolean)}.
      *

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -426,6 +426,7 @@ public final class SlimefunUtils {
     /**
      * This checks whether the {@link Player} is able to use the given {@link ItemStack}.
      * It will always return <code>true</code> for non-Slimefun items.
+     * Since this is used to determine if a player can make something it ignores your dont-need-research-to-use setting
      * <p>
      * If you already have an instance of {@link SlimefunItem}, please use {@link SlimefunItem#canUse(Player, boolean)}.
      *
@@ -444,7 +445,7 @@ public final class SlimefunUtils {
         SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
         if (sfItem != null) {
-            return sfItem.canUse(p, sendMessage);
+            return sfItem.canUse(p, sendMessage, true);
         } else {
             return true;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,7 @@ researches:
   free-in-creative-mode: true
   enable-fireworks: true
   disable-learning-animation: false
+  dont-need-research-to-use: false
 
 URID:
   info-delay: 3000

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,7 +28,7 @@ researches:
   free-in-creative-mode: true
   enable-fireworks: true
   disable-learning-animation: false
-  dont-need-research-to-use: false
+  require-research-on-use: true
 
 URID:
   info-delay: 3000


### PR DESCRIPTION

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Added a new option to the config file called dont-need-research-to-use. If set to true slimefun items (with the exception of multiblock structures) will be usable by players even without reaserching the item first. They will still need the research to use multiblock structures and to make any slimefun items.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Slight change to canUse method in the SlimefunItem to to check the config setting if needed to be researched. 
Also added a parameter to check ignoring the new config setting for multilocks and for crafting.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
