### PR TITLE
Bugfix Ancient Pedestal & Make Never Despawn

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -139,6 +139,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> {
             entity.setVelocity(new Vector(0, 0.1, 0));
             entity.setCustomNameVisible(true);
             entity.setCustomName(nametag);
+            entity.setUnlimitedLifetime(true);
             SlimefunUtils.markAsNoPickup(entity, "altar_item");
             p.playSound(b.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.3F, 0.3F);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -152,6 +152,7 @@ public class AncientAltarListener implements Listener {
         } else if (!removedItems.contains(stack.get().getUniqueId())) {
             Item entity = stack.get();
             UUID uuid = entity.getUniqueId();
+            AncientPedestal.getArmorStand(pedestal).removePassenger(entity);
             removedItems.add(uuid);
 
             Slimefun.runSync(() -> removedItems.remove(uuid), 30L);
@@ -164,7 +165,7 @@ public class AncientAltarListener implements Listener {
              * Drop the item instead if the player's inventory is full and
              * no stack space left else add remaining items from the returned map value
              */
-            Map<Integer, ItemStack> remainingItemMap = p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity));
+            Map<Integer, ItemStack> remainingItemMap = p.getInventory().addItem(pedestalItem.getOriginalItemStack(entity, pedestal));
 
             for (ItemStack item : remainingItemMap.values()) {
                 p.getWorld().dropItem(pedestal.getLocation().add(0, 1, 0), item.clone());
@@ -218,7 +219,7 @@ public class AncientAltarListener implements Listener {
             Optional<Item> stack = pedestalItem.getPlacedItem(pedestal);
 
             if (stack.isPresent()) {
-                input.add(pedestalItem.getOriginalItemStack(stack.get()));
+                input.add(pedestalItem.getOriginalItemStack(stack.get(),pedestal));
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1503,7 +1503,7 @@ public final class SlimefunItemSetup {
 
         new AncientPedestal(itemGroups.magicalGadgets, SlimefunItems.ANCIENT_PEDESTAL, RecipeType.MAGIC_WORKBENCH,
         new ItemStack[] {new ItemStack(Material.OBSIDIAN), SlimefunItems.GOLD_8K, new ItemStack(Material.OBSIDIAN), null, new ItemStack(Material.STONE), null, new ItemStack(Material.OBSIDIAN), SlimefunItems.GOLD_8K, new ItemStack(Material.OBSIDIAN)}, 
-        new SlimefunItemStack(SlimefunItems.ANCIENT_PEDESTAL, 4))
+        new SlimefunItemStack(SlimefunItems.ANCIENT_PEDESTAL, 4),plugin)
         .register(plugin);
 
         new AncientAltar(itemGroups.magicalGadgets, SlimefunItems.ANCIENT_ALTAR, RecipeType.MAGIC_WORKBENCH,

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
@@ -133,13 +133,14 @@ public class AncientAltarTask implements Runnable {
         } else {
             Item entity = item.get();
             particleLocations.add(pedestal.getLocation().add(0.5, 1.5, 0.5));
-            items.add(pedestalItem.getOriginalItemStack(entity));
+            items.add(pedestalItem.getOriginalItemStack(entity,pedestal));
             pedestal.getWorld().playSound(pedestal.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1F, 2F);
 
             dropLocation.getWorld().spawnParticle(Particle.ENCHANTMENT_TABLE, pedestal.getLocation().add(0.5, 1.5, 0.5), 16, 0.3F, 0.2F, 0.3F);
             dropLocation.getWorld().spawnParticle(Particle.CRIT_MAGIC, pedestal.getLocation().add(0.5, 1.5, 0.5), 8, 0.3F, 0.2F, 0.3F);
 
             positionLock.remove(entity);
+            AncientPedestal.getArmorStand(pedestal).removePassenger(entity);
             entity.remove();
             entity.removeMetadata("no_pickup", Slimefun.instance());
         }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
To fix 2 bugs with the Ancient Pedestal and to allow people to use it to show off items

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I have made the Ancient Pedestal create a Armor stand, with slightly modified code to that of the Hologram Projector
And set the Ancient Pedestal item to be a passenger of that Armor Stand, it stops it from being affected by both falling blocks and fluids.
I have also made the Item have an Unlimited Lifetime, that way people don't have to worry about items despawning & can use the Ancient Pedestal to show off items!

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #2940 
Resolves #3147 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
