### PR TITLE
Fixed light blocks causing cargo nodes to not be placed.

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CargoNodeListener.java
@@ -2,7 +2,11 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.type.Light;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -15,7 +19,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.cargo.CargoNode;
 /**
  * This {@link Listener} is solely responsible for preventing Cargo Nodes from being placed
  * on the top or bottom of a block.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -30,6 +34,10 @@ public class CargoNodeListener implements Listener {
         Block b = e.getBlock();
 
         if ((b.getY() != e.getBlockAgainst().getY() || !e.getBlockReplacedState().getType().isAir()) && isCargoNode(e.getItemInHand())) {
+            
+            if(Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)){
+                if(e.getBlockReplacedState().getType() == Material.LIGHT) return;
+            }
             Slimefun.getLocalization().sendMessage(e.getPlayer(), "machines.CARGO_NODES.must-be-placed", true);
             e.setCancelled(true);
         }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I noticed that when placing cargo nodes inside light blocks it causes an error. 
## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Allow cargo nodes to be placed inside of light blocks.
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x]  I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
- [ ]  I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
