### PR TITLE
Update soulbound rune to respect itemPickupDelay()

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
@@ -118,7 +118,7 @@ public class SoulboundRune extends SimpleSlimefunItem<ItemDropHandler> {
         if (entity instanceof Item) {
             Item item = (Item) entity;
 
-            return !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
+            return item.getPickupDelay == 0 && !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
         }
 
         return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
@@ -118,7 +118,7 @@ public class SoulboundRune extends SimpleSlimefunItem<ItemDropHandler> {
         if (entity instanceof Item) {
             Item item = (Item) entity;
 
-            return item.getPickupDelay == 0 && !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
+            return item.getPickupDelay() == 0 && !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
         }
 
         return false;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Updated soulbound rune to respect vanilla getPickupDelay() value

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
added a check to ensure item can be picked up by players before the soulbound code converts the item.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
resolves #3657
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
