### PR TITLE
Storm Staff PVP overhaul to improve accessibility

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.StormStaffLightningListener;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
@@ -623,6 +624,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         new SoulboundListener(this);
         new AutoCrafterListener(this);
         new SlimefunItemHitListener(this);
+        new StormStaffLightningListener(this);
 
         // Bees were added in 1.15
         if (minecraftVersion.isAtLeast(MinecraftVersion.MINECRAFT_1_15)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -15,7 +15,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.StormStaffLightningListener;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
@@ -109,6 +108,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.Firewo
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.IronGolemListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.MobDropListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.PiglinListener;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.StormStaffLightningListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.WitherListener;
 import io.github.thebusybiscuit.slimefun4.implementation.resources.GEOResourcesSetup;
 import io.github.thebusybiscuit.slimefun4.implementation.setup.PostSetup;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -43,7 +43,8 @@ public class StormStaff extends LimitedUseItem {
     private static final NamespacedKey usageKey = new NamespacedKey(Slimefun.instance(), "stormstaff_usage");
     private final ItemSetting<Boolean> allowNonPVPUse = new ItemSetting<>(this, "allow-non-pvp-use", false);
 
-    public static final Map<UUID, UUID> stormStaffLightnings = new HashMap<>();
+    // This is a Map<LightningStrikeUuid, PlayerUuid> to keep track of the caster/lightning strike relationship for listeners
+    private static final Map<UUID, UUID> stormStaffLightnings = new HashMap<>();
 
     @ParametersAreNonnullByDefault
     public StormStaff(ItemGroup group, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -105,6 +106,10 @@ public class StormStaff extends LimitedUseItem {
         }
 
         damageItem(p, item);
+    }
+
+    public static @Nonnull Map<UUID, UUID> getStormStaffLightnings() {
+        return stormStaffLightnings;
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -3,7 +3,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -17,6 +16,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -70,7 +70,7 @@ public class StormStaff extends LimitedUseItem {
                 Location loc = p.getTargetBlock(null, 30).getLocation();
 
                 if (loc.getWorld() != null && loc.getChunk().isLoaded()) {
-                    if ((loc.getWorld().getPVP() || allowNonPVPUse.getValue()) && Slimefun.getProtectionManager().hasPermission(p, loc, Interaction.ATTACK_PLAYER)) {
+                    if ((loc.getWorld().getPVP() && Slimefun.getProtectionManager().hasPermission(p, loc, Interaction.ATTACK_PLAYER)) || allowNonPVPUse.getValue()) {
                         e.cancel();
                         useItem(p, item, loc);
                     } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -36,12 +37,14 @@ public class StormStaff extends LimitedUseItem {
     public static final int MAX_USES = 8;
 
     private static final NamespacedKey usageKey = new NamespacedKey(Slimefun.instance(), "stormstaff_usage");
+    private final ItemSetting<Boolean> allowNonPVPUse = new ItemSetting<>(this, "allow-non-pvp-use", false);
 
     @ParametersAreNonnullByDefault
     public StormStaff(ItemGroup group, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(group, item, recipeType, recipe);
 
         setMaxUseCount(MAX_USES);
+        addItemSetting(allowNonPVPUse);
     }
 
     @Override
@@ -60,7 +63,7 @@ public class StormStaff extends LimitedUseItem {
                 Location loc = p.getTargetBlock(null, 30).getLocation();
 
                 if (loc.getWorld() != null && loc.getChunk().isLoaded()) {
-                    if (loc.getWorld().getPVP() && Slimefun.getProtectionManager().hasPermission(p, loc, Interaction.ATTACK_PLAYER)) {
+                    if ((loc.getWorld().getPVP() || allowNonPVPUse.getValue()) && Slimefun.getProtectionManager().hasPermission(p, loc, Interaction.ATTACK_PLAYER)) {
                         e.cancel();
                         useItem(p, item, loc);
                     } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -24,6 +24,10 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.LimitedUseItem;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 /**
  * This {@link SlimefunItem} casts a {@link LightningStrike} where you are pointing.
  * Unlike the other Staves, it has a limited amount of uses.
@@ -38,6 +42,8 @@ public class StormStaff extends LimitedUseItem {
 
     private static final NamespacedKey usageKey = new NamespacedKey(Slimefun.instance(), "stormstaff_usage");
     private final ItemSetting<Boolean> allowNonPVPUse = new ItemSetting<>(this, "allow-non-pvp-use", false);
+
+    public static final Map<UUID, UUID> stormStaffLightnings = new HashMap<>();
 
     @ParametersAreNonnullByDefault
     public StormStaff(ItemGroup group, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -80,7 +86,8 @@ public class StormStaff extends LimitedUseItem {
     private void useItem(Player p, ItemStack item, Location loc) {
         World world = loc.getWorld();
         if (world != null) {
-            world.strikeLightning(loc);
+            LightningStrike lightningStrike = world.strikeLightning(loc);
+            stormStaffLightnings.put(lightningStrike.getUniqueId(), p.getUniqueId());
         }
 
         if (item.getType() == Material.SHEARS) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/staves/StormStaff.java
@@ -86,6 +86,7 @@ public class StormStaff extends LimitedUseItem {
     private void useItem(Player p, ItemStack item, Location loc) {
         World world = loc.getWorld();
         if (world != null) {
+            // Store the strike and caster so StormStaffLightningListener can take care of possible damage events
             LightningStrike lightningStrike = world.strikeLightning(loc);
             stormStaffLightnings.put(lightningStrike.getUniqueId(), p.getUniqueId());
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
@@ -1,0 +1,58 @@
+package io.github.thebusybiscuit.slimefun4.implementation.listeners.entity;
+
+import javax.annotation.Nonnull;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.LightningStrike;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.weather.LightningStrikeEvent;
+import org.bukkit.inventory.meta.FireworkMeta;
+
+import io.github.thebusybiscuit.slimefun4.api.researches.Research;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+import java.util.UUID;
+
+/**
+ * This {@link Listener} makes sure that if a {@link org.bukkit.entity.LightningStrike} spawned by a {@link io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff}
+ * causes damage {@link Player}, the event is transformed into a {@link}
+ * unlocking a {@link Research} does not cause damage to be dealt.
+ *
+ * @author TheBusyBiscuit
+ *
+ */
+public class StormStaffLightningListener implements Listener {
+
+    public StormStaffLightningListener(@Nonnull Slimefun plugin) {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onLightningDamage(EntityDamageByEntityEvent e) {
+        if (e.getDamager() instanceof LightningStrike) {
+            LightningStrike lightningStrike = (LightningStrike) e.getDamager();
+            UUID lightningStrikeUuid = lightningStrike.getUniqueId();
+            if (StormStaff.stormStaffLightnings.containsKey(lightningStrikeUuid)) {
+                e.setCancelled(true);
+                Player caster = Bukkit.getPlayer(StormStaff.stormStaffLightnings.get(lightningStrikeUuid));
+                EntityDamageByEntityEvent newEvent = new EntityDamageByEntityEvent(caster, e.getEntity(), e.getCause(), e.getDamage());
+                Bukkit.getPluginManager().callEvent(newEvent);
+            }
+        }
+    }
+
+    // To prevent memory leaks, we want the stored lightnings to always be removed whether they dealt damage or not
+    @EventHandler(ignoreCancelled = true)
+    public void onLightningFall(LightningStrikeEvent e) {
+        StormStaff.stormStaffLightnings.remove(e.getLightning().getUniqueId());
+    }
+
+}
+

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
@@ -2,7 +2,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners.entity;
 
 import javax.annotation.Nonnull;
 
-import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Player;
@@ -12,6 +11,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.weather.LightningStrikeEvent;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
 
 import java.util.UUID;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
@@ -21,11 +21,11 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import java.util.UUID;
 
 /**
- * This {@link Listener} makes sure that if a {@link org.bukkit.entity.LightningStrike} spawned by a {@link io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff}
+ * This {@link Listener} makes sure that if a {@link LightningStrike} spawned by a {@link StormStaff}
  * causes damage {@link Player}, the event is transformed into a {@link}
  * unlocking a {@link Research} does not cause damage to be dealt.
  *
- * @author TheBusyBiscuit
+ * @author Sfiguz7
  *
  */
 public class StormStaffLightningListener implements Listener {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
@@ -4,26 +4,21 @@ import javax.annotation.Nonnull;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.StormStaff;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Firework;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.weather.LightningStrikeEvent;
-import org.bukkit.inventory.meta.FireworkMeta;
 
-import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 import java.util.UUID;
 
 /**
  * This {@link Listener} makes sure that if a {@link LightningStrike} spawned by a {@link StormStaff}
- * causes damage {@link Player}, the event is transformed into a {@link}
- * unlocking a {@link Research} does not cause damage to be dealt.
+ * causes damage to an {@link org.bukkit.entity.Entity}, the event is transformed so the damage is
+ * attributed to the StormStaff caster.
  *
  * @author Sfiguz7
  *

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/StormStaffLightningListener.java
@@ -34,9 +34,10 @@ public class StormStaffLightningListener implements Listener {
         if (e.getDamager() instanceof LightningStrike) {
             LightningStrike lightningStrike = (LightningStrike) e.getDamager();
             UUID lightningStrikeUuid = lightningStrike.getUniqueId();
-            if (StormStaff.stormStaffLightnings.containsKey(lightningStrikeUuid)) {
+            UUID casterUuid = StormStaff.getStormStaffLightnings().get(lightningStrikeUuid);
+            if (casterUuid != null) {
                 e.setCancelled(true);
-                Player caster = Bukkit.getPlayer(StormStaff.stormStaffLightnings.get(lightningStrikeUuid));
+                Player caster = Bukkit.getPlayer(casterUuid);
                 EntityDamageByEntityEvent newEvent = new EntityDamageByEntityEvent(caster, e.getEntity(), e.getCause(), e.getDamage());
                 Bukkit.getPluginManager().callEvent(newEvent);
             }
@@ -46,7 +47,7 @@ public class StormStaffLightningListener implements Listener {
     // To prevent memory leaks, we want the stored lightnings to always be removed whether they dealt damage or not
     @EventHandler(ignoreCancelled = true)
     public void onLightningFall(LightningStrikeEvent e) {
-        StormStaff.stormStaffLightnings.remove(e.getLightning().getUniqueId());
+        StormStaff.getStormStaffLightnings().remove(e.getLightning().getUniqueId());
     }
 
 }


### PR DESCRIPTION
## Description
This PR is twofold: on one hand, it transforms all the damage dealt by lightnings to damage dealt by the caster; on the other, it adds the ability to enable StormStaff usage in non PVP areas (as any damage is now automatically nullified, having the EntityDamageByEntityEvent been "transformed" to attribute the damage to the caster).

## Proposed changes
- Substituted any EntityDamageByEntityEvent caused by StormStaff lightnings with ones with the caster as damager
- Added an ItemSetting to allow enabling usage of Storm Staves in non PVP area (damage to players is prevented)

## Related Issues (if applicable)
#3396
#3408 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
