### PR TITLE
Add SlimefunBlockDropEvent 

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimeBlockDropEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimeBlockDropEvent.java
@@ -19,53 +19,53 @@ import java.util.List;
  */
 public class SlimeBlockDropEvent extends BlockEvent {
 
-	private static final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
 
-	private final Player player;
-	private List<ItemStack> drops;
+    private final Player player;
+    private List<ItemStack> drops;
 
-	public SlimeBlockDropEvent(Player player, Block theBlock, List<ItemStack> drops) {
-		super(theBlock);
-		this.player = player;
-		this.drops = drops;
-	}
+    public SlimeBlockDropEvent(Player player, Block theBlock, List<ItemStack> drops) {
+        super(theBlock);
+        this.player = player;
+        this.drops = drops;
+    }
 
 
-	/**
-	 * This returns the {@link Player} that broke the block.
-	 *
-	 * @return The {@link Player}
-	 */
-	@Nonnull
-	public Player getPlayer() {
-		return player;
-	}
+    /**
+     * This returns the {@link Player} that broke the block.
+     *
+     * @return The {@link Player}
+     */
+    @Nonnull
+    public Player getPlayer() {
+        return player;
+    }
 
-	/**
-	 * Gets the {@link List} of {@link ItemStack}s that should be dropped.
-	 *
-	 * @return The {@link List} of {@link ItemStack}s
-	 */
-	@Nonnull
-	public List<ItemStack> getDrops() {
-		return drops;
-	}
+    /**
+     * Gets the {@link List} of {@link ItemStack}s that should be dropped.
+     *
+     * @return The {@link List} of {@link ItemStack}s
+     */
+    @Nonnull
+    public List<ItemStack> getDrops() {
+        return drops;
+    }
 
-	/**
-	 * Sets the {@link List} of {@link ItemStack}s that should be dropped.
-	 *
-	 * @param drops The {@link List} of {@link ItemStack}s
-	 */
-	public void setDrops(@Nonnull List<ItemStack> drops) {
-		Validate.notNull(drops, "The drops list should not be null!");
-		this.drops = drops;
-	}
+    /**
+     * Sets the {@link List} of {@link ItemStack}s that should be dropped.
+     *
+     * @param drops The {@link List} of {@link ItemStack}s
+     */
+    public void setDrops(@Nonnull List<ItemStack> drops) {
+        Validate.notNull(drops, "The drops list should not be null!");
+        this.drops = drops;
+    }
 
-	@Nonnull
-	@Override
-	public HandlerList getHandlers() {
-		return handlers;
-	}
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
 
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimeBlockDropEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimeBlockDropEvent.java
@@ -1,0 +1,71 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.BlockEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * This {@link Event} is called whenever a {@link Player} break a Slimefun block which should drop some {@link ItemStack}.
+ *
+ * @author CarmJos
+ * @see io.github.thebusybiscuit.slimefun4.implementation.listeners.BlockListener
+ */
+public class SlimeBlockDropEvent extends BlockEvent {
+
+	private static final HandlerList handlers = new HandlerList();
+
+	private final Player player;
+	private List<ItemStack> drops;
+
+	public SlimeBlockDropEvent(Player player, Block theBlock, List<ItemStack> drops) {
+		super(theBlock);
+		this.player = player;
+		this.drops = drops;
+	}
+
+
+	/**
+	 * This returns the {@link Player} that broke the block.
+	 *
+	 * @return The {@link Player}
+	 */
+	@Nonnull
+	public Player getPlayer() {
+		return player;
+	}
+
+	/**
+	 * Gets the {@link List} of {@link ItemStack}s that should be dropped.
+	 *
+	 * @return The {@link List} of {@link ItemStack}s
+	 */
+	@Nonnull
+	public List<ItemStack> getDrops() {
+		return drops;
+	}
+
+	/**
+	 * Sets the {@link List} of {@link ItemStack}s that should be dropped.
+	 *
+	 * @param drops The {@link List} of {@link ItemStack}s
+	 */
+	public void setDrops(@Nonnull List<ItemStack> drops) {
+		Validate.notNull(drops, "The drops list should not be null!");
+		this.drops = drops;
+	}
+
+	@Nonnull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunBlockDropEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunBlockDropEvent.java
@@ -17,14 +17,14 @@ import java.util.List;
  * @author CarmJos
  * @see io.github.thebusybiscuit.slimefun4.implementation.listeners.BlockListener
  */
-public class SlimeBlockDropEvent extends BlockEvent {
+public class SlimefunBlockDropEvent extends BlockEvent {
 
     private static final HandlerList handlers = new HandlerList();
 
     private final Player player;
     private List<ItemStack> drops;
 
-    public SlimeBlockDropEvent(Player player, Block theBlock, List<ItemStack> drops) {
+    public SlimefunBlockDropEvent(Player player, Block theBlock, List<ItemStack> drops) {
         super(theBlock);
         this.player = player;
         this.drops = drops;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -46,211 +46,211 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class BlockListener implements Listener {
 
-	public BlockListener(@Nonnull Slimefun plugin) {
-		plugin.getServer().getPluginManager().registerEvents(this, plugin);
-	}
+    public BlockListener(@Nonnull Slimefun plugin) {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-	public void onBlockPlaceExisting(BlockPlaceEvent e) {
-		Block block = e.getBlock();
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onBlockPlaceExisting(BlockPlaceEvent e) {
+        Block block = e.getBlock();
 
-		// Fixes #2636 - This will solve the "ghost blocks" issue
-		if (e.getBlockReplacedState().getType().isAir()) {
-			SlimefunItem sfItem = BlockStorage.check(block);
+        // Fixes #2636 - This will solve the "ghost blocks" issue
+        if (e.getBlockReplacedState().getType().isAir()) {
+            SlimefunItem sfItem = BlockStorage.check(block);
 
-			if (sfItem != null && !Slimefun.getTickerTask().isDeletedSoon(block.getLocation())) {
-				for (ItemStack item : sfItem.getDrops()) {
-					if (item != null && !item.getType().isAir()) {
-						block.getWorld().dropItemNaturally(block.getLocation(), item);
-					}
-				}
+            if (sfItem != null && !Slimefun.getTickerTask().isDeletedSoon(block.getLocation())) {
+                for (ItemStack item : sfItem.getDrops()) {
+                    if (item != null && !item.getType().isAir()) {
+                        block.getWorld().dropItemNaturally(block.getLocation(), item);
+                    }
+                }
 
-				BlockStorage.clearBlockInfo(block);
-			}
-		} else if (BlockStorage.hasBlockInfo(e.getBlock())) {
-			// If there is no air (e.g. grass) then don't let the block be placed
-			e.setCancelled(true);
-		}
-	}
+                BlockStorage.clearBlockInfo(block);
+            }
+        } else if (BlockStorage.hasBlockInfo(e.getBlock())) {
+            // If there is no air (e.g. grass) then don't let the block be placed
+            e.setCancelled(true);
+        }
+    }
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void onBlockPlace(BlockPlaceEvent e) {
-		ItemStack item = e.getItemInHand();
-		SlimefunItem sfItem = SlimefunItem.getByItem(item);
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent e) {
+        ItemStack item = e.getItemInHand();
+        SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
-		if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
-			if (!sfItem.canUse(e.getPlayer(), true)) {
-				e.setCancelled(true);
-			} else {
-				if (Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
-					Slimefun.getBlockDataService().setBlockData(e.getBlock(), sfItem.getId());
-				}
+        if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
+            if (!sfItem.canUse(e.getPlayer(), true)) {
+                e.setCancelled(true);
+            } else {
+                if (Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
+                    Slimefun.getBlockDataService().setBlockData(e.getBlock(), sfItem.getId());
+                }
 
-				BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getId(), true);
-				sfItem.callItemHandler(BlockPlaceHandler.class, handler -> handler.onPlayerPlace(e));
-			}
-		}
-	}
+                BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getId(), true);
+                sfItem.callItemHandler(BlockPlaceHandler.class, handler -> handler.onPlayerPlace(e));
+            }
+        }
+    }
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void onBlockBreak(BlockBreakEvent e) {
-		// Simply ignore any events that were faked by other plugins
-		if (Slimefun.getIntegrations().isEventFaked(e)) {
-			return;
-		}
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent e) {
+        // Simply ignore any events that were faked by other plugins
+        if (Slimefun.getIntegrations().isEventFaked(e)) {
+            return;
+        }
 
-		// Also ignore custom blocks which were placed by other plugins
-		if (Slimefun.getIntegrations().isCustomBlock(e.getBlock())) {
-			return;
-		}
+        // Also ignore custom blocks which were placed by other plugins
+        if (Slimefun.getIntegrations().isCustomBlock(e.getBlock())) {
+            return;
+        }
 
-		// Ignore blocks which we have marked as deleted (Fixes #2771)
-		if (Slimefun.getTickerTask().isDeletedSoon(e.getBlock().getLocation())) {
-			return;
-		}
+        // Ignore blocks which we have marked as deleted (Fixes #2771)
+        if (Slimefun.getTickerTask().isDeletedSoon(e.getBlock().getLocation())) {
+            return;
+        }
 
-		ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
-		checkForSensitiveBlockAbove(e, item);
+        ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+        checkForSensitiveBlockAbove(e, item);
 
-		int fortune = getBonusDropsWithFortune(item, e.getBlock());
-		List<ItemStack> drops = new ArrayList<>();
+        int fortune = getBonusDropsWithFortune(item, e.getBlock());
+        List<ItemStack> drops = new ArrayList<>();
 
-		if (!e.isCancelled() && !item.getType().isAir()) {
-			callToolHandler(e, item, fortune, drops);
-		}
+        if (!e.isCancelled() && !item.getType().isAir()) {
+            callToolHandler(e, item, fortune, drops);
+        }
 
-		if (!e.isCancelled()) {
-			callBlockHandler(e, item, drops);
-		}
+        if (!e.isCancelled()) {
+            callBlockHandler(e, item, drops);
+        }
 
-		dropItems(e, drops);
-	}
+        dropItems(e, drops);
+    }
 
-	@ParametersAreNonnullByDefault
-	private void callToolHandler(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-		SlimefunItem tool = SlimefunItem.getByItem(item);
+    @ParametersAreNonnullByDefault
+    private void callToolHandler(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
+        SlimefunItem tool = SlimefunItem.getByItem(item);
 
-		if (tool != null) {
-			if (tool.canUse(e.getPlayer(), true)) {
-				tool.callItemHandler(ToolUseHandler.class, handler -> handler.onToolUse(e, item, fortune, drops));
-			} else {
-				e.setCancelled(true);
-			}
-		}
-	}
+        if (tool != null) {
+            if (tool.canUse(e.getPlayer(), true)) {
+                tool.callItemHandler(ToolUseHandler.class, handler -> handler.onToolUse(e, item, fortune, drops));
+            } else {
+                e.setCancelled(true);
+            }
+        }
+    }
 
-	@ParametersAreNonnullByDefault
-	private void callBlockHandler(BlockBreakEvent e, ItemStack item, List<ItemStack> drops) {
-		SlimefunItem sfItem = BlockStorage.check(e.getBlock());
+    @ParametersAreNonnullByDefault
+    private void callBlockHandler(BlockBreakEvent e, ItemStack item, List<ItemStack> drops) {
+        SlimefunItem sfItem = BlockStorage.check(e.getBlock());
 
-		if (sfItem == null && Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
-			Optional<String> blockData = Slimefun.getBlockDataService().getBlockData(e.getBlock());
+        if (sfItem == null && Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
+            Optional<String> blockData = Slimefun.getBlockDataService().getBlockData(e.getBlock());
 
-			if (blockData.isPresent()) {
-				sfItem = SlimefunItem.getById(blockData.get());
-			}
-		}
+            if (blockData.isPresent()) {
+                sfItem = SlimefunItem.getById(blockData.get());
+            }
+        }
 
-		if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
-			sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(e, item, drops));
+        if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
+            sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(e, item, drops));
 
-			if (e.isCancelled()) {
-				return;
-			}
+            if (e.isCancelled()) {
+                return;
+            }
 
-			drops.addAll(sfItem.getDrops());
-			BlockStorage.clearBlockInfo(e.getBlock());
-		}
-	}
+            drops.addAll(sfItem.getDrops());
+            BlockStorage.clearBlockInfo(e.getBlock());
+        }
+    }
 
