### PR TITLE
Fix for Book Binder

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1819,7 +1819,7 @@ public final class SlimefunItemSetup {
         new BookBinder(itemGroups.electricity, SlimefunItems.BOOK_BINDER, RecipeType.ENHANCED_CRAFTING_TABLE,
         new ItemStack[] {null, new ItemStack(Material.ENCHANTING_TABLE), null, new ItemStack(Material.BOOKSHELF), SlimefunItems.HARDENED_METAL_INGOT, new ItemStack(Material.BOOKSHELF), SlimefunItems.SYNTHETIC_SAPPHIRE, SlimefunItems.SMALL_CAPACITOR, SlimefunItems.SYNTHETIC_SAPPHIRE})
         .setCapacity(256)
-        .setEnergyConsumption(16)
+        .setEnergyConsumption(8)
         .setProcessingSpeed(1)
         .register(plugin);
 


### PR DESCRIPTION
changed book binder energy consumption from 16 to 8 as energy consumption is per tick and not second. the lore shows 16/s therefore the j/t should be 8/t instead of 16/t as each tick is half a second.

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
changed book binder energy consumption from 16 to 8 as energy consumption is per tick and not second. the lore shows 16/s therefore the j/t should be 8/t instead of 16/t as each tick is half a second.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
changed book binder energy consumption from 16 to 8
## Related Issues (if applicable)


## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
