### PR TITLE
Fix flask of knowledge able to fill up water

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/KnowledgeFlask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/KnowledgeFlask.java
@@ -32,6 +32,7 @@ public class KnowledgeFlask extends SimpleSlimefunItem<ItemUseHandler> {
     @Override
     public ItemUseHandler getItemHandler() {
         return e -> {
+            e.cancel();
             Player p = e.getPlayer();
 
             if (p.getLevel() >= 1 && (!e.getClickedBlock().isPresent() || !(e.getClickedBlock().get().getType().isInteractable()))) {
@@ -47,7 +48,6 @@ public class KnowledgeFlask extends SimpleSlimefunItem<ItemUseHandler> {
                 p.playSound(p.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1F, 0.5F);
 
                 ItemUtils.consumeItem(e.getItem(), false);
-                e.cancel();
             }
         };
     }


### PR DESCRIPTION
## Description
Prevent flask of knowledge from able to fill up water which can turn the flask to a water bottle instead

## Proposed changes
- Moved the cancel event method outside of the condition

## Related Issues (if applicable)
- Resolves #3524 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
