### PR TITLE
Ability to use isLenient flag of BiomeMapParser

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
@@ -149,6 +149,15 @@ public class BiomeMap<T> implements Keyed {
     }
 
     @ParametersAreNonnullByDefault
+    public static <T> @Nonnull BiomeMap<T> fromJson(NamespacedKey key, String json, BiomeDataConverter<T> valueConverter, boolean isLenient) throws BiomeMapException {
+        // All parameters are validated by the Parser.
+        BiomeMapParser<T> parser = new BiomeMapParser<>(key, valueConverter);
+        parser.setLenient(isLenient);
+        parser.read(json);
+        return parser.buildBiomeMap();
+    }
+
+    @ParametersAreNonnullByDefault
     public static <T> @Nonnull BiomeMap<T> fromResource(NamespacedKey key, JavaPlugin plugin, String path, BiomeDataConverter<T> valueConverter) throws BiomeMapException {
         Validate.notNull(key, "The key shall not be null.");
         Validate.notNull(plugin, "The plugin shall not be null.");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMapParser.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMapParser.java
@@ -33,7 +33,7 @@ import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
  * 
  * @see BiomeMap
  */
-class BiomeMapParser<T> {
+public class BiomeMapParser<T> {
 
     private static final String VALUE_KEY = "value";
     private static final String BIOMES_KEY = "biomes";
@@ -61,7 +61,7 @@ class BiomeMapParser<T> {
      *            A function to convert {@link JsonElement}s into your desired data type
      */
     @ParametersAreNonnullByDefault
-    BiomeMapParser(NamespacedKey key, BiomeDataConverter<T> valueConverter) {
+    public BiomeMapParser(NamespacedKey key, BiomeDataConverter<T> valueConverter) {
         Validate.notNull(key, "The key shall not be null.");
         Validate.notNull(valueConverter, "You must provide a Function to convert raw json values to your desired data type.");
 
@@ -79,7 +79,7 @@ class BiomeMapParser<T> {
      * @param isLenient
      *            Whether this parser should be lenient or not.
      */
-    void setLenient(boolean isLenient) {
+    public void setLenient(boolean isLenient) {
         this.isLenient = isLenient;
     }
 
@@ -92,11 +92,11 @@ class BiomeMapParser<T> {
      * 
      * @return Whether this parser is lenient or not.
      */
-    boolean isLenient() {
+    public boolean isLenient() {
         return isLenient;
     }
 
-    void read(@Nonnull String json) throws BiomeMapException {
+    public void read(@Nonnull String json) throws BiomeMapException {
         Validate.notNull(json, "The JSON string should not be null!");
         JsonArray root = null;
 
@@ -113,7 +113,7 @@ class BiomeMapParser<T> {
         read(root);
     }
 
-    void read(@Nonnull JsonArray json) throws BiomeMapException {
+    public void read(@Nonnull JsonArray json) throws BiomeMapException {
         Validate.notNull(json, "The JSON Array should not be null!");
 
         for (JsonElement element : json) {
@@ -200,7 +200,7 @@ class BiomeMapParser<T> {
      * @return The resulting {@link BiomeMap}
      */
     @Nonnull
-    BiomeMap<T> buildBiomeMap() {
+    public BiomeMap<T> buildBiomeMap() {
         BiomeMap<T> biomeMap = new BiomeMap<>(key);
         biomeMap.putAll(map);
         return biomeMap;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The reason behind my changes is that I need to use the isLenient flag in order to load all valid biomes from my _editable_ biomemap file without the process being stopped by an exception. After that, missing (unconfigured) biomes would be used with a default value.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Made BiomeMapParser class public
- Added a new fromJson method to BiomeMap class with the isLenient parameter

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