-	@ParametersAreNonnullByDefault
-	private void dropItems(BlockBreakEvent e, List<ItemStack> drops) {
-		if (!drops.isEmpty() && !e.isCancelled()) {
-			// Notify plugins like CoreProtect
-			Slimefun.getProtectionManager().logAction(e.getPlayer(), e.getBlock(), Interaction.BREAK_BLOCK);
+    @ParametersAreNonnullByDefault
+    private void dropItems(BlockBreakEvent e, List<ItemStack> drops) {
+        if (!drops.isEmpty() && !e.isCancelled()) {
+            // Notify plugins like CoreProtect
+            Slimefun.getProtectionManager().logAction(e.getPlayer(), e.getBlock(), Interaction.BREAK_BLOCK);
 
-			// Fixes #2560
-			if (e.isDropItems()) {
-				// Disable normal block drops
-				e.setDropItems(false);
+            // Fixes #2560
+            if (e.isDropItems()) {
+                // Disable normal block drops
+                e.setDropItems(false);
 
-				// Call event for items dropped by the block
-				SlimeBlockDropEvent dropEvent = new SlimeBlockDropEvent(e.getPlayer(), e.getBlock(), drops);
-				Bukkit.getPluginManager().callEvent(dropEvent);
+                // Call event for items dropped by the block
+                SlimeBlockDropEvent dropEvent = new SlimeBlockDropEvent(e.getPlayer(), e.getBlock(), drops);
+                Bukkit.getPluginManager().callEvent(dropEvent);
 
-				// Only drop event's items.
-				for (ItemStack drop : dropEvent.getDrops()) {
-					// Prevent null or air from being dropped
-					if (drop != null && drop.getType() != Material.AIR) {
-						e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
-					}
-				}
-			}
-		}
-	}
+                // Only drop event's items.
+                for (ItemStack drop : dropEvent.getDrops()) {
+                    // Prevent null or air from being dropped
+                    if (drop != null && drop.getType() != Material.AIR) {
+                        e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
+                    }
+                }
+            }
+        }
+    }
 
