### PR TITLE
- Adjust ticker times to show correct time on config changes for custom-ticker-delay

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -45,7 +45,7 @@ public class CraftingOperation implements MachineOperation {
          * Normalize the tickrate to the config value custom-ticker-delay.
          * This makes the machines run nearly the same speed on changing the delay.
          */
-        int tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
+        int tickRate = Slimefun.getTickerTask().getTickRate();
         int normalizedTickRate = (int) Math.round((tickRate / 10.0D) * num);
 
         currentTicks += Math.max(normalizedTickRate, num);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -7,7 +7,6 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
 
 /**
@@ -49,7 +48,7 @@ public class CraftingOperation implements MachineOperation {
         int tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
         int normalizedTickRate = (int) Math.round((tickRate / 10.0D) * num);
 
-        currentTicks += normalizedTickRate;
+        currentTicks += Math.max(normalizedTickRate, num);
     }
 
     public @Nonnull ItemStack[] getIngredients() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -7,7 +7,6 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
 
 /**
@@ -22,7 +21,6 @@ public class CraftingOperation implements MachineOperation {
     private final ItemStack[] results;
 
     private final int totalTicks;
-    private int tickRate;
     private int currentTicks = 0;
 
     public CraftingOperation(@Nonnull MachineRecipe recipe) {
@@ -37,8 +35,6 @@ public class CraftingOperation implements MachineOperation {
         this.ingredients = ingredients;
         this.results = results;
         this.totalTicks = totalTicks;
-
-        this.tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
     }
 
     @Override
@@ -49,7 +45,8 @@ public class CraftingOperation implements MachineOperation {
          * Normalize the tickrate to the config value custom-ticker-delay.
          * This makes the machines run nearly the same speed on changing the delay.
          */
-        int normalizedTickRate = (int) Math.round((tickRate / 10.0d) * num);
+        int tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
+        int normalizedTickRate = (int) Math.round((tickRate / 10.0D) * num);
 
         currentTicks += normalizedTickRate;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang.Validate;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
 
@@ -21,10 +22,13 @@ public class CraftingOperation implements MachineOperation {
     private final ItemStack[] results;
 
     private final int totalTicks;
+    private int tickRate;
     private int currentTicks = 0;
 
     public CraftingOperation(@Nonnull MachineRecipe recipe) {
         this(recipe.getInput(), recipe.getOutput(), recipe.getTicks());
+
+        this.tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
     }
 
     public CraftingOperation(@Nonnull ItemStack[] ingredients, @Nonnull ItemStack[] results, int totalTicks) {
@@ -35,12 +39,21 @@ public class CraftingOperation implements MachineOperation {
         this.ingredients = ingredients;
         this.results = results;
         this.totalTicks = totalTicks;
+
+        this.tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
     }
 
     @Override
     public void addProgress(int num) {
         Validate.isTrue(num > 0, "Progress must be positive.");
-        currentTicks += num;
+
+        /**
+         * Normalize the tickrate to the config value custom-ticker-delay.
+         * This makes the machines run nearly the same speed on changing the delay.
+         */
+        int normalizedTickRate = (int) Math.round((tickRate / 10.0d) * num);
+
+        currentTicks += normalizedTickRate;
     }
 
     public @Nonnull ItemStack[] getIngredients() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
 
 /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -27,8 +27,6 @@ public class CraftingOperation implements MachineOperation {
 
     public CraftingOperation(@Nonnull MachineRecipe recipe) {
         this(recipe.getInput(), recipe.getOutput(), recipe.getTicks());
-
-        this.tickRate = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
     }
 
     public CraftingOperation(@Nonnull ItemStack[] ingredients, @Nonnull ItemStack[] results, int totalTicks) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -177,7 +177,7 @@ public final class NumberUtils {
          * This is the amount calculated in addProgress(). 
          * This will be the scale used for timer.
          */
-        double timeScale = Slimefun.getCfg().getInt("URID.custom-ticker-delay") / 10.0D;
+        double timeScale = Slimefun.getTickerTask().getTickRate() / 10.0D;
         double normalScale = timeScale - Math.round(timeScale);
 
         int seconds = ticksLeft;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -180,7 +180,7 @@ public final class NumberUtils {
         double timeScale = Slimefun.getCfg().getInt("URID.custom-ticker-delay") / 10.0D;
         double normalScale = timeScale - Math.round(timeScale);
 
-        int seconds = 0;
+        int seconds = ticksLeft;
 
         if (normalScale < 0) {
             //Adjust for positive change
@@ -188,9 +188,6 @@ public final class NumberUtils {
         } else if (normalScale > 0) {
             // Adjust for negative change 
             seconds = (int) (ticksLeft * (normalScale + 1.0D));
-        } else {
-            // No change 
-            seconds = ticksLeft;
         }
 
         int minutes = (int) (seconds / 60L);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -25,6 +25,10 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
  *
  */
 public final class NumberUtils {
+    /**
+     * Save config value for tick rate
+     */
+    private static final int TICK_RATE = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
 
     /**
      * This is our {@link DecimalFormat} for decimal values.
@@ -35,7 +39,8 @@ public final class NumberUtils {
     /**
      * We do not want any instance of this to be created.
      */
-    private NumberUtils() {}
+    private NumberUtils() {
+    }
 
     /**
      * This method formats a given {@link Integer} to be displayed nicely with
@@ -171,8 +176,30 @@ public final class NumberUtils {
         }
     }
 
-    public static @Nonnull String getTimeLeft(int seconds) {
+    public static @Nonnull String getTimeLeft(int ticksLeft) {
         String timeleft = "";
+
+        /**
+         * This is the amount calculated in addProgress(). 
+         * This will be the scale used for timer.
+         */
+        double timeScale = (TICK_RATE / 10.0d) * 1;
+        double normalScale = ((timeScale) - Math.round(timeScale));
+
+        int seconds = 0;
+
+        //Adjust for positive change
+        if (normalScale < 0) {
+            seconds = (int) (ticksLeft * (normalScale / 2 + 1.0d));
+        }
+        // Adjust for negative change 
+        else if (normalScale > 0) {
+            seconds = (int) (ticksLeft * (normalScale + 1.0d));
+        }
+        // No change 
+        else {
+            seconds = ticksLeft;
+        }
 
         int minutes = (int) (seconds / 60L);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -183,7 +183,7 @@ public final class NumberUtils {
          * This is the amount calculated in addProgress(). 
          * This will be the scale used for timer.
          */
-        double timeScale = (TICK_RATE / 10.0d) * 1;
+        double timeScale = (TICK_RATE / 10.0d);
         double normalScale = ((timeScale) - Math.round(timeScale));
 
         int seconds = 0;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -26,11 +26,6 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
  */
 public final class NumberUtils {
     /**
-     * Save config value for tick rate
-     */
-    private static final int TICK_RATE = Slimefun.getCfg().getInt("URID.custom-ticker-delay");
-
-    /**
      * This is our {@link DecimalFormat} for decimal values.
      * This instance is not thread-safe!
      */
@@ -39,8 +34,7 @@ public final class NumberUtils {
     /**
      * We do not want any instance of this to be created.
      */
-    private NumberUtils() {
-    }
+    private NumberUtils() {}
 
     /**
      * This method formats a given {@link Integer} to be displayed nicely with
@@ -183,21 +177,19 @@ public final class NumberUtils {
          * This is the amount calculated in addProgress(). 
          * This will be the scale used for timer.
          */
-        double timeScale = (TICK_RATE / 10.0d);
-        double normalScale = ((timeScale) - Math.round(timeScale));
+        double timeScale = Slimefun.getCfg().getInt("URID.custom-ticker-delay") / 10.0D;
+        double normalScale = timeScale - Math.round(timeScale);
 
         int seconds = 0;
 
-        //Adjust for positive change
         if (normalScale < 0) {
-            seconds = (int) (ticksLeft * (normalScale / 2 + 1.0d));
-        }
-        // Adjust for negative change 
-        else if (normalScale > 0) {
-            seconds = (int) (ticksLeft * (normalScale + 1.0d));
-        }
-        // No change 
-        else {
+            //Adjust for positive change
+            seconds = (int) (ticksLeft * (normalScale / 2 + 1.0D));
+        } else if (normalScale > 0) {
+            // Adjust for negative change 
+            seconds = (int) (ticksLeft * (normalScale + 1.0D));
+        } else {
+            // No change 
             seconds = ticksLeft;
         }
 


### PR DESCRIPTION
- Adjust ticker execution steps based on custom-ticker-delay changes

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->

This PR adjust the tick rate based on the config value for custom-ticker-delay.
It will try to keep the tickers execution at a similar speed as to when the default value is used.

I also adjust the displayed time based on the difference of execution time.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

Changed CraftingOperation to take into account the new ticks config. Normalize the value to the default one of one operation per 10 ticks. 

Changed NumberUtils. Added logic that calculates the time new changes will take to finish the operation.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

Not sure if there is na issue open.

Here is how to reproduce the issue:
1. Adjust custom-ticker-delay to 20.
2. Run a ticker ingame.
3. The display timer will be wrong the execution slows down by 1/2 so the secounds and minutes are not synced to the actual values.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
