### PR TITLE
Talisman of the Hunter saddle dupe fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Trident;
+import org.bukkit.entity.Ravager;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -199,6 +200,15 @@ public class TalismanListener implements Listener {
                     items.remove(item);
                 }
             }
+        }
+
+        /*
+         * Fixes #3254
+         * Prevents saddle duplication from entities that don't drop
+         * saddle from their loot table
+         */
+        if (!(entity instanceof Ravager)) {
+            items.removeIf(item -> item.getType() == Material.SADDLE);
         }
 
         /*


### PR DESCRIPTION
## Description
Fixes the saddle dupe for talisman of the hunter, removes the duplicated saddle from the ```#getExtraDrops``` if the entity is given a saddle and killed by a player while the talisman procs. Ravagers drop saddle from their default loot table unlike pigs, strider, horses, etc. Tested the changes many times but will like to hear from you guys if there are other cases.

## Proposed changes
 - Fix the saddle duplication associated with Talisman of the hunter.

## Related Issues (if applicable)
- Resolves #3254

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
