### PR TITLE
Check if player is crouching

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
@@ -66,11 +66,7 @@ public class LumberAxe extends SlimefunItem implements NotPlaceable {
     @Nonnull
     public ItemUseHandler onItemUse() {
         return e -> {
-            if (e.getClickedBlock().isPresent()) {
-                if (e.getPlayer().isSneaking()) {
-                    return;
-                }
-
+            if (e.getClickedBlock().isPresent() && !e.getPlayer().isSneaking()) {
                 Block block = e.getClickedBlock().get();
 
                 if (isUnstrippedLog(block)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
@@ -109,5 +109,4 @@ public class LumberAxe extends SlimefunItem implements NotPlaceable {
 
         b.setType(Material.AIR);
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
@@ -67,6 +67,10 @@ public class LumberAxe extends SlimefunItem implements NotPlaceable {
     public ItemUseHandler onItemUse() {
         return e -> {
             if (e.getClickedBlock().isPresent()) {
+                if (e.getPlayer().isSneaking()) {
+                    return;
+                }
+
                 Block block = e.getClickedBlock().get();
 
                 if (isUnstrippedLog(block)) {


### PR DESCRIPTION
## Description
Only activate the Lumber Axe when the player is crouching. (similar to explosivetools)

## Proposed changes
Add a crouch check in the LumberAxe

## Related Issues (if applicable)
[Discord issue 1515](https://discord.com/channels/565557184348422174/627048923122499584/892393743133577287)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