-	/**
-	 * This method checks for a sensitive {@link Block}.
-	 * Sensitive {@link Block Blocks} are pressure plates or saplings, which should be broken
-	 * when the block beneath is broken as well.
-	 *
-	 * @param p The {@link Player} who broke this {@link Block}
-	 * @param b The {@link Block} that was broken
-	 */
-	@ParametersAreNonnullByDefault
-	private void checkForSensitiveBlockAbove(BlockBreakEvent e, ItemStack item) {
-		Block blockAbove = e.getBlock().getRelative(BlockFace.UP);
+    /**
+     * This method checks for a sensitive {@link Block}.
+     * Sensitive {@link Block Blocks} are pressure plates or saplings, which should be broken
+     * when the block beneath is broken as well.
+     *
+     * @param p The {@link Player} who broke this {@link Block}
+     * @param b The {@link Block} that was broken
+     */
+    @ParametersAreNonnullByDefault
+    private void checkForSensitiveBlockAbove(BlockBreakEvent e, ItemStack item) {
+        Block blockAbove = e.getBlock().getRelative(BlockFace.UP);
 
-		if (SlimefunTag.SENSITIVE_MATERIALS.isTagged(blockAbove.getType())) {
-			SlimefunItem sfItem = BlockStorage.check(blockAbove);
+        if (SlimefunTag.SENSITIVE_MATERIALS.isTagged(blockAbove.getType())) {
+            SlimefunItem sfItem = BlockStorage.check(blockAbove);
 
-			if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
-				/*
-				 * We create a dummy here to pass onto the BlockBreakHandler.
-				 * This will set the correct block context.
-				 */
-				BlockBreakEvent dummyEvent = new BlockBreakEvent(blockAbove, e.getPlayer());
-				List<ItemStack> drops = new ArrayList<>();
-				drops.addAll(sfItem.getDrops(e.getPlayer()));
+            if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
+                /*
+                 * We create a dummy here to pass onto the BlockBreakHandler.
+                 * This will set the correct block context.
+                 */
+                BlockBreakEvent dummyEvent = new BlockBreakEvent(blockAbove, e.getPlayer());
+                List<ItemStack> drops = new ArrayList<>();
+                drops.addAll(sfItem.getDrops(e.getPlayer()));
 
-				sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
-				blockAbove.setType(Material.AIR);
+                sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
+                blockAbove.setType(Material.AIR);
 
-				if (!dummyEvent.isCancelled() && dummyEvent.isDropItems()) {
-					for (ItemStack drop : drops) {
-						if (drop != null && !drop.getType().isAir()) {
-							blockAbove.getWorld().dropItemNaturally(blockAbove.getLocation(), drop);
-						}
-					}
-				}
+                if (!dummyEvent.isCancelled() && dummyEvent.isDropItems()) {
+                    for (ItemStack drop : drops) {
+                        if (drop != null && !drop.getType().isAir()) {
+                            blockAbove.getWorld().dropItemNaturally(blockAbove.getLocation(), drop);
+                        }
+                    }
+                }
 
-				// Fixes #2944 - Don't forget to clear the Block Data
-				BlockStorage.clearBlockInfo(blockAbove);
-			}
-		}
-	}
+                // Fixes #2944 - Don't forget to clear the Block Data
+                BlockStorage.clearBlockInfo(blockAbove);
+            }
+        }
+    }
 
