### PR TITLE
make parachute class respect constructor recipetype parameter

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/Parachute.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/Parachute.java
@@ -28,7 +28,7 @@ public class Parachute extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
     public Parachute(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(itemGroup, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
+        super(itemGroup, item, recipeType, recipe);
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
right now, regardless of what recipetype you construct parachute with, it will always be enhanced crafting table
this fixes that

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
make parachute respect the constructor parameter

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
