### PR TITLE
Add event to allow changing outputs of the AutoDisenchanter

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoDisenchanterProcessEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoDisenchanterProcessEvent.java
@@ -13,7 +13,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 
 /**
- * An {@link Event} that is fired just after {@link AutoDisenchantEvent} iff it was not cancelled.
+ * An {@link Event} that is fired just after {@link AutoDisenchantEvent} if and onyl if it was not cancelled.
  * This event will start out as being cancelled unless it contains a bukkit enchantment.
  * The enchantment transfer logic is already performed by slimefun before this event is fired, though this
  * logic does not affect input items.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoDisenchanterProcessEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoDisenchanterProcessEvent.java
@@ -21,7 +21,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
  *
  * @author Geolykt
  */
-public class AutoDisenchanterComputeOutputEvent extends Event {
+public class AsyncAutoDisenchanterProcessEvent extends Event {
 
     private static final HandlerList handlers = new HandlerList();
 
@@ -34,7 +34,7 @@ public class AutoDisenchanterComputeOutputEvent extends Event {
     private int transferredEnchantmentsAmount;
 
     @ParametersAreNonnullByDefault
-    public AutoDisenchanterComputeOutputEvent(BlockMenu menu, ItemStack inBook, ItemStack inItem, ItemStack outBook, ItemStack outStack, int transferredEnchantmentsAmount) {
+    public AsyncAutoDisenchanterProcessEvent(BlockMenu menu, ItemStack inBook, ItemStack inItem, ItemStack outBook, ItemStack outStack, int transferredEnchantmentsAmount) {
         super(true);
         this.menu = menu;
         this.inputBook = inBook;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoDisenchanterProcessEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoDisenchanterProcessEvent.java
@@ -13,7 +13,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 
 /**
- * An {@link Event} that is fired just after {@link AutoDisenchantEvent} if and onyl if it was not cancelled.
+ * An {@link Event} that is fired just after {@link AutoDisenchantEvent} if and only if it was not cancelled.
  * This event will start out as being cancelled unless it contains a bukkit enchantment.
  * The enchantment transfer logic is already performed by slimefun before this event is fired, though this
  * logic does not affect input items.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchantEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchantEvent.java
@@ -14,9 +14,12 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines
  * disenchanted an {@link ItemStack}.
  * 
  * @author poma123
+ * @author Geolykt
  *
  * @see AutoEnchantEvent
+ * @deprecated Replaced by {@link AutoDisenchanterComputeOutputEvent}, which is more versatile
  */
+@Deprecated
 public class AutoDisenchantEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchantEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchantEvent.java
@@ -17,7 +17,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines
  * @author Geolykt
  *
  * @see AutoEnchantEvent
- * @deprecated Replaced by {@link AutoDisenchanterComputeOutputEvent}, which is more versatile
+ * @deprecated Replaced by {@link AsyncAutoDisenchanterProcessEvent}, which is more versatile
  */
 @Deprecated
 public class AutoDisenchantEvent extends Event implements Cancellable {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchanterComputeOutputEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchanterComputeOutputEvent.java
@@ -1,0 +1,178 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.enchanting.AutoDisenchanter;
+
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+
+/**
+ * An {@link Event} that is fired just after {@link AutoDisenchantEvent} iff it was not cancelled.
+ * This event will start out as being cancelled unless it contains a bukkit enchantment.
+ * The enchantment transfer logic is already performed by slimefun before this event is fired, though this
+ * logic does not affect input items.
+ * The main usecase of this event is to control the output items or to control the time the disenchanting process takes.
+ *
+ * @author Geolykt
+ */
+public class AutoDisenchanterComputeOutputEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private Result result = Result.DEFAULT;
+    private final BlockMenu menu;
+    private final ItemStack inputBook;
+    private final ItemStack inputItem;
+    private ItemStack outputBook;
+    private ItemStack outputStack;
+    private int transferredEnchantmentsAmount;
+
+    @ParametersAreNonnullByDefault
+    public AutoDisenchanterComputeOutputEvent(BlockMenu menu, ItemStack inBook, ItemStack inItem, ItemStack outBook, ItemStack outStack, int transferredEnchantmentsAmount) {
+        super(true);
+        this.menu = menu;
+        this.inputBook = inBook;
+        this.inputItem = inItem;
+        setOutputBook(outBook);
+        setOutputStack(outStack);
+        setTransferredEnchantmentsAmount(transferredEnchantmentsAmount);
+    }
+
+    public static @Nonnull HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public @Nonnull HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    /**
+     * This returns the input {@link ItemStack} to disenchant. The returned instance should not be modified.
+     *
+     * @return The {@link ItemStack} that is being disenchanted
+     */
+    public @Nonnull ItemStack getInputBook() {
+        return inputBook;
+    }
+
+    /**
+     * This returns the input {@link ItemStack} which represents the book where the enchantments are applied onto.
+     * The returned instance should not be modified.
+     *
+     * @return The input {@link ItemStack} book
+     */
+    public @Nonnull ItemStack getInputItem() {
+        return inputItem;
+    }
+
+    /**
+     * This returns the {@link AutoDisenchanter}'s {@link BlockMenu}.
+     *
+     * @return The {@link BlockMenu} of {@link AutoDisenchanter} that is enchanting item
+     */
+    public BlockMenu getMenu() {
+        return menu;
+    }
+
+    /**
+     * This returns the output {@link ItemStack} that represents the book after the disenchanting process.
+     * This instance can be directly modified, however usage of {@link #setOutputBook(ItemStack)} is equally valid.
+     *
+     * @return The output {@link ItemStack} book
+     */
+    public @Nonnull ItemStack getOutputBook() {
+        return outputBook;
+    }
+
+    /**
+     * This returns the output {@link ItemStack} to disenchant with the enchantments being stripped.
+     * This instance can be directly modified, however usage of {@link #setOutputStack(ItemStack)} is equally valid.
+     *
+     * @return The output {@link ItemStack} that is being disenchanted
+     */
+    public @Nonnull ItemStack getOutputStack() {
+        // Lazily clone the output stack instance if it is the same instance as the input stack instance
+        // Therefore the instance comparison is intended
+        // The alternative would be to forbid mutating the itemstack through the documentation
+        // but this will likely result in excess amounts of cloning or unstable (and potentially exploitable) code
+        if (outputStack == inputItem) {
+            outputStack = outputStack.clone();
+        }
+        return outputStack;
+    }
+
+    /**
+     * Obtains the result of the event. If the result is {@link Result#DENY} then the disenchanting process 
+     * will be denied and will also be denied if it is set to {@link Result#DEFAULT} and slimefun did not transfer
+     * any enchantments. The default value is {@link Result#DEFAULT}, where as plugins should set it to other values
+     * via {@link #setResult(Result)} if applicable.
+     *
+     * @return The current {@link Result} of the event
+     */
+    public @Nonnull Result getResult() {
+        return result;
+    }
+
+    /**
+     * Obtains the amount of transferred enchantments. This includes the enchantments transferred by slimefun.
+     * This value is used to compute the duration for which the AutoDisenchanter stays active.
+     *
+     * @return The amount of transferred enchantments
+     */
+    public int getTransferredEnchantmentsAmount() {
+        return transferredEnchantmentsAmount;
+    }
+
+    /**
+     * This sets the output {@link ItemStack} that represents the book after the disenchanting process.
+     * If you wish to increase the time the disenchanting process is taking you must use
+     * {@link #setTransferredEnchantmentsAmount(int)}.
+     *
+     * @param outputBook The output {@link ItemStack} book
+     */
+    public void setOutputBook(@Nonnull ItemStack outputBook) {
+        Validate.notNull(outputBook, "The outputBook parameter may not be null");
+        this.outputBook = outputBook;
+    }
+
+    /**
+     * This sets the output {@link ItemStack} to disenchant with the enchantments being stripped.
+     *
+     * @param outputStack The output {@link ItemStack} that is being disenchanted
+     */
+    public void setOutputStack(@Nonnull ItemStack outputStack) {
+        Validate.notNull(outputStack, "The outputStack parameter may not be null");
+        this.outputStack = outputStack;
+    }
+
+    /**
+     * Sets the result of the event.
+     * Listeners should only set it to {@link Result#ACCEPT} or {@link Result#DENY}.
+     *
+     * @param result The new {@link Result} of the event
+     */
+    public void setResult(@Nonnull Result result) {
+        Validate.notNull(result, "The new result must not be null");
+        this.result = result;
+    }
+
+    /**
+     * Sets the amount of transferred enchantments. This includes the enchantments transferred by slimefun.
+     * The value is used to compute the duration for which the AutoDisenchanter stays active.
+     *
+     * @param transferredEnchantmentsAmount The amount of transferred enchantments
+     */
+    public void setTransferredEnchantmentsAmount(int transferredEnchantmentsAmount) {
+        if (transferredEnchantmentsAmount < 0) {
+            throw new IllegalArgumentException("transferredEnchantmentsAmount must be a non-negative integer but was " + transferredEnchantmentsAmount);
+        }
+        this.transferredEnchantmentsAmount = transferredEnchantmentsAmount;
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
@@ -17,7 +17,7 @@ import org.bukkit.inventory.meta.Repairable;
 
 import io.github.bakedlibs.dough.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.api.events.AutoDisenchantEvent;
-import io.github.thebusybiscuit.slimefun4.api.events.AutoDisenchanterComputeOutputEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.AsyncAutoDisenchanterProcessEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -97,7 +97,7 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
             }
         }
 
-        AutoDisenchanterComputeOutputEvent event;
+        AsyncAutoDisenchanterProcessEvent event;
 
         // Check if we found any valid enchantments
         if (!enchantments.isEmpty()) {
@@ -107,9 +107,9 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
             ItemStack enchantedBook = new ItemStack(Material.ENCHANTED_BOOK);
             transferEnchantments(disenchantedItem, enchantedBook, enchantments);
 
-            event = new AutoDisenchanterComputeOutputEvent(menu, book, item, enchantedBook, disenchantedItem, enchantments.size());
+            event = new AsyncAutoDisenchanterProcessEvent(menu, book, item, enchantedBook, disenchantedItem, enchantments.size());
         } else {
-            event = new AutoDisenchanterComputeOutputEvent(menu, book, item, new ItemStack(Material.ENCHANTED_BOOK), item, 0);
+            event = new AsyncAutoDisenchanterProcessEvent(menu, book, item, new ItemStack(Material.ENCHANTED_BOOK), item, 0);
         }
 
         Bukkit.getPluginManager().callEvent(event);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Right now there is no way to transfer enchantments via the AutoDisenchanter if the enchantments are added by a plugin that does not extends bukkit's Enchantments class.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Create AutoDisenchanterComputeOutputEvent, which fires whenever an AutoDisenchanter attempts to disenchant an item. Call the event whenever a AutoDisenchanter crafts, and cancel/allow the disenchantment process if needed.
Furthermore AutoDisenchantEvent was deprecated as AutoDisenchanterComputeOutputEvent is basically doing the same thing

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them. [It shouldn't anyways, ABI compat is preserved]
- [X] I followed the existing code standards and didn't mess up the formatting.
- [X] I did my best to add documentation to any public classes or methods I added.
- [X] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