-	private int getBonusDropsWithFortune(@Nullable ItemStack item, @Nonnull Block b) {
-		int amount = 1;
+    private int getBonusDropsWithFortune(@Nullable ItemStack item, @Nonnull Block b) {
+        int amount = 1;
 
-		if (item != null && !item.getType().isAir() && item.hasItemMeta()) {
-			/*
-			 * Small performance optimization:
-			 * ItemStack#getEnchantmentLevel() calls ItemStack#getItemMeta(), so if
-			 * we are handling more than one Enchantment, we should access the ItemMeta
-			 * directly and re use it.
-			 */
-			ItemMeta meta = item.getItemMeta();
-			int fortuneLevel = meta.getEnchantLevel(Enchantment.LOOT_BONUS_BLOCKS);
+        if (item != null && !item.getType().isAir() && item.hasItemMeta()) {
+            /*
+             * Small performance optimization:
+             * ItemStack#getEnchantmentLevel() calls ItemStack#getItemMeta(), so if
+             * we are handling more than one Enchantment, we should access the ItemMeta
+             * directly and re use it.
+             */
+            ItemMeta meta = item.getItemMeta();
+            int fortuneLevel = meta.getEnchantLevel(Enchantment.LOOT_BONUS_BLOCKS);
 
-			if (fortuneLevel > 0 && !meta.hasEnchant(Enchantment.SILK_TOUCH)) {
-				Random random = ThreadLocalRandom.current();
+            if (fortuneLevel > 0 && !meta.hasEnchant(Enchantment.SILK_TOUCH)) {
+                Random random = ThreadLocalRandom.current();
 
-				amount = Math.max(1, random.nextInt(fortuneLevel + 2) - 1);
-				amount = (b.getType() == Material.LAPIS_ORE ? 4 + random.nextInt(5) : 1) * (amount + 1);
-			}
-		}
+                amount = Math.max(1, random.nextInt(fortuneLevel + 2) - 1);
+                amount = (b.getType() == Material.LAPIS_ORE ? 4 + random.nextInt(5) : 1) * (amount + 1);
+            }
+        }
 
-		return amount;
-	}
+        return amount;
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -1,7 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
 import io.github.bakedlibs.dough.protection.Interaction;
-import io.github.thebusybiscuit.slimefun4.api.events.SlimeBlockDropEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.SlimefunBlockDropEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
@@ -175,7 +175,7 @@ public class BlockListener implements Listener {
                 e.setDropItems(false);
 
                 // Call event for items dropped by the block
-                SlimeBlockDropEvent dropEvent = new SlimeBlockDropEvent(e.getPlayer(), e.getBlock(), drops);
+                SlimefunBlockDropEvent dropEvent = new SlimefunBlockDropEvent(e.getPlayer(), e.getBlock(), drops);
                 Bukkit.getPluginManager().callEvent(dropEvent);
 
                 // Only drop event's items.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -1,15 +1,16 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-
+import io.github.bakedlibs.dough.protection.Interaction;
+import io.github.thebusybiscuit.slimefun4.api.events.SlimeBlockDropEvent;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -23,16 +24,14 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import io.github.bakedlibs.dough.protection.Interaction;
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
-import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
-import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
-
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * The {@link BlockListener} is responsible for listening to the {@link BlockPlaceEvent}
@@ -41,216 +40,217 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
  * @author TheBusyBiscuit
  * @author Linox
  * @author Patbox
- *
  * @see BlockPlaceHandler
  * @see BlockBreakHandler
  * @see ToolUseHandler
- *
  */
 public class BlockListener implements Listener {
 
-    public BlockListener(@Nonnull Slimefun plugin) {
-        plugin.getServer().getPluginManager().registerEvents(this, plugin);
-    }
+	public BlockListener(@Nonnull Slimefun plugin) {
+		plugin.getServer().getPluginManager().registerEvents(this, plugin);
+	}
 
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onBlockPlaceExisting(BlockPlaceEvent e) {
-        Block block = e.getBlock();
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void onBlockPlaceExisting(BlockPlaceEvent e) {
+		Block block = e.getBlock();
 
-        // Fixes #2636 - This will solve the "ghost blocks" issue
-        if (e.getBlockReplacedState().getType().isAir()) {
-            SlimefunItem sfItem = BlockStorage.check(block);
+		// Fixes #2636 - This will solve the "ghost blocks" issue
+		if (e.getBlockReplacedState().getType().isAir()) {
+			SlimefunItem sfItem = BlockStorage.check(block);
 
-            if (sfItem != null && !Slimefun.getTickerTask().isDeletedSoon(block.getLocation())) {
-                for (ItemStack item : sfItem.getDrops()) {
-                    if (item != null && !item.getType().isAir()) {
-                        block.getWorld().dropItemNaturally(block.getLocation(), item);
-                    }
-                }
+			if (sfItem != null && !Slimefun.getTickerTask().isDeletedSoon(block.getLocation())) {
+				for (ItemStack item : sfItem.getDrops()) {
+					if (item != null && !item.getType().isAir()) {
+						block.getWorld().dropItemNaturally(block.getLocation(), item);
+					}
+				}
 
-                BlockStorage.clearBlockInfo(block);
-            }
-        } else if (BlockStorage.hasBlockInfo(e.getBlock())) {
-            // If there is no air (e.g. grass) then don't let the block be placed
-            e.setCancelled(true);
-        }
-    }
+				BlockStorage.clearBlockInfo(block);
+			}
+		} else if (BlockStorage.hasBlockInfo(e.getBlock())) {
+			// If there is no air (e.g. grass) then don't let the block be placed
+			e.setCancelled(true);
+		}
+	}
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onBlockPlace(BlockPlaceEvent e) {
-        ItemStack item = e.getItemInHand();
-        SlimefunItem sfItem = SlimefunItem.getByItem(item);
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onBlockPlace(BlockPlaceEvent e) {
+		ItemStack item = e.getItemInHand();
+		SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
-        if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
-            if (!sfItem.canUse(e.getPlayer(), true)) {
-                e.setCancelled(true);
-            } else {
-                if (Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
-                    Slimefun.getBlockDataService().setBlockData(e.getBlock(), sfItem.getId());
-                }
+		if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
+			if (!sfItem.canUse(e.getPlayer(), true)) {
+				e.setCancelled(true);
+			} else {
+				if (Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
+					Slimefun.getBlockDataService().setBlockData(e.getBlock(), sfItem.getId());
+				}
 
-                BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getId(), true);
-                sfItem.callItemHandler(BlockPlaceHandler.class, handler -> handler.onPlayerPlace(e));
-            }
-        }
-    }
+				BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getId(), true);
+				sfItem.callItemHandler(BlockPlaceHandler.class, handler -> handler.onPlayerPlace(e));
+			}
+		}
+	}
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onBlockBreak(BlockBreakEvent e) {
-        // Simply ignore any events that were faked by other plugins
-        if (Slimefun.getIntegrations().isEventFaked(e)) {
-            return;
-        }
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onBlockBreak(BlockBreakEvent e) {
+		// Simply ignore any events that were faked by other plugins
+		if (Slimefun.getIntegrations().isEventFaked(e)) {
+			return;
+		}
 
-        // Also ignore custom blocks which were placed by other plugins
-        if (Slimefun.getIntegrations().isCustomBlock(e.getBlock())) {
-            return;
-        }
+		// Also ignore custom blocks which were placed by other plugins
+		if (Slimefun.getIntegrations().isCustomBlock(e.getBlock())) {
+			return;
+		}
 
-        // Ignore blocks which we have marked as deleted (Fixes #2771)
-        if (Slimefun.getTickerTask().isDeletedSoon(e.getBlock().getLocation())) {
-            return;
-        }
+		// Ignore blocks which we have marked as deleted (Fixes #2771)
+		if (Slimefun.getTickerTask().isDeletedSoon(e.getBlock().getLocation())) {
+			return;
+		}
 
-        ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
-        checkForSensitiveBlockAbove(e, item);
+		ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+		checkForSensitiveBlockAbove(e, item);
 
-        int fortune = getBonusDropsWithFortune(item, e.getBlock());
-        List<ItemStack> drops = new ArrayList<>();
+		int fortune = getBonusDropsWithFortune(item, e.getBlock());
+		List<ItemStack> drops = new ArrayList<>();
 
-        if (!e.isCancelled() && !item.getType().isAir()) {
-            callToolHandler(e, item, fortune, drops);
-        }
+		if (!e.isCancelled() && !item.getType().isAir()) {
+			callToolHandler(e, item, fortune, drops);
+		}
 
-        if (!e.isCancelled()) {
-            callBlockHandler(e, item, drops);
-        }
+		if (!e.isCancelled()) {
+			callBlockHandler(e, item, drops);
+		}
 
-        dropItems(e, drops);
-    }
+		dropItems(e, drops);
+	}
 
