### PR TITLE
Update SoulboundRune.java

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
@@ -118,7 +118,7 @@ public class SoulboundRune extends SimpleSlimefunItem<ItemDropHandler> {
         if (entity instanceof Item) {
             Item item = (Item) entity;
 
-            return !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
+            return item.getPickupDelay == 0 && !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
         }
 
         return false;


### PR DESCRIPTION
Make sure a soulbound rune will not pick up an item that a player could not pick up, eg one that has a pickup delay.

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
soulbound rune's will currently convert an item that has a pickup delay, eg one that can not be picked up by a player.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
added a check for the item.getPickupDelay()
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
resolves #3657 3657
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
