### PR TITLE
added rooted dirt to dirt variants

### DIFF
--- a/src/main/resources/tags/dirt_variants.json
+++ b/src/main/resources/tags/dirt_variants.json
@@ -11,6 +11,10 @@
 			"id": "minecraft:dirt_path",
 			"required": false
 		},
+		{
+			"id": "minecraft:rooted_dirt",
+			"required": false
+		},
 		"minecraft:farmland",
 		"minecraft:podzol",
 		"minecraft:mycelium"


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
added rooted dirt to fix issue  #3469

might be smart to add #minecraft:shovel to the explosive shovel aswell this tag has been added since 1.17.
Rooted dirt has been added in 1.16 so that still doesnt solve the issue.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
added rooted dirt to fix issue  #3469

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves  #3469

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
