### PR TITLE
Add Hologram Controller

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
@@ -50,6 +50,8 @@ public class CargoNet extends AbstractItemNetwork implements HologramOwner {
     protected final Map<Location, Integer> roundRobin = new HashMap<>();
     private int tickDelayThreshold = 0;
 
+    public boolean showHologram = true;
+
     @Nullable
     public static CargoNet getNetworkFromLocation(@Nonnull Location l) {
         return Slimefun.getNetworkManager().getNetworkFromLocation(l, CargoNet.class).orElse(null);
@@ -161,7 +163,9 @@ public class CargoNet extends AbstractItemNetwork implements HologramOwner {
         if (connectorNodes.isEmpty() && terminusNodes.isEmpty()) {
             updateHologram(b, "&cNo Cargo Nodes found");
         } else {
-            updateHologram(b, "&7Status: &a&lONLINE");
+            if (showHologram) {
+                updateHologram(b, "&7Status: &a&lONLINE");
+            }
 
             // Skip ticking if the threshold is not reached. The delay is not same as minecraft tick,
             // but it's based on 'custom-ticker-delay' config.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -54,6 +54,8 @@ public class EnergyNet extends Network implements HologramOwner {
         super(Slimefun.getNetworkManager(), l);
     }
 
+    public boolean showHologram = true;
+
     @Override
     public int getRange() {
         return RANGE;
@@ -159,7 +161,10 @@ public class EnergyNet extends Network implements HologramOwner {
             }
 
             storeRemainingEnergy(remainingEnergy);
-            updateHologram(b, supply, demand);
+
+            if (showHologram) {
+                updateHologram(b, supply, demand);
+            }
         }
 
         // We have subtracted the timings from Generators, so they do not show up twice.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -63,6 +63,7 @@ public final class SlimefunItems {
     public static final SlimefunItemStack VITAMINS = new SlimefunItemStack("VITAMINS", Material.NETHER_WART, "&cVitamins", "", "&aLevel III - Medical Supply", "", "&fRestores 4 Hearts", "&fExtinguishes Fire", "&fCures Poison/Wither/Radiation", "", LoreBuilder.RIGHT_CLICK_TO_USE);
     public static final SlimefunItemStack MEDICINE = new SlimefunItemStack("MEDICINE", Material.POTION, Color.RED, "&cMedicine", "", "&aLevel III - Medical Supply", "", "&fRestores 4 Hearts", "&fExtinguishes Fire", "&fCures Poison/Wither/Radiation");
     public static final SlimefunItemStack MAGICAL_ZOMBIE_PILLS = new SlimefunItemStack("MAGICAL_ZOMBIE_PILLS", Material.NETHER_WART, "&6Magical Zombie Pills", "", "&eRight Click &7a Zombified Villager", "&eor &7a Zombified Piglin to", "&7instantly cure it from its curse");
+    public static final SlimefunItemStack HOLOGRAM_CONTROLLER = new SlimefunItemStack("HOLOGRAM_CONTROLLER", Material.IRON_SHOVEL, "&bHologram Controller", "", "&eRight Click &7on an", "&7Energy Regulator or Cargo Manager", "&7to toggle its hologram");
 
     public static final SlimefunItemStack FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FLASK_OF_KNOWLEDGE", Material.GLASS_BOTTLE, "&cFlask of Knowledge", "", "&fAllows you to store some of", "&fyour Experience in a Bottle", "&7Cost: &a1 Level");
     public static final SlimefunItemStack FILLED_FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FILLED_FLASK_OF_KNOWLEDGE", Material.EXPERIENCE_BOTTLE, "&aFlask of Knowledge");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -78,6 +78,8 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
     private final Set<Location> explosionsQueue = new HashSet<>();
     private final MachineProcessor<FuelOperation> processor = new MachineProcessor<>(this);
 
+    public boolean showHologram = true;
+
     @ParametersAreNonnullByDefault
     protected Reactor(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
@@ -431,14 +433,18 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
             for (int slot : getCoolantSlots()) {
                 if (SlimefunUtils.isItemSimilar(menu.getItemInSlot(slot), coolant, true, false)) {
                     menu.consumeItem(slot);
-                    updateHologram(reactor.getBlock(), "&b\u2744 &7100%");
+                    if (showHologram) {
+                        updateHologram(reactor.getBlock(), "&b\u2744 &7100%");
+                    }
                     return true;
                 }
             }
 
             return false;
         } else {
-            updateHologram(reactor.getBlock(), "&b\u2744 &7" + getPercentage(operation.getRemainingTicks(), operation.getTotalTicks()) + "%");
+            if (showHologram) {
+                updateHologram(reactor.getBlock(), "&b\u2744 &7" + getPercentage(operation.getRemainingTicks(), operation.getTotalTicks()) + "%");
+            }
         }
 
         return true;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
@@ -67,6 +67,8 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
     private int energyCapacity = -1;
     private int processingSpeed = -1;
 
+    public boolean showHologram = true;
+
     @ParametersAreNonnullByDefault
     public GEOMiner(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
@@ -194,7 +196,9 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
             @Override
             public void onPlayerPlace(BlockPlaceEvent e) {
-                updateHologram(e.getBlock(), "&7Idling...");
+                if (showHologram) {
+                    updateHologram(e.getBlock(), "&7Idling...");
+                }
             }
         };
     }
@@ -317,7 +321,9 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
                 processor.endOperation(b);
             }
         } else if (!BlockStorage.hasChunkInfo(b.getWorld(), b.getX() >> 4, b.getZ() >> 4)) {
-            updateHologram(b, "&4GEO-Scan required!");
+            if (showHologram) {
+                updateHologram(b, "&4GEO-Scan required!");
+            }
         } else {
             start(b, inv);
         }
