### PR TITLE
fix #3504

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
                 <!-- Compiler plugin -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.10.1</version>
 
                 <configuration>
                     <excludes>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
@@ -4,8 +4,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -29,6 +33,9 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
+
+import java.util.ArrayList;
+import java.util.Set;
 
 /**
  * This abstract class is the super class of all cargo nodes.
@@ -92,6 +99,8 @@ abstract class AbstractCargoNode extends SimpleSlimefunItem<BlockPlaceHandler> i
         boolean isChestTerminalInstalled = Slimefun.getIntegrations().isChestTerminalInstalled();
         int channel = getSelectedChannel(b);
 
+
+
         menu.replaceExistingItem(slotPrev, new CustomItemStack(HeadTexture.CARGO_ARROW_LEFT.getAsItemStack(), "&bPrevious Channel", "", "&e> Click to decrease the Channel ID by 1"));
         menu.addMenuClickHandler(slotPrev, (p, slot, item, action) -> {
             int newChannel = channel - 1;
@@ -113,7 +122,7 @@ abstract class AbstractCargoNode extends SimpleSlimefunItem<BlockPlaceHandler> i
             menu.replaceExistingItem(slotCurrent, new CustomItemStack(HeadTexture.CHEST_TERMINAL.getAsItemStack(), "&bChannel ID: &3" + (channel + 1)));
             menu.addMenuClickHandler(slotCurrent, ChestMenuUtils.getEmptyClickHandler());
         } else {
-            menu.replaceExistingItem(slotCurrent, new CustomItemStack(ColoredMaterial.WOOL.get(channel), "&bChannel ID: &3" + (channel + 1)));
+            menu.replaceExistingItem(slotCurrent, new CustomItemStack(SlimefunTag.WOOL.get(channel), "&bChannel ID: &3" + (channel + 1)));
             menu.addMenuClickHandler(slotCurrent, ChestMenuUtils.getEmptyClickHandler());
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
@@ -199,29 +199,29 @@ public enum ColoredMaterial {
             Material.GREEN_SHULKER_BOX,
             Material.RED_SHULKER_BOX,
             Material.BLACK_SHULKER_BOX
-    }),
+    });
     
     /**
      * This {@link List} contains all candle colors ordered by their appearance ingame.
      */
-    CANDLE(new Material[] {
-            Material.WHITE_CANDLE,
-            Material.ORANGE_CANDLE,
-            Material.MAGENTA_CANDLE,
-            Material.LIGHT_BLUE_CANDLE,
-            Material.YELLOW_CANDLE,
-            Material.LIME_CANDLE,
-            Material.PINK_CANDLE,
-            Material.GRAY_CANDLE,
-            Material.LIGHT_GRAY_CANDLE,
-            Material.CYAN_CANDLE,
-            Material.PURPLE_CANDLE,
-            Material.BLUE_CANDLE,
-            Material.BROWN_CANDLE,
-            Material.GREEN_CANDLE,
-            Material.RED_CANDLE,
-            Material.BLACK_CANDLE
-    });
+//    CANDLE(new Material[] {
+//            Material.WHITE_CANDLE,
+//            Material.ORANGE_CANDLE,
+//            Material.MAGENTA_CANDLE,
+//            Material.LIGHT_BLUE_CANDLE,
+//            Material.YELLOW_CANDLE,
+//            Material.LIME_CANDLE,
+//            Material.PINK_CANDLE,
+//            Material.GRAY_CANDLE,
+//            Material.LIGHT_GRAY_CANDLE,
+//            Material.CYAN_CANDLE,
+//            Material.PURPLE_CANDLE,
+//            Material.BLUE_CANDLE,
+//            Material.BROWN_CANDLE,
+//            Material.GREEN_CANDLE,
+//            Material.RED_CANDLE,
+//            Material.BLACK_CANDLE
+//    });
     
     // @formatter:on
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
@@ -1,9 +1,11 @@
 package io.github.thebusybiscuit.slimefun4.utils.tags;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -251,7 +253,12 @@ public enum SlimefunTag implements Tag<Material> {
     /**
      * All materials that are affected by gravity.
      */
-    GRAVITY_AFFECTED_BLOCKS;
+    GRAVITY_AFFECTED_BLOCKS,
+
+    /**
+     * All wool blocks.
+     */
+    WOOL;
 
     /**
      * Lookup table for tag names.
@@ -271,7 +278,7 @@ public enum SlimefunTag implements Tag<Material> {
     }
 
     private final NamespacedKey key;
-    private final Set<Material> includedMaterials = EnumSet.noneOf(Material.class);
+    private final List<Material> includedMaterials = new ArrayList<>();
     private final Set<Tag<Material>> additionalTags = new HashSet<>();
 
     /**
@@ -341,7 +348,7 @@ public enum SlimefunTag implements Tag<Material> {
     @Override
     public @Nonnull Set<Material> getValues() {
         if (additionalTags.isEmpty()) {
-            return Collections.unmodifiableSet(includedMaterials);
+            return Collections.unmodifiableSet(new HashSet<>(includedMaterials));
         } else {
             Set<Material> materials = EnumSet.noneOf(Material.class);
             materials.addAll(includedMaterials);
@@ -352,6 +359,25 @@ public enum SlimefunTag implements Tag<Material> {
 
             return materials;
         }
+    }
+
+    public @Nonnull List<Material> getOrderedValues() {
+        if (additionalTags.isEmpty()) {
+            //todo make immutable
+            return Collections.unmodifiableList(includedMaterials);
+        } else {
+            List<Material> materials = new ArrayList<>(includedMaterials);
+
+            for (Tag<Material> tag : additionalTags) {
+                materials.addAll(tag.getValues());
+            }
+
+            return materials;
+        }
+    }
+
+    public @Nonnull Material get(int index) {
+        return getOrderedValues().get(index);
     }
 
     public boolean isEmpty() {

--- a/src/main/resources/tags/wool.json
+++ b/src/main/resources/tags/wool.json
@@ -1,0 +1,20 @@
+{
+  "values" : [
+    "minecraft:white_wool",
+    "minecraft:orange_wool",
+    "minecraft:magenta_wool",
+    "minecraft:light_blue_wool",
+    "minecraft:yellow_wool",
+    "minecraft:lime_wool",
+    "minecraft:pink_wool",
+    "minecraft:gray_wool",
+    "minecraft:light_gray_wool",
+    "minecraft:cyan_wool",
+    "minecraft:purple_wool",
+    "minecraft:blue_wool",
+    "minecraft:brown_wool",
+    "minecraft:green_wool",
+    "minecraft:red_wool",
+    "minecraft:black_wool"
+  ]
+}


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This pr will change the way Slimefun handles colours materials
This will remove the ColoredMaterial class and will change completely in to tags
Right now i just have changed Cargo to support this.
When this proposal actually gets accepted i will change all other classes to also support tags

With the current implementation cargo actually already works this is fully tested


## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Remove ColoredMaterials class
Add different tags for colored materials 
Add a way to get a ordered list instead of a set
Change rainbowblocks, cargo and all others that currently use ColoredMaterial class to tags

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
fix #3504

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