-    @ParametersAreNonnullByDefault
-    private void callToolHandler(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-        SlimefunItem tool = SlimefunItem.getByItem(item);
+	@ParametersAreNonnullByDefault
+	private void callToolHandler(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
+		SlimefunItem tool = SlimefunItem.getByItem(item);
 
-        if (tool != null) {
-            if (tool.canUse(e.getPlayer(), true)) {
-                tool.callItemHandler(ToolUseHandler.class, handler -> handler.onToolUse(e, item, fortune, drops));
-            } else {
-                e.setCancelled(true);
-            }
-        }
-    }
+		if (tool != null) {
+			if (tool.canUse(e.getPlayer(), true)) {
+				tool.callItemHandler(ToolUseHandler.class, handler -> handler.onToolUse(e, item, fortune, drops));
+			} else {
+				e.setCancelled(true);
+			}
+		}
+	}
 
-    @ParametersAreNonnullByDefault
-    private void callBlockHandler(BlockBreakEvent e, ItemStack item, List<ItemStack> drops) {
-        SlimefunItem sfItem = BlockStorage.check(e.getBlock());
+	@ParametersAreNonnullByDefault
+	private void callBlockHandler(BlockBreakEvent e, ItemStack item, List<ItemStack> drops) {
+		SlimefunItem sfItem = BlockStorage.check(e.getBlock());
 
-        if (sfItem == null && Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
-            Optional<String> blockData = Slimefun.getBlockDataService().getBlockData(e.getBlock());
+		if (sfItem == null && Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
+			Optional<String> blockData = Slimefun.getBlockDataService().getBlockData(e.getBlock());
 
-            if (blockData.isPresent()) {
-                sfItem = SlimefunItem.getById(blockData.get());
-            }
-        }
+			if (blockData.isPresent()) {
+				sfItem = SlimefunItem.getById(blockData.get());
+			}
+		}
 
-        if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
-            sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(e, item, drops));
+		if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
+			sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(e, item, drops));
 
