### PR TITLE
Fix pedestal item disappearing

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -156,8 +156,19 @@ public class AncientAltarListener implements Listener {
             Slimefun.runSync(() -> removedItems.remove(uuid), 30L);
 
             entity.remove();
-            p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity));
             p.playSound(pedestal.getLocation(), Sound.ENTITY_ITEM_PICKUP, 1F, 1F);
+
+            /*
+             * Fixes #3476
+             * Drop the item instead if the player's
+             * inventory is full
+             */
+            if (p.getInventory().firstEmpty() != -1) {
+                p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity));
+
+            } else {
+                p.getWorld().dropItem(pedestal.getLocation().add(0, 1, 0), pedestalItem.getOriginalItemStack(entity));
+            }
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -161,12 +161,12 @@ public class AncientAltarListener implements Listener {
             /*
              * Fixes #3476
              * Drop the item instead if the player's inventory is full and
-             * no stack space left else add the item in the inventory
+             * no stack space left else add remaining items from the returned map value
              */
-            for (Map.Entry<Integer, ItemStack> stackEntry : p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity)).entrySet()) {
-                if (stackEntry != null) {
-                    p.getWorld().dropItem(pedestal.getLocation().add(0, 1, 0), stackEntry.getValue().clone());
-                }
+            Map<Integer,ItemStack> remainingItemMap = p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity));
+            
+            for (ItemStack item : remainingItemMap.values()) {
+                p.getWorld().dropItem(pedestal.getLocation().add(0, 1, 0), item.clone());
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -160,13 +160,13 @@ public class AncientAltarListener implements Listener {
 
             /*
              * Fixes #3476
-             * Drop the item instead if the player's
-             * inventory is full
+             * Drop the item instead if the player's inventory is full and
+             * no stack space left else add remaining items from the returned map value
              */
-            if (p.getInventory().firstEmpty() != -1) {
-                p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity));
-            } else {
-                p.getWorld().dropItem(pedestal.getLocation().add(0, 1, 0), pedestalItem.getOriginalItemStack(entity));
+            for (Map.Entry<Integer, ItemStack> stackEntry : p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity)).entrySet()) {
+                if (stackEntry != null) {
+                    p.getWorld().dropItem(pedestal.getLocation().add(0, 1, 0), stackEntry.getValue().clone());
+                }
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -165,7 +165,6 @@ public class AncientAltarListener implements Listener {
              */
             if (p.getInventory().firstEmpty() != -1) {
                 p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity));
-
             } else {
                 p.getWorld().dropItem(pedestal.getLocation().add(0, 1, 0), pedestalItem.getOriginalItemStack(entity));
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -161,7 +161,7 @@ public class AncientAltarListener implements Listener {
             /*
              * Fixes #3476
              * Drop the item instead if the player's inventory is full and
-             * no stack space left else add remaining items from the returned map value
+             * no stack space left else add the item in the inventory
              */
             for (Map.Entry<Integer, ItemStack> stackEntry : p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity)).entrySet()) {
                 if (stackEntry != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -115,7 +115,7 @@ public class AncientAltarListener implements Listener {
                 return;
             }
 
-            // Make altarinuse simply because that was the last block clicked.
+            // Make altar in use simply because that was the last block clicked.
             altarsInUse.add(b.getLocation());
             e.cancel();
 


### PR DESCRIPTION
## Description
A small bug fix for the ancient pedestal when retrieving placed items.

## Proposed changes
- Drop item instead if the player's inventory is full and no remaining stack space when retrieving the item back from the pedestal

## Related Issues (if applicable)
- Resolves #3476 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
