### PR TITLE
Add /sf dump command with blockstorage initially

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunTabCompleter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunTabCompleter.java
@@ -52,6 +52,12 @@ class SlimefunTabCompleter implements TabCompleter {
                 // Returning null will make it fallback to the default arguments (all online players)
                 return null;
             }
+        } else if (args[0].equalsIgnoreCase("dump")) {
+            // Only one option here for now, but preparing for further usages of /sf dump
+            List<String> suggestions = new LinkedList<>();
+            suggestions.add("blockstorage");
+
+            return createReturnList(suggestions, args[1]);
         } else if (args.length == 4 && args[0].equalsIgnoreCase("give")) {
             return createReturnList(Arrays.asList("1", "2", "4", "8", "16", "32", "64"), args[3]);
         } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunTabCompleter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunTabCompleter.java
@@ -54,8 +54,7 @@ class SlimefunTabCompleter implements TabCompleter {
             }
         } else if (args[0].equalsIgnoreCase("dump")) {
             // Only one option here for now, but preparing for further usages of /sf dump
-            List<String> suggestions = new LinkedList<>();
-            suggestions.add("blockstorage");
+            List<String> suggestions = List.of("blockstorage");
 
             return createReturnList(suggestions, args[1]);
         } else if (args.length == 4 && args[0].equalsIgnoreCase("give")) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BlockStorageCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BlockStorageCommand.java