-            if (e.isCancelled()) {
-                return;
-            }
+			if (e.isCancelled()) {
+				return;
+			}
 
-            drops.addAll(sfItem.getDrops());
-            BlockStorage.clearBlockInfo(e.getBlock());
-        }
-    }
+			drops.addAll(sfItem.getDrops());
+			BlockStorage.clearBlockInfo(e.getBlock());
+		}
+	}
 
-    @ParametersAreNonnullByDefault
-    private void dropItems(BlockBreakEvent e, List<ItemStack> drops) {
-        if (!drops.isEmpty() && !e.isCancelled()) {
-            // Notify plugins like CoreProtect
-            Slimefun.getProtectionManager().logAction(e.getPlayer(), e.getBlock(), Interaction.BREAK_BLOCK);
+	@ParametersAreNonnullByDefault
+	private void dropItems(BlockBreakEvent e, List<ItemStack> drops) {
+		if (!drops.isEmpty() && !e.isCancelled()) {
+			// Notify plugins like CoreProtect
+			Slimefun.getProtectionManager().logAction(e.getPlayer(), e.getBlock(), Interaction.BREAK_BLOCK);
 
-            // Fixes #2560
-            if (e.isDropItems()) {
-                // Disable normal block drops
-                e.setDropItems(false);
+			// Fixes #2560
+			if (e.isDropItems()) {
+				// Disable normal block drops
+				e.setDropItems(false);
 
-                for (ItemStack drop : drops) {
-                    // Prevent null or air from being dropped
-                    if (drop != null && drop.getType() != Material.AIR) {
-                        e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
-                    }
-                }
-            }
-        }
-    }
+				// Call event for items dropped by the block
+				SlimeBlockDropEvent dropEvent = new SlimeBlockDropEvent(e.getPlayer(), e.getBlock(), drops);
+				Bukkit.getPluginManager().callEvent(dropEvent);
 
-    /**
-     * This method checks for a sensitive {@link Block}.
-     * Sensitive {@link Block Blocks} are pressure plates or saplings, which should be broken
-     * when the block beneath is broken as well.
-     *
-     * @param p
-     *            The {@link Player} who broke this {@link Block}
-     * @param b
-     *            The {@link Block} that was broken
-     */
-    @ParametersAreNonnullByDefault
-    private void checkForSensitiveBlockAbove(BlockBreakEvent e, ItemStack item) {
-        Block blockAbove = e.getBlock().getRelative(BlockFace.UP);
+				// Only drop event's items.
+				for (ItemStack drop : dropEvent.getDrops()) {
+					// Prevent null or air from being dropped
+					if (drop != null && drop.getType() != Material.AIR) {
+						e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
+					}
+				}
+			}
+		}
+	}
 
-        if (SlimefunTag.SENSITIVE_MATERIALS.isTagged(blockAbove.getType())) {
-            SlimefunItem sfItem = BlockStorage.check(blockAbove);
+	/**
+	 * This method checks for a sensitive {@link Block}.
+	 * Sensitive {@link Block Blocks} are pressure plates or saplings, which should be broken
+	 * when the block beneath is broken as well.
+	 *
+	 * @param p The {@link Player} who broke this {@link Block}
+	 * @param b The {@link Block} that was broken
+	 */
+	@ParametersAreNonnullByDefault
+	private void checkForSensitiveBlockAbove(BlockBreakEvent e, ItemStack item) {
+		Block blockAbove = e.getBlock().getRelative(BlockFace.UP);
 
-            if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
-                /*
-                 * We create a dummy here to pass onto the BlockBreakHandler.
-                 * This will set the correct block context.
-                 */
-                BlockBreakEvent dummyEvent = new BlockBreakEvent(blockAbove, e.getPlayer());
-                List<ItemStack> drops = new ArrayList<>();
-                drops.addAll(sfItem.getDrops(e.getPlayer()));
+		if (SlimefunTag.SENSITIVE_MATERIALS.isTagged(blockAbove.getType())) {
+			SlimefunItem sfItem = BlockStorage.check(blockAbove);
 
-                sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
-                blockAbove.setType(Material.AIR);
+			if (sfItem != null && !sfItem.useVanillaBlockBreaking()) {
+				/*
+				 * We create a dummy here to pass onto the BlockBreakHandler.
+				 * This will set the correct block context.
+				 */
+				BlockBreakEvent dummyEvent = new BlockBreakEvent(blockAbove, e.getPlayer());
+				List<ItemStack> drops = new ArrayList<>();
+				drops.addAll(sfItem.getDrops(e.getPlayer()));
 
-                if (!dummyEvent.isCancelled() && dummyEvent.isDropItems()) {
-                    for (ItemStack drop : drops) {
-                        if (drop != null && !drop.getType().isAir()) {
-                            blockAbove.getWorld().dropItemNaturally(blockAbove.getLocation(), drop);
-                        }
-                    }
-                }
+				sfItem.callItemHandler(BlockBreakHandler.class, handler -> handler.onPlayerBreak(dummyEvent, item, drops));
+				blockAbove.setType(Material.AIR);
 
-                // Fixes #2944 - Don't forget to clear the Block Data
-                BlockStorage.clearBlockInfo(blockAbove);
-            }
-        }
-    }
+				if (!dummyEvent.isCancelled() && dummyEvent.isDropItems()) {
+					for (ItemStack drop : drops) {
+						if (drop != null && !drop.getType().isAir()) {
+							blockAbove.getWorld().dropItemNaturally(blockAbove.getLocation(), drop);
+						}
+					}
+				}
 
-    private int getBonusDropsWithFortune(@Nullable ItemStack item, @Nonnull Block b) {
-        int amount = 1;
+				// Fixes #2944 - Don't forget to clear the Block Data
+				BlockStorage.clearBlockInfo(blockAbove);
+			}
+		}
+	}
 
