### PR TITLE
Disable Slimefun when CS-CoreLib is installed

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -269,6 +269,8 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         // Check if CS-CoreLib is installed (it is no longer needed)
         if (getServer().getPluginManager().getPlugin("CS-CoreLib") != null) {
             StartupWarnings.discourageCSCoreLib(logger);
+            getServer().getPluginManager().disablePlugin(this);
+            return;
         }
 
         // Encourage newer Java version

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
@@ -24,14 +24,16 @@ final class StartupWarnings {
 
     @ParametersAreNonnullByDefault
     static void discourageCSCoreLib(Logger logger) {
-        logger.log(Level.WARNING, BORDER);
-        logger.log(Level.WARNING, PREFIX + "It looks like you are still using CS-CoreLib.");
-        logger.log(Level.WARNING, PREFIX);
-        logger.log(Level.WARNING, PREFIX + "Slimefun no longer requires CS-CoreLib to be");
-        logger.log(Level.WARNING, PREFIX + "installed as of January 30th 2021. It is safe");
-        logger.log(Level.WARNING, PREFIX + "to remove and we recommend you to uninstall");
-        logger.log(Level.WARNING, PREFIX + "CS-CoreLib from your server immediately.");
-        logger.log(Level.WARNING, BORDER);
+        logger.log(Level.SEVERE, BORDER);
+        logger.log(Level.SEVERE, PREFIX + "It looks like you are still using CS-CoreLib.");
+        logger.log(Level.SEVERE, PREFIX);
+        logger.log(Level.SEVERE, PREFIX + "Slimefun no longer requires CS-CoreLib to be");
+        logger.log(Level.SEVERE, PREFIX + "installed as of January 30th 2021. It is safe");
+        logger.log(Level.SEVERE, PREFIX + "to remove and we recommend you to uninstall");
+        logger.log(Level.SEVERE, PREFIX + "CS-CoreLib from your server immediately.");
+        logger.log(Level.SEVERE, PREFIX);
+        logger.log(Level.SEVERE, PREFIX + "You need to remove CS-CoreLib for Slimefun to run.");
+        logger.log(Level.SEVERE, BORDER);
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
@@ -28,9 +28,7 @@ final class StartupWarnings {
         logger.log(Level.SEVERE, PREFIX + "It looks like you are still using CS-CoreLib.");
         logger.log(Level.SEVERE, PREFIX);
         logger.log(Level.SEVERE, PREFIX + "Slimefun no longer requires CS-CoreLib to be");
-        logger.log(Level.SEVERE, PREFIX + "installed as of January 30th 2021. It is safe");
-        logger.log(Level.SEVERE, PREFIX + "to remove and we recommend you to uninstall");
-        logger.log(Level.SEVERE, PREFIX + "CS-CoreLib from your server immediately.");
+        logger.log(Level.SEVERE, PREFIX + "installed as of January 30th 2021.");
         logger.log(Level.SEVERE, PREFIX);
         logger.log(Level.SEVERE, PREFIX + "You need to remove CS-CoreLib for Slimefun to run.");
         logger.log(Level.SEVERE, BORDER);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
@@ -28,9 +28,8 @@ final class StartupWarnings {
         logger.log(Level.SEVERE, PREFIX + "It looks like you are still using CS-CoreLib.");
         logger.log(Level.SEVERE, PREFIX);
         logger.log(Level.SEVERE, PREFIX + "Slimefun no longer requires CS-CoreLib to be");
-        logger.log(Level.SEVERE, PREFIX + "installed as of January 30th 2021.");
-        logger.log(Level.SEVERE, PREFIX);
-        logger.log(Level.SEVERE, PREFIX + "You need to remove CS-CoreLib for Slimefun to run.");
+        logger.log(Level.SEVERE, PREFIX + "installed as of January 30th 2021. You need to");
+        logger.log(Level.SEVERE, PREFIX + "remove CS-CoreLib for Slimefun to run.");
         logger.log(Level.SEVERE, BORDER);
     }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
(Idea from @J3fftw1 )
Since CS-CoreLib is no longer needed, and will cause issues to some addons, we should disable Slimefun and let users remove CS-CoreLib in order to run Slimefun and addons properly.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Change the CS-CoreLib warning level to severe.
Disable Slimefun when CS-CoreLib is installed.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
