### PR TITLE
Allow addons to specify wiki page to items

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunAddon.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunAddon.java
@@ -1,6 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.api;
 
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunAddon.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunAddon.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
@@ -23,6 +24,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
  * an Addon.
  * 
  * @author TheBusyBiscuit
+ * @author ybw0014
  *
  */
 public interface SlimefunAddon {
@@ -96,5 +98,12 @@ public interface SlimefunAddon {
         PluginDescriptionFile description = getJavaPlugin().getDescription();
         return description.getDepend().contains(dependency) || description.getSoftDepend().contains(dependency);
     }
+
+    /**
+     * This method returns the prefix of the wiki link of this addon.
+     *
+     * @return The prefix of wiki link, null if wiki does not exist
+     */
+    default @Nullable String getWikiPrefix() { return null; }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -858,16 +858,19 @@ public class SlimefunItem implements Placeable {
      * @param page
      *            The associated wiki page
      */
-    public final void addOfficialWikipage(@Nonnull String page) {
+    public final void addWikipage(@Nonnull String page) {
         Validate.notNull(page, "Wiki page cannot be null.");
-        wikiURL = Optional.of("https://github.com/Slimefun/Slimefun4/wiki/" + page);
+
+        if (addon.getWikiPrefix() != null) {
+            wikiURL = Optional.of(addon.getWikiPrefix() + page);
+        }
     }
 
     /**
      * This method returns the wiki page that has been assigned to this item.
      * It will return null, if no wiki page was found.
      * 
-     * @see SlimefunItem#addOfficialWikipage(String)
+     * @see SlimefunItem#addWikipage(String)
      * 
      * @return This item's wiki page
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -860,6 +860,7 @@ public class SlimefunItem implements Placeable {
      */
     public final void addWikipage(@Nonnull String page) {
         Validate.notNull(page, "Wiki page cannot be null.");
+        Validate.notNull(addon, "addWikipage() should be called after registering");
 
         if (addon.getWikiPrefix() != null) {
             wikiURL = Optional.of(addon.getWikiPrefix() + page);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
@@ -20,6 +20,9 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 /**
  * This class used to setup the wiki pages.
  *
+ * The methods in this class should call {@link SlimefunItem#addWikipage(String)}
+ * after items are registered.
+ *
  * @author ybw0014
  *
  * @see SlimefunItem

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
@@ -35,7 +35,7 @@ public final class WikiSetup {
      */
     public static void fromJson(JavaPlugin addon) {
         if (!(addon instanceof SlimefunAddon)) {
-            throw new IllegalArgumentException("This is not a valid slimefun addon");
+            throw new IllegalArgumentException("This is not a Slimefun addon");
         }
 
         addon.getLogger().log(Level.INFO, "Loading Wiki pages...");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
@@ -1,0 +1,60 @@
+package io.github.thebusybiscuit.slimefun4.api.setup;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+
+/**
+ * This class used to setup the wiki pages.
+ *
+ * @author ybw0014
+ *
+ * @see SlimefunItem
+ */
+public final class WikiSetup {
+
+    private WikiSetup() {}
+
+    /**
+     * This method will load wiki pages from "/wiki.json" file.
+     *
+     * @param addon The {@link SlimefunAddon} instance that is setting up wiki pages
+     */
+    public static void fromJson(JavaPlugin addon) {
+        if (!(addon instanceof SlimefunAddon)) {
+            throw new IllegalArgumentException("This is not a valid slimefun addon");
+        }
+
+        addon.getLogger().log(Level.INFO, "Loading Wiki pages...");
+        JsonParser parser = new JsonParser();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(addon.getClass().getResourceAsStream("/wiki.json"), StandardCharsets.UTF_8))) {
+            JsonElement element = parser.parse(reader.lines().collect(Collectors.joining("")));
+            JsonObject json = element.getAsJsonObject();
+
+            for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
+                SlimefunItem item = SlimefunItem.getById(entry.getKey());
+
+                if (item != null) {
+                    item.addWikipage(entry.getValue().getAsString());
+                }
+            }
+        } catch (IOException e) {
+            addon.getLogger().log(Level.SEVERE, "Failed to load wiki.json file", e);
+        }
+
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/setup/WikiSetup.java
@@ -42,10 +42,9 @@ public final class WikiSetup {
         }
 
         addon.getLogger().log(Level.INFO, "Loading Wiki pages...");
-        JsonParser parser = new JsonParser();
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(addon.getClass().getResourceAsStream("/wiki.json"), StandardCharsets.UTF_8))) {
-            JsonElement element = parser.parse(reader.lines().collect(Collectors.joining("")));
+            JsonElement element = JsonParser.parseString(reader.lines().collect(Collectors.joining("")));
             JsonObject json = element.getAsJsonObject();
 
             for (Map.Entry<String, JsonElement> entry : json.entrySet()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -377,6 +377,11 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         return "https://github.com/Slimefun/Slimefun4/issues";
     }
 
+    @Override
+    public String getWikiPrefix() {
+        return "https://github.com/Slimefun/Slimefun4/wiki/";
+    }
+
     /**
      * This method gets called when the {@link Plugin} gets disabled.
      * Most often it is called when the {@link Server} is shutting down or reloading.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -73,7 +73,6 @@ public class Talisman extends SlimefunItem {
         this.suffix = messageSuffix;
         this.effects = effects;
         this.chance = chance;
-        addOfficialWikipage(WIKI_PAGE);
 
         if (!(this instanceof EnderTalisman)) {
             String name = "&5Ender " + ChatColor.stripColor(getItem().getItemMeta().getDisplayName());
@@ -128,6 +127,7 @@ public class Talisman extends SlimefunItem {
     public void postRegister() {
         EnderTalisman talisman = new EnderTalisman(this, getEnderVariant());
         talisman.register(getAddon());
+        addWikipage(WIKI_PAGE);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -1,17 +1,11 @@
 package io.github.thebusybiscuit.slimefun4.implementation.setup;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -21,11 +15,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.ItemStack;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.setup.WikiSetup;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks.GrindStone;
@@ -41,23 +32,7 @@ public final class PostSetup {
     private PostSetup() {}
 
     public static void setupWiki() {
-        Slimefun.logger().log(Level.INFO, "Loading Wiki pages...");
-        JsonParser parser = new JsonParser();
-
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(Slimefun.class.getResourceAsStream("/wiki.json"), StandardCharsets.UTF_8))) {
-            JsonElement element = parser.parse(reader.lines().collect(Collectors.joining("")));
-            JsonObject json = element.getAsJsonObject();
-
-            for (Map.Entry<String, JsonElement> entry : json.entrySet()) {
-                SlimefunItem item = SlimefunItem.getById(entry.getKey());
-
-                if (item != null) {
-                    item.addWikipage(entry.getValue().getAsString());
-                }
-            }
-        } catch (IOException e) {
-            Slimefun.logger().log(Level.SEVERE, "Failed to load wiki.json file", e);
-        }
+        WikiSetup.fromJson(Slimefun.instance());
     }
 
     public static void loadItems() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -52,7 +52,7 @@ public final class PostSetup {
                 SlimefunItem item = SlimefunItem.getById(entry.getKey());
 
                 if (item != null) {
-                    item.addOfficialWikipage(entry.getValue().getAsString());
+                    item.addWikipage(entry.getValue().getAsString());
                 }
             }
         } catch (IOException e) {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
@@ -47,9 +47,9 @@ class TestSlimefunItem {
         Assertions.assertFalse(item.getWikipage().isPresent());
 
         // null should not be a valid argument
-        Assertions.assertThrows(IllegalArgumentException.class, () -> item.addOfficialWikipage(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> item.addWikipage(null));
 
-        item.addOfficialWikipage("Test");
+        item.addWikipage("Test");
 
         Optional<String> wiki = item.getWikipage();
         Assertions.assertTrue(wiki.isPresent());


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Some addons have wiki pages too, however current codes only allow core slimefun items to show the wiki item in their recipes.
I add a feature to allow addons to speficy the wiki prefix, and call `SlimefunItem#addWikipage()` to show the wiki icon.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Add `getWikiPrefix()` in `SlimefunAddon` to specify the wiki prefix of addon.
- Rename `addOfficialWikipage()` to `addWikipage()` in `SlimefunItem`, and call `SlimefunAddon#getWikiPrefix()` to get the wiki prefix.
- Add `WikiSetup` class to setup wiki from "wiki.json".
- Change the location of `addWikipage` in `Talisman` because it now needs to be called after registering.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