-        if (item != null && !item.getType().isAir() && item.hasItemMeta()) {
-            /*
-             * Small performance optimization:
-             * ItemStack#getEnchantmentLevel() calls ItemStack#getItemMeta(), so if
-             * we are handling more than one Enchantment, we should access the ItemMeta
-             * directly and re use it.
-             */
-            ItemMeta meta = item.getItemMeta();
-            int fortuneLevel = meta.getEnchantLevel(Enchantment.LOOT_BONUS_BLOCKS);
+	private int getBonusDropsWithFortune(@Nullable ItemStack item, @Nonnull Block b) {
+		int amount = 1;
 
-            if (fortuneLevel > 0 && !meta.hasEnchant(Enchantment.SILK_TOUCH)) {
-                Random random = ThreadLocalRandom.current();
+		if (item != null && !item.getType().isAir() && item.hasItemMeta()) {
+			/*
+			 * Small performance optimization:
+			 * ItemStack#getEnchantmentLevel() calls ItemStack#getItemMeta(), so if
+			 * we are handling more than one Enchantment, we should access the ItemMeta
+			 * directly and re use it.
+			 */
+			ItemMeta meta = item.getItemMeta();
+			int fortuneLevel = meta.getEnchantLevel(Enchantment.LOOT_BONUS_BLOCKS);
 
-                amount = Math.max(1, random.nextInt(fortuneLevel + 2) - 1);
-                amount = (b.getType() == Material.LAPIS_ORE ? 4 + random.nextInt(5) : 1) * (amount + 1);
-            }
-        }
+			if (fortuneLevel > 0 && !meta.hasEnchant(Enchantment.SILK_TOUCH)) {
+				Random random = ThreadLocalRandom.current();
 
-        return amount;
-    }
+				amount = Math.max(1, random.nextInt(fortuneLevel + 2) - 1);
+				amount = (b.getType() == Material.LAPIS_ORE ? 4 + random.nextInt(5) : 1) * (amount + 1);
+			}
+		}
+
+		return amount;
+	}
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
In some cases, developers want to prevent slimefun's block drops or make drops directly into some containers.

But in previous codes, this is not possible because it uses the `#dropItemNaturally(...)` method.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

I added a event called `SlimefunBlockDropEvent` to provide a way for developers edit the drops.

I have tested the event by my own plugin.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [X] I followed the existing code standards and didn't mess up the formatting.
- [X] I did my best to add documentation to any public classes or methods I added.
- [X] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
