### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,9 +2,14 @@ name: Auto approve
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   auto-approve:
 
+    permissions:
+      pull-requests: write  # for hmarr/auto-approve-action to approve PRs
     name: Auto approve Pull Request
     runs-on: ubuntu-latest
 

--- a/.github/workflows/json-validator.yml
+++ b/.github/workflows/json-validator.yml
@@ -8,6 +8,9 @@ on:
     paths:
     - 'src/main/resources/wiki.json'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
 

--- a/.github/workflows/maven-compiler.yml
+++ b/.github/workflows/maven-compiler.yml
@@ -13,6 +13,9 @@ on:
     - 'src/**'
     - 'pom.xml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   scan:
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