@@ -329,7 +335,9 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
                 OptionalInt optional = Slimefun.getGPSNetwork().getResourceManager().getSupplies(resource, b.getWorld(), b.getX() >> 4, b.getZ() >> 4);
 
                 if (!optional.isPresent()) {
-                    updateHologram(b, "&4GEO-Scan required!");
+                    if (showHologram) {
+                        updateHologram(b, "&4GEO-Scan required!");
+                    }
                     return;
                 }
 
@@ -341,13 +349,17 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
                     processor.startOperation(b, new MiningOperation(resource.getItem().clone(), PROCESSING_TIME));
                     Slimefun.getGPSNetwork().getResourceManager().setSupplies(resource, b.getWorld(), b.getX() >> 4, b.getZ() >> 4, supplies - 1);
-                    updateHologram(b, "&7Mining: &r" + resource.getName());
+                    if (showHologram) {
+                        updateHologram(b, "&7Mining: &r" + resource.getName());
+                    }
                     return;
                 }
             }
         }
 
-        updateHologram(b, "&7Finished");
+        if (showHologram) {
+            updateHologram(b, "&7Finished");
+        }
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
@@ -1,0 +1,80 @@
+package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
+import io.github.thebusybiscuit.slimefun4.core.networks.cargo.CargoNet;
+import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNet;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.items.cargo.CargoManager;
+import io.github.thebusybiscuit.slimefun4.implementation.items.electric.EnergyRegulator;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Optional;
+
+public class HologramController extends SlimefunItem {
+
+    @ParametersAreNonnullByDefault
+    public HologramController(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+    }
+
+    @Nonnull
+    private ItemUseHandler getItemUseHandler() {
+        return e -> {
+            e.cancel();
+            e.getInteractEvent().setCancelled(true);
+
+            Optional<SlimefunItem> optionalSfBlock = e.getSlimefunBlock();
+
+            if (optionalSfBlock.isPresent() && e.getClickedBlock().isPresent()) {
+                SlimefunItem sfBlock = optionalSfBlock.get();
+                Block b = e.getClickedBlock().get();
+                Location l = b.getLocation();
+
+                if (sfBlock.equals(SlimefunItem.getByItem(SlimefunItems.ENERGY_REGULATOR))) {
+                    EnergyRegulator regulator = (EnergyRegulator) sfBlock;
+
+                    EnergyNet net = EnergyNet.getNetworkFromLocationOrCreate(l);
+                    net.showHologram = !net.showHologram;
+
+                    if (!net.showHologram) {
+                        regulator.removeHologram(b);
+                    }
+                } else if (sfBlock.equals(SlimefunItem.getByItem(SlimefunItems.CARGO_MANAGER))) {
+                    CargoManager manager = (CargoManager) sfBlock;
+
+                    CargoNet net = CargoNet.getNetworkFromLocationOrCreate(l);
+                    net.showHologram = !net.showHologram;
+
+                    if (!net.showHologram) {
+                        manager.removeHologram(b);
+                    }
+                }
+            }
+        };
+    }
+
+    @Nonnull
+    private ToolUseHandler getToolUseHandler() {
+        return (e, tool, fortune, drops) -> {
+            // The Hologram Controller cannot be used as a shovel
+            e.setCancelled(true);
+        };
+    }
+
+    @Override
+    public void preRegister() {
+        super.preRegister();
+
+        addItemHandler(getItemUseHandler());
+        addItemHandler(getToolUseHandler());
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
@@ -20,6 +20,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Optional;
 
+/**
+ * The {@link HologramController} is a utility that can
+ * toggle the hologram above various machines.
+ *
+ * @author Apeiros-46B
+ *
+ */
 public class HologramController extends SlimefunItem {
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
@@ -1,5 +1,8 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -8,9 +11,12 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.core.networks.cargo.CargoNet;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNet;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.HologramProjector;
 import io.github.thebusybiscuit.slimefun4.implementation.items.cargo.CargoManager;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.EnergyRegulator;
+import io.github.thebusybiscuit.slimefun4.implementation.items.electric.reactors.Reactor;
+import io.github.thebusybiscuit.slimefun4.implementation.items.geo.GEOMiner;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
@@ -39,23 +45,35 @@ public class HologramController extends SlimefunItem {
                 Block b = e.getClickedBlock().get();
                 Location l = b.getLocation();
 
-                if (sfBlock.equals(SlimefunItem.getByItem(SlimefunItems.ENERGY_REGULATOR))) {
+                if (sfBlock instanceof EnergyRegulator) {
                     EnergyRegulator regulator = (EnergyRegulator) sfBlock;
-
                     EnergyNet net = EnergyNet.getNetworkFromLocationOrCreate(l);
-                    net.showHologram = !net.showHologram;
 
+                    net.showHologram = !net.showHologram;
                     if (!net.showHologram) {
                         regulator.removeHologram(b);
                     }
-                } else if (sfBlock.equals(SlimefunItem.getByItem(SlimefunItems.CARGO_MANAGER))) {
+                } else if (sfBlock instanceof CargoManager) {
                     CargoManager manager = (CargoManager) sfBlock;
-
                     CargoNet net = CargoNet.getNetworkFromLocationOrCreate(l);
-                    net.showHologram = !net.showHologram;
 
+                    net.showHologram = !net.showHologram;
                     if (!net.showHologram) {
                         manager.removeHologram(b);
+                    }
+                } else if (sfBlock instanceof GEOMiner) {
+                    GEOMiner miner = (GEOMiner) sfBlock;
+
+                    miner.showHologram = !miner.showHologram;
+                    if (!miner.showHologram) {
+                        miner.removeHologram(b);
+                    }
+                } else if (sfBlock instanceof Reactor) {
+                    Reactor reactor = (Reactor) sfBlock;
+
+                    reactor.showHologram = !reactor.showHologram;
+                    if (!reactor.showHologram) {
+                        reactor.removeHologram(b);
                     }
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HologramController.java
@@ -1,8 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParser;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -11,12 +8,10 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.core.networks.cargo.CargoNet;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNet;
-import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.HologramProjector;
 import io.github.thebusybiscuit.slimefun4.implementation.items.cargo.CargoManager;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.EnergyRegulator;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.reactors.Reactor;
 import io.github.thebusybiscuit.slimefun4.implementation.items.geo.GEOMiner;
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/ResearchSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/ResearchSetup.java
@@ -174,7 +174,7 @@ public final class ResearchSetup {
         register("android_memory_core", 163, "Memory Core", 28, SlimefunItems.ANDROID_MEMORY_CORE);
         register("oil", 164, "Oil", 30, SlimefunItems.OIL_BUCKET, SlimefunItems.OIL_PUMP);
         register("fuel", 165, "Fuel", 30, SlimefunItems.FUEL_BUCKET, SlimefunItems.REFINERY);
-        register("hologram_projector", 166, "Holograms", 36, SlimefunItems.HOLOGRAM_PROJECTOR);
+        register("hologram_projector", 166, "Holograms", 36, SlimefunItems.HOLOGRAM_PROJECTOR, SlimefunItems.HOLOGRAM_CONTROLLER);
         register("capacitors", 167, "Tier 1 Capacitors", 25, SlimefunItems.SMALL_CAPACITOR, SlimefunItems.MEDIUM_CAPACITOR, SlimefunItems.BIG_CAPACITOR);
         register("high_tier_capacitors", 168, "Tier 2 Capacitors", 32, SlimefunItems.LARGE_CAPACITOR, SlimefunItems.CARBONADO_EDGED_CAPACITOR);
         register("solar_generators", 169, "Solar Power Plant", 14, SlimefunItems.SOLAR_GENERATOR);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.items.tools.HologramController;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -1812,6 +1813,10 @@ public final class SlimefunItemSetup {
 
         new Multimeter(categories.technicalGadgets, SlimefunItems.MULTIMETER, RecipeType.ENHANCED_CRAFTING_TABLE,
         new ItemStack[] {SlimefunItems.COPPER_INGOT, null, SlimefunItems.COPPER_INGOT, null, SlimefunItems.REDSTONE_ALLOY, null, null, SlimefunItems.GOLD_6K, null})
+        .register(plugin);
+
+        new HologramController(categories.technicalGadgets, SlimefunItems.HOLOGRAM_CONTROLLER, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new ItemStack[] {SlimefunItems.POWER_CRYSTAL, SlimefunItems.HARDENED_GLASS, SlimefunItems.POWER_CRYSTAL, null, SlimefunItems.HOLOGRAM_PROJECTOR, null, null, SlimefunItems.HARDENED_METAL_INGOT, null})
         .register(plugin);
 
         new SlimefunItem(categories.technicalComponents, SlimefunItems.PLASTIC_SHEET, RecipeType.HEATED_PRESSURE_CHAMBER,


### PR DESCRIPTION
## Description
I made this pull request because of a few discord suggestions and because I also want this feature.

## Proposed changes
I have added a new item called the Hologram Controller, which is unlocked together with the Hologram Projector. Right clicking on an Energy Regulator, Cargo Manager, GEO Miner, Nuclear Reactor, or Nether Star Reactor with a Hologram Controller in the hand will toggle the hologram.

## Related Issues (if applicable)
Discord suggestion 899
Discord suggestion 1107
Discord suggestion 1121
Discord suggestion 1175

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
