### PR TITLE
Hercules Pickaxe drops fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -27,38 +27,49 @@ public class HerculesPickaxe extends SimpleSlimefunItem<ToolUseHandler> {
     @Override
     public @Nonnull ToolUseHandler getItemHandler() {
         return (e, tool, fortune, drops) -> {
+            boolean hadDoubledDrops = false;
             Material mat = e.getBlock().getType();
 
             if (SlimefunTag.ORES.isTagged(mat)) {
                 if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
-                    switch (mat) {
+                    switch(mat) {
                         case DEEPSLATE_IRON_ORE:
                             drops.add(new CustomItemStack(SlimefunItems.IRON_DUST, 2));
+                            hadDoubledDrops = true;
                             break;
                         case DEEPSLATE_GOLD_ORE:
                             drops.add(new CustomItemStack(SlimefunItems.GOLD_DUST, 2));
+                            hadDoubledDrops = true;
                             break;
                         case COPPER_ORE:
                         case DEEPSLATE_COPPER_ORE:
                             drops.add(new CustomItemStack(SlimefunItems.COPPER_DUST, 2));
+                            hadDoubledDrops = true;
                             break;
                         default:
                             break;
                     }
                 }
 
-                switch (mat) {
-                    case IRON_ORE:
-                        drops.add(new CustomItemStack(SlimefunItems.IRON_DUST, 2));
-                        break;
-                    case GOLD_ORE:
-                        drops.add(new CustomItemStack(SlimefunItems.GOLD_DUST, 2));
-                        break;
-                    default:
-                        for (ItemStack drop : e.getBlock().getDrops(tool)) {
-                            drops.add(new CustomItemStack(drop, drop.getAmount() * 2));
-                        }
-                        break;
+                /*
+                 * Fixes #3455
+                 * Prevents the switch case below that can do natural drops
+                 * if the switch/case above gets fired
+                 */
+                if (!hadDoubledDrops) {
+                    switch (mat) {
+                        case IRON_ORE:
+                            drops.add(new CustomItemStack(SlimefunItems.IRON_DUST, 2));
+                            break;
+                        case GOLD_ORE:
+                            drops.add(new CustomItemStack(SlimefunItems.GOLD_DUST, 2));
+                            break;
+                        default:
+                            for (ItemStack drop : e.getBlock().getDrops(tool)) {
+                                drops.add(new CustomItemStack(drop, drop.getAmount() * 2));
+                            }
+                            break;
+                    }
                 }
             }
         };

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -32,7 +32,7 @@ public class HerculesPickaxe extends SimpleSlimefunItem<ToolUseHandler> {
 
             if (SlimefunTag.ORES.isTagged(mat)) {
                 if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
-                    switch(mat) {
+                    switch (mat) {
                         case DEEPSLATE_IRON_ORE:
                             drops.add(new CustomItemStack(SlimefunItems.IRON_DUST, 2));
                             hadDoubledDrops = true;


### PR DESCRIPTION
## Description
Fixes the drops for the hercules pickaxe, a simple boolean that prevents it from doing the default case for the second switch/case. 

## Proposed changes
- Prevents the switch/case from doing the default fallback during block mining which can do natural drops

## Related Issues (if applicable)
- Resolves #3455 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
