### PR TITLE
Fix industrial miner mining up sf blocks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -203,12 +203,12 @@ public class IndustrialMiner extends MultiBlockMachine {
     }
 
     /**
-     * This returns whether this {@link IndustrialMiner} can mine the given {@link Material}.
+     * This returns whether this {@link IndustrialMiner} can mine the given {@link Block}.
      *
      * @param block
      *            The {@link Block} to check
      * 
-     * @return Whether this {@link IndustrialMiner} is capable of mining this {@link Material}
+     * @return Whether this {@link IndustrialMiner} is capable of mining this {@link Block}
      */
     public boolean canMine(@Nonnull Block block) {
         MinecraftVersion version = Slimefun.getMinecraftVersion();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -31,6 +31,7 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 
 /**
@@ -203,21 +204,21 @@ public class IndustrialMiner extends MultiBlockMachine {
 
     /**
      * This returns whether this {@link IndustrialMiner} can mine the given {@link Material}.
-     * 
-     * @param type
-     *            The {@link Material} to check
+     *
+     * @param block
+     *            The {@link Block} to check
      * 
      * @return Whether this {@link IndustrialMiner} is capable of mining this {@link Material}
      */
-    public boolean canMine(@Nonnull Material type) {
+    public boolean canMine(@Nonnull Block block) {
         MinecraftVersion version = Slimefun.getMinecraftVersion();
 
-        if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_16) && type == Material.ANCIENT_DEBRIS) {
-            return canMineAncientDebris.getValue();
-        } else if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_17) && SlimefunTag.DEEPSLATE_ORES.isTagged(type)) {
-            return canMineDeepslateOres.getValue();
+        if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_16) && block.getType() == Material.ANCIENT_DEBRIS) {
+            return canMineAncientDebris.getValue() && BlockStorage.check(block) == null;
+        } else if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_17) && SlimefunTag.DEEPSLATE_ORES.isTagged(block.getType())) {
+            return canMineDeepslateOres.getValue() && BlockStorage.check(block) == null;
         } else {
-            return SlimefunTag.INDUSTRIAL_MINER_ORES.isTagged(type);
+            return SlimefunTag.INDUSTRIAL_MINER_ORES.isTagged(block.getType()) && BlockStorage.check(block) == null;
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -214,11 +214,11 @@ public class IndustrialMiner extends MultiBlockMachine {
         MinecraftVersion version = Slimefun.getMinecraftVersion();
 
         if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_16) && block.getType() == Material.ANCIENT_DEBRIS) {
-            return canMineAncientDebris.getValue() && BlockStorage.hasBlockInfo(block);
+            return canMineAncientDebris.getValue() && !BlockStorage.hasBlockInfo(block);
         } else if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_17) && SlimefunTag.DEEPSLATE_ORES.isTagged(block.getType())) {
-            return canMineDeepslateOres.getValue() && BlockStorage.hasBlockInfo(block);
+            return canMineDeepslateOres.getValue() && !BlockStorage.hasBlockInfo(block);
         } else {
-            return SlimefunTag.INDUSTRIAL_MINER_ORES.isTagged(block.getType()) && BlockStorage.hasBlockInfo(block);
+            return SlimefunTag.INDUSTRIAL_MINER_ORES.isTagged(block.getType()) && !BlockStorage.hasBlockInfo(block);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -214,11 +214,11 @@ public class IndustrialMiner extends MultiBlockMachine {
         MinecraftVersion version = Slimefun.getMinecraftVersion();
 
         if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_16) && block.getType() == Material.ANCIENT_DEBRIS) {
-            return canMineAncientDebris.getValue() && BlockStorage.check(block) == null;
+            return canMineAncientDebris.getValue() && BlockStorage.hasBlockInfo(block);
         } else if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_17) && SlimefunTag.DEEPSLATE_ORES.isTagged(block.getType())) {
-            return canMineDeepslateOres.getValue() && BlockStorage.check(block) == null;
+            return canMineDeepslateOres.getValue() && BlockStorage.hasBlockInfo(block);
         } else {
-            return SlimefunTag.INDUSTRIAL_MINER_ORES.isTagged(block.getType()) && BlockStorage.check(block) == null;
+            return SlimefunTag.INDUSTRIAL_MINER_ORES.isTagged(block.getType()) && BlockStorage.hasBlockInfo(block);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
@@ -32,6 +32,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.WorldUtils;
 import io.papermc.lib.PaperLib;
 
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 
 /**
@@ -198,7 +199,7 @@ class MiningTask implements Runnable {
                         return;
                     }
 
-                    if (miner.canMine(b.getType()) && push(miner.getOutcome(b.getType()))) {
+                    if (!BlockStorage.hasBlockInfo(b) && miner.canMine(b.getType()) && push(miner.getOutcome(b.getType()))) {
                         furnace.getWorld().playEffect(furnace.getLocation(), Effect.STEP_SOUND, b.getType());
                         furnace.getWorld().playSound(furnace.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 0.2F, 1F);
 
@@ -314,7 +315,7 @@ class MiningTask implements Runnable {
                 /*
                  * Fixes #3336
                  * Respects the state of the miner if there are
-                 * no errors during #setPistonState
+                 * no any errors during #setPistonState
                  */
                 if (fuelType.test(item) && running) {
                     ItemUtils.consumeItem(item, false);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
@@ -315,7 +315,7 @@ class MiningTask implements Runnable {
                 /*
                  * Fixes #3336
                  * Respects the state of the miner if there are
-                 * no any errors during #setPistonState
+                 * no errors during #setPistonState
                  */
                 if (fuelType.test(item) && running) {
                     ItemUtils.consumeItem(item, false);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
@@ -314,7 +314,7 @@ class MiningTask implements Runnable {
                 /*
                  * Fixes #3336
                  * Respects the state of the miner if there are
-                 * no any errors during #setPistonState
+                 * no errors during #setPistonState
                  */
                 if (fuelType.test(item) && running) {
                     ItemUtils.consumeItem(item, false);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/MiningTask.java
@@ -32,7 +32,6 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.WorldUtils;
 import io.papermc.lib.PaperLib;
 
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 
 /**
@@ -199,7 +198,7 @@ class MiningTask implements Runnable {
                         return;
                     }
 
-                    if (!BlockStorage.hasBlockInfo(b) && miner.canMine(b.getType()) && push(miner.getOutcome(b.getType()))) {
+                    if (miner.canMine(b) && push(miner.getOutcome(b.getType()))) {
                         furnace.getWorld().playEffect(furnace.getLocation(), Effect.STEP_SOUND, b.getType());
                         furnace.getWorld().playSound(furnace.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 0.2F, 1F);
 
@@ -315,7 +314,7 @@ class MiningTask implements Runnable {
                 /*
                  * Fixes #3336
                  * Respects the state of the miner if there are
-                 * no errors during #setPistonState
+                 * no any errors during #setPistonState
                  */
                 if (fuelType.test(item) && running) {
                     ItemUtils.consumeItem(item, false);


### PR DESCRIPTION
## Description
Prevent the industrial miner from mining any sf blocks that uses ores as their material

## Proposed changes
- Added a short circuit condition to prevent unintentional mining of sf blocks

## Related Issues (if applicable)
- Resolves #3511 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
