### PR TITLE
Allow addons to disable warning

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -185,7 +185,7 @@ public class ItemGroup implements Keyed {
             return;
         }
 
-        if (isRegistered() && !item.getAddon().getName().equals(this.addon.getName()) && !isCrossAddonItemGroup()) {
+        if (isRegistered() && !isCrossAddonItemGroup() && !item.getAddon().getName().equals(this.addon.getName())) {
             item.warn("This item does not belong into ItemGroup " + this + " as that group belongs to " + this.addon.getName());
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -44,7 +44,7 @@ public class ItemGroup implements Keyed {
     protected final NamespacedKey key;
     protected final ItemStack item;
     protected int tier;
-    protected boolean allowOtherAddonItems = false;
+    protected boolean crossAddonItemGroup = false;
 
     /**
      * Constructs a new {@link ItemGroup} with the given {@link NamespacedKey} as an identifier
@@ -185,7 +185,7 @@ public class ItemGroup implements Keyed {
             return;
         }
 
-        if (isRegistered() && !item.getAddon().getName().equals(this.addon.getName()) && !this.allowOtherAddonItems) {
+        if (isRegistered() && !item.getAddon().getName().equals(this.addon.getName()) && !isCrossAddonItemGroup()) {
             item.warn("This item does not belong into ItemGroup " + this + " as that group belongs to " + this.addon.getName());
         }
 
@@ -332,8 +332,8 @@ public class ItemGroup implements Keyed {
      *
      * @return true if items from other addons are allowed to be added to this {@link ItemGroup}.
      */
-    public boolean areOtherAddonItemsAllowed() {
-        return allowOtherAddonItems;
+    public boolean isCrossAddonItemGroup() {
+        return crossAddonItemGroup;
     }
 
     /**
@@ -342,11 +342,11 @@ public class ItemGroup implements Keyed {
      * be added, without a warning, into the group. False by default.
      * If set to true, Slimefun will not warn about items being added.
      *
-     * @param allowOtherAddons
+     * @param crossAddonItemGroup
      *                          Whether items from another addon are allowable
      */
-    public void setAllowOtherAddonItems(boolean allowOtherAddons) {
-        this.allowOtherAddonItems = allowOtherAddons;
+    public void setCrossAddonItemGroup(boolean crossAddonItemGroup) {
+        this.crossAddonItemGroup = crossAddonItemGroup;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -44,6 +44,7 @@ public class ItemGroup implements Keyed {
     protected final NamespacedKey key;
     protected final ItemStack item;
     protected int tier;
+    protected boolean allowOtherAddonItems = false;
 
     /**
      * Constructs a new {@link ItemGroup} with the given {@link NamespacedKey} as an identifier
@@ -184,7 +185,7 @@ public class ItemGroup implements Keyed {
             return;
         }
 
-        if (isRegistered() && !item.getAddon().getName().equals(this.addon.getName())) {
+        if (isRegistered() && !item.getAddon().getName().equals(this.addon.getName()) && !this.allowOtherAddonItems) {
             item.warn("This item does not belong into ItemGroup " + this + " as that group belongs to " + this.addon.getName());
         }
 
@@ -323,6 +324,14 @@ public class ItemGroup implements Keyed {
         }
 
         return false;
+    }
+
+    public boolean areOtherAddonItemsAllowed() {
+        return allowOtherAddonItems;
+    }
+
+    public void setAllowOtherAddonItems(boolean allowOtherAddons) {
+        this.allowOtherAddonItems = allowOtherAddons;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -326,10 +326,25 @@ public class ItemGroup implements Keyed {
         return false;
     }
 
+    /**
+     * Returns if items from other addons are allowed to be
+     * added to this {@link ItemGroup}.
+     *
+     * @return true if items from other addons are allowed to be added to this {@link ItemGroup}.
+     */
     public boolean areOtherAddonItemsAllowed() {
         return allowOtherAddonItems;
     }
 
+    /**
+     * This method will set if this {@link ItemGroup} will
+     * allow {@link SlimefunItem}s from other addons to
+     * be added, without a warning, into the group. False by default.
+     * If set to true, Slimefun will not warn about items being added.
+     *
+     * @param allowOtherAddons
+     *                          Whether items from another addon are allowable
+     */
     public void setAllowOtherAddonItems(boolean allowOtherAddons) {
         this.allowOtherAddonItems = allowOtherAddons;
     }


### PR DESCRIPTION
## Description
Currently when an addon adds an item to another addon's ItemGroup, a warning is thrown to the console. This allows addons to allow this behaviour if they want to (defaulted to current behaviour) so the warnings will not be triggered. This doesn't strictly change the behaviour of the items being added as this check didn't actually stop the items being added.

## Proposed changes
A boolean that can be set to disable the warning. Defaults to false.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