@@ -26,50 +26,56 @@ class BlockStorageCommand extends SubCommand {
 
     @ParametersAreNonnullByDefault
     BlockStorageCommand(Slimefun plugin, SlimefunCommand cmd) {
-        super(plugin, cmd, "blockstorage", false);
+        super(plugin, cmd, "dump", false);
     }
 
     @Override
     protected String getDescription() {
-        return "commands.blockstorage.description";
+        return "commands.dump.description";
     }
 
     @Override
     public void onExecute(CommandSender sender, String[] args) {
-        if (sender.hasPermission("slimefun.command.blockstorage") || sender instanceof ConsoleCommandSender) {
-            final Map<String, Integer> map = new LinkedHashMap<>();
-            for (World world : Bukkit.getWorlds()) {
-                for (Config value : BlockStorage.getRawStorage(world).values()) {
-                    final String id = value.getString("id");
-                    map.merge(id, 1, Integer::sum);
-                }
-            }
-
-            final String path = Slimefun.instance().getDataFolder().getAbsolutePath();
-
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(path + "/BlockStorageSummary.txt"))) {
-                map.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(
-                    entry -> {
-                        final String message = entry.getKey() + " -> " + entry.getValue();
-                        try {
-                            writer.write(message + "\n");
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-                        // sender.sendMessage(message);
-                    }
-                );
-                Slimefun.getLocalization().sendMessage(
-                    sender,
-                    "commands.blockstorage.complete",
-                    true,
-                    msg -> msg.replace("%path%", path)
-                );
-            } catch (IOException e) {
-                e.printStackTrace();
+        if (sender.hasPermission("slimefun.command.dump") || sender instanceof ConsoleCommandSender) {
+            String sub = args[1];
+            if (sub.equalsIgnoreCase("blockstorage")) {
+                Bukkit.getScheduler().runTaskAsynchronously(this.plugin, task -> dumpBlockStorage(sender));
             }
         } else {
             Slimefun.getLocalization().sendMessage(sender, "messages.no-permission", true);
+        }
+    }
+
+    private void dumpBlockStorage(CommandSender sender) {
+        final Map<String, Integer> map = new LinkedHashMap<>();
+        for (World world : Bukkit.getWorlds()) {
+            for (Config value : BlockStorage.getRawStorage(world).values()) {
+                final String id = value.getString("id");
+                map.merge(id, 1, Integer::sum);
+            }
+        }
+
+        final String path = Slimefun.instance().getDataFolder().getAbsolutePath();
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(path + "/blockstorage_dump.txt"))) {
+            map.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(
+                entry -> {
+                    final String message = entry.getKey() + " -> " + entry.getValue();
+                    try {
+                        writer.write(message + "\n");
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            );
+            Slimefun.getLocalization().sendMessage(
+                sender,
+                "commands.dump.blockstorage.complete",
+                true,
+                msg -> msg.replace("%path%", path)
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BlockStorageCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BlockStorageCommand.java
@@ -1,0 +1,75 @@
+package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
+
+import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
+import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Checks the contents of BlockStorage and creates a file of the contents.
+ *
+ * @author Sefiraat
+ */
+class BlockStorageCommand extends SubCommand {
+
+    @ParametersAreNonnullByDefault
+    BlockStorageCommand(Slimefun plugin, SlimefunCommand cmd) {
+        super(plugin, cmd, "blockstorage", false);
+    }
+
+    @Override
+    protected String getDescription() {
+        return "commands.blockstorage.description";
+    }
+
+    @Override
+    public void onExecute(CommandSender sender, String[] args) {
+        if (sender.hasPermission("slimefun.command.blockstorage") || sender instanceof ConsoleCommandSender) {
+            final Map<String, Integer> map = new LinkedHashMap<>();
+            for (World world : Bukkit.getWorlds()) {
+                for (Config value : BlockStorage.getRawStorage(world).values()) {
+                    final String id = value.getString("id");
+                    map.merge(id, 1, Integer::sum);
+                }
+            }
+
+            final String path = Slimefun.instance().getDataFolder().getAbsolutePath();
+
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(path + "/BlockStorageSummary.txt"))) {
+                map.entrySet().stream().sorted(Map.Entry.comparingByValue()).forEach(
+                    entry -> {
+                        final String message = entry.getKey() + " -> " + entry.getValue();
+                        try {
+                            writer.write(message + "\n");
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                        // sender.sendMessage(message);
+                    }
+                );
+                Slimefun.getLocalization().sendMessage(
+                    sender,
+                    "commands.blockstorage.complete",
+                    true,
+                    msg -> msg.replace("%path%", path)
+                );
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            Slimefun.getLocalization().sendMessage(sender, "messages.no-permission", true);
+        }
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/DumpCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/DumpCommand.java
@@ -15,6 +15,8 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -30,7 +32,7 @@ import java.util.function.Supplier;
  */
 class DumpCommand extends SubCommand {
 
-    private static final String PATH = Slimefun.instance().getDataFolder().getAbsolutePath() + "\\dumps\\";
+    private static final String PATH = Paths.get(Slimefun.instance().getDataFolder().getAbsolutePath(), "dumps").toString();
 
     @ParametersAreNonnullByDefault
     DumpCommand(Slimefun plugin, SlimefunCommand cmd) {
@@ -45,11 +47,20 @@ class DumpCommand extends SubCommand {
     @Override
     public void onExecute(CommandSender sender, String[] args) {
         if (sender.hasPermission("slimefun.command.dump") || sender instanceof ConsoleCommandSender) {
-            String sub = args[1];
-            if (sub.equalsIgnoreCase("blockstorage")) {
-                Bukkit.getScheduler().runTaskAsynchronously(
-                    this.plugin,
-                    task -> createDump(sender, "blockstorage", this::dumpBlockStorage)
+            if (args.length > 1) {
+                String sub = args[1];
+                if (sub.equalsIgnoreCase("blockstorage")) {
+                    Bukkit.getScheduler().runTaskAsynchronously(
+                        this.plugin,
+                        task -> createDump(sender, "blockstorage", this::dumpBlockStorage)
+                    );
+                }
+            } else {
+                Slimefun.getLocalization().sendMessage(
+                    sender,
+                    "messages.usage",
+                    true,
+                    msg -> msg.replace("%usage%", "/sf dump <Dump Type>")
                 );
             }
         } else {
@@ -59,9 +70,9 @@ class DumpCommand extends SubCommand {
 
     @ParametersAreNonnullByDefault
     private void createDump(CommandSender sender, String filePrefix, Supplier<List<String>> dump) {
-        final String dateTimeStamp = new SimpleDateFormat("'_'yyyyMMddHHmm'.txt'").format(new Date());
-        final String fullPath = PATH + filePrefix + dateTimeStamp;
-        final File directory = new File(PATH);
+        String dateTimeStamp = new SimpleDateFormat("'_'yyyyMMddHHmm'.txt'").format(new Date());
+        String fullPath = Paths.get(PATH, filePrefix + dateTimeStamp).toString();
+        File directory = new File(PATH);
 
         if (!directory.exists()) {
             directory.mkdir();
@@ -72,20 +83,20 @@ class DumpCommand extends SubCommand {
             for (String string : dump.get()) {
                 writer.write(string + "\n");
             }
-
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
             Slimefun.getLocalization().sendMessage(
                 sender,
                 "commands.dump.complete",
                 true,
                 msg -> msg.replace("%path%", fullPath)
             );
-        } catch (IOException e) {
-            e.printStackTrace();
         }
     }
 
     private List<String> dumpBlockStorage() {
-        final Map<String, Integer> map = new LinkedHashMap<>();
+        Map<String, Integer> map = new LinkedHashMap<>();
         for (World world : Bukkit.getWorlds()) {
             for (Config value : BlockStorage.getRawStorage(world).values()) {
                 final String id = value.getString("id");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/DumpCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/DumpCommand.java
@@ -18,14 +18,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Checks the contents of BlockStorage and creates a file of the contents.
+ * Provides commands to dump data for triaging
  *
  * @author Sefiraat
  */
-class BlockStorageCommand extends SubCommand {
+class DumpCommand extends SubCommand {
 
     @ParametersAreNonnullByDefault
-    BlockStorageCommand(Slimefun plugin, SlimefunCommand cmd) {
+    DumpCommand(Slimefun plugin, SlimefunCommand cmd) {
         super(plugin, cmd, "dump", false);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
@@ -42,7 +42,7 @@ public final class SlimefunSubCommands {
         commands.add(new BackpackCommand(plugin, cmd));
         commands.add(new ChargeCommand(plugin, cmd));
         commands.add(new DebugCommand(plugin, cmd));
-        commands.add(new BlockStorageCommand(plugin, cmd));
+        commands.add(new DumpCommand(plugin, cmd));
 
         return commands;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
@@ -42,6 +42,7 @@ public final class SlimefunSubCommands {
         commands.add(new BackpackCommand(plugin, cmd));
         commands.add(new ChargeCommand(plugin, cmd));
         commands.add(new DebugCommand(plugin, cmd));
+        commands.add(new BlockStorageCommand(plugin, cmd));
 
         return commands;
     }

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -39,9 +39,10 @@ commands:
     running: '&7Running debug mode with test: &6%test%'
     disabled: '&7Disabled debug mode.'
 
-  blockstorage:
-    description: 'Collects and writes the contents of BlockStorage to a file'
-    complete: '&aAll blocks processed, file saved to: &6%path%'
+  dump:
+    description: 'Contains commands to dump data to files'
+    blockstorage:
+      complete: '&aAll blocks processed, file saved to: &6%path%'
 
 placeholderapi:
   profile-loading: 'Loading...'

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -41,8 +41,7 @@ commands:
 
   dump:
     description: 'Contains commands to dump data to files'
-    blockstorage:
-      complete: '&aAll blocks processed, file saved to: &6%path%'
+    complete: '&aDump completed, file saved to: &6%path%'
 
 placeholderapi:
   profile-loading: 'Loading...'

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -39,6 +39,10 @@ commands:
     running: '&7Running debug mode with test: &6%test%'
     disabled: '&7Disabled debug mode.'
 
+  blockstorage:
+    description: 'Collects and writes the contents of BlockStorage to a file'
+    complete: '&aAll blocks processed, file saved to: &6%path%'
+
 placeholderapi:
   profile-loading: 'Loading...'
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -68,6 +68,9 @@ permissions:
   slimefun.command.debug:
     description: Allows you to do /sf debug
     default: op
+  slimefun.command.blockstorage:
+    description: Allows you to do /sf blockstorage
+    default: op
   slimefun.android.bypass:
     description: Allows you to edit other Players Androids
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -68,8 +68,8 @@ permissions:
   slimefun.command.debug:
     description: Allows you to do /sf debug
     default: op
-  slimefun.command.blockstorage:
-    description: Allows you to do /sf blockstorage
+  slimefun.command.dump:
+    description: Allows you to do /sf dump
     default: op
   slimefun.android.bypass:
     description: Allows you to edit other Players Androids


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Adds a new command /sf dump <blockstorage>. This command just collects the blocks held in BlockStorage into a single file denoting the item ID and the amount held in storage.

Recently many servers have had issues with BlockStorage and a simple fix (for some) has been to show them just how many of a certain block they have to allow them to triage and tackle the amount. This has been very positive for servers with ExoticGarden where they have had upwards of millions of several of plants which, when they purged them, released a not insignificant amount of RAM. 

Until now I have just offered this command as a separate JAR to server owners having issues and worked through the resolution with them but I think it makes sense to have the command here, regardless of the few use-cases.

## Proposed changes
Add a new command that dumps contents into a file.

<img width="642" alt="image" src="https://user-images.githubusercontent.com/20646323/211083935-a495b0c0-1e59-4bce-af01-384d03f6c123.png">

<img width="661" alt="image" src="https://user-images.githubusercontent.com/20646323/211083985-afcb2a33-0fdf-45ff-98da-59ce68c23b11.png">

<img width="537" alt="image" src="https://user-images.githubusercontent.com/20646323/211081434-9668fd86-886a-4e52-ae25-9244a7762180.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/20646323/211084043-f06538f4-8f33-4930-b916-f4161d13d7af.png">

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
