### PR TITLE
added a way to set max enchants to go on an item

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
@@ -28,6 +28,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
  *
  * @author TheBusyBiscuit
  * @author Rothes
+ * @author J3fftw1
  *
  * @see AutoEnchanter
  * @see AutoDisenchanter
@@ -40,6 +41,12 @@ abstract class AbstractEnchantmentMachine extends AContainer {
     private final ItemSetting<Boolean> useIgnoredLores = new ItemSetting<>(this, "use-ignored-lores", false);
     private final ItemSetting<List<String>> ignoredLores = new ItemSetting<>(this, "ignored-lores", Collections.singletonList("&7- &cCan't be used in " + this.getItemName()));
 
+    /*
+     * Default value is -1, Minecraft doesn't limit enchants by default.
+     * -1 means its disabled and doesn't check for a max number of enchantments.
+     */
+    private final ItemSetting<Integer> maxEnchants = new ItemSetting<>(this, "max-enchants", -1);
+
     @ParametersAreNonnullByDefault
     protected AbstractEnchantmentMachine(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
@@ -48,6 +55,7 @@ abstract class AbstractEnchantmentMachine extends AContainer {
         addItemSetting(levelLimit);
         addItemSetting(useIgnoredLores);
         addItemSetting(ignoredLores);
+        addItemSetting(maxEnchants);
     }
 
     protected boolean isEnchantmentLevelAllowed(int enchantmentLevel) {
@@ -83,5 +91,9 @@ abstract class AbstractEnchantmentMachine extends AContainer {
         }
 
         return false;
+    }
+
+    protected boolean IsEnchantmentAmountAllowed(@Nonnull ItemStack item ) {
+        return maxEnchants.getValue() != -1 && item.getEnchantments().size() >= maxEnchants.getValue();
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Material;
+import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -38,12 +39,8 @@ abstract class AbstractEnchantmentMachine extends AContainer {
 
     private final ItemSetting<Boolean> useLevelLimit = new ItemSetting<>(this, "use-enchant-level-limit", false);
     private final IntRangeSetting levelLimit = new IntRangeSetting(this, "enchant-level-limit", 0, 10, Short.MAX_VALUE);
-
-    /*
-     * Default value is -1, Minecraft doesn't limit enchants by default.
-     * -1 means its disabled and doesn't check for a max number of enchantments.
-     */
-    private final ItemSetting<Integer> maxEnchants = new IntRangeSetting(this, "max-enchants", -1, -1, Short.MAX_VALUE);
+    private final ItemSetting<Integer> maxEnchants = new IntRangeSetting(this, "max-enchants", 0, 10, Short.MAX_VALUE);
+    private final ItemSetting<Boolean> useMaxEnchants= new ItemSetting<>(this, "use-max-encahnts", false);
     private final ItemSetting<Boolean> useIgnoredLores = new ItemSetting<>(this, "use-ignored-lores", false);
     private final ItemSetting<List<String>> ignoredLores = new ItemSetting<>(this, "ignored-lores", Collections.singletonList("&7- &cCan't be used in " + this.getItemName()));
 
@@ -56,6 +53,7 @@ abstract class AbstractEnchantmentMachine extends AContainer {
         addItemSetting(useIgnoredLores);
         addItemSetting(ignoredLores);
         addItemSetting(maxEnchants);
+        addItemSetting(useMaxEnchants);
     }
 
     protected boolean isEnchantmentLevelAllowed(int enchantmentLevel) {
@@ -94,6 +92,6 @@ abstract class AbstractEnchantmentMachine extends AContainer {
     }
 
     protected boolean IsEnchantmentAmountAllowed(@Nonnull ItemStack item ) {
-        return maxEnchants.getValue() != -1 && item.getEnchantments().size() >= maxEnchants.getValue();
+        return !useMaxEnchants.getValue() || item.getEnchantments().size() >= maxEnchants.getValue();
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
@@ -91,7 +91,7 @@ abstract class AbstractEnchantmentMachine extends AContainer {
         return false;
     }
 
-    protected boolean IsEnchantmentAmountAllowed(@Nonnull ItemStack item ) {
+    protected boolean isEnchantmentAmountAllowed(@Nonnull ItemStack item ) {
         return !useMaxEnchants.getValue() || item.getEnchantments().size() >= maxEnchants.getValue();
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
@@ -38,14 +38,14 @@ abstract class AbstractEnchantmentMachine extends AContainer {
 
     private final ItemSetting<Boolean> useLevelLimit = new ItemSetting<>(this, "use-enchant-level-limit", false);
     private final IntRangeSetting levelLimit = new IntRangeSetting(this, "enchant-level-limit", 0, 10, Short.MAX_VALUE);
-    private final ItemSetting<Boolean> useIgnoredLores = new ItemSetting<>(this, "use-ignored-lores", false);
-    private final ItemSetting<List<String>> ignoredLores = new ItemSetting<>(this, "ignored-lores", Collections.singletonList("&7- &cCan't be used in " + this.getItemName()));
 
     /*
      * Default value is -1, Minecraft doesn't limit enchants by default.
      * -1 means its disabled and doesn't check for a max number of enchantments.
      */
-    private final ItemSetting<Integer> maxEnchants = new ItemSetting<>(this, "max-enchants", -1);
+    private final ItemSetting<Integer> maxEnchants = new IntRangeSetting(this, "max-enchants", -1, -1, Short.MAX_VALUE);
+    private final ItemSetting<Boolean> useIgnoredLores = new ItemSetting<>(this, "use-ignored-lores", false);
+    private final ItemSetting<List<String>> ignoredLores = new ItemSetting<>(this, "ignored-lores", Collections.singletonList("&7- &cCan't be used in " + this.getItemName()));
 
     @ParametersAreNonnullByDefault
     protected AbstractEnchantmentMachine(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
@@ -94,6 +94,10 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
             }
         }
 
+        if (isEnchantmentAmountAllowed(item)) {
+            return null;
+        }
+
         // Check if we found any valid enchantments
         if (!enchantments.isEmpty()) {
             ItemStack disenchantedItem = item.clone();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -109,8 +109,8 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
         }
 
         /*
-         * If override is false, remove those with lower level, so we don't override existing enchants
-         * This also removes those with the same level, so they aren't accounted for enchanting time
+         * If override is false, remove those with lower level so we don't override existing enchants
+         * This also removes those with the same level so they aren't accounted for enchanting time
          */
         if (!overrideExistingEnchantsLvl.getValue()) {
             enchantments.entrySet().removeIf(e -> target.getEnchantmentLevel(e.getKey()) >= e.getValue());
@@ -120,7 +120,7 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
          * When maxEnchants is set to -1 it will be ignored. When it's set to 0 it will not allow any enchants to go
          * on an item. When maxEnchants is set to any other value it will allow that many enchants to go on the item.
          */
-        if (IsEnchantmentAmountAllowed(target)) {
+        if (isEnchantmentAmountAllowed(target)) {
             return null;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -34,6 +34,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
  * @author Mooy1
  * @author StarWishSama
  * @author martinbrom
+ * @author J3fftw1
  *
  * @see AutoDisenchanter
  *
@@ -42,11 +43,18 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
 
     private final ItemSetting<Boolean> overrideExistingEnchantsLvl = new ItemSetting<>(this, "override-existing-enchants-lvl", false);
 
+    /*
+    * Default value is -1, Minecraft doesn't limit enchants by default.
+    * -1 means its disabled and doesn't check for a max number of enchantments.
+    */
+    private final ItemSetting<Integer> maxEnchants = new ItemSetting<>(this, "max-enchants", -1);
+
     @ParametersAreNonnullByDefault
     public AutoEnchanter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(overrideExistingEnchantsLvl);
+        addItemSetting(maxEnchants);
     }
 
     @Override
@@ -114,6 +122,14 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
          */
         if (!overrideExistingEnchantsLvl.getValue()) {
             enchantments.entrySet().removeIf(e -> target.getEnchantmentLevel(e.getKey()) >= e.getValue());
+        }
+
+        /*
+         * When maxEnchants is set to -1 it will be ignored. When it's set to 0 it will not allow any enchants to go
+         * on an item. When maxEnchants is set to any other value it will allow that many enchants to go on the item.
+         */
+        if (maxEnchants.getValue() != -1 && target.getEnchantments().size() >= maxEnchants.getValue()) {
+            return null;
         }
 
         // Check if we found any valid enchantments

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -117,8 +117,8 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
         }
 
         /*
-         * If override is false, remove those with lower level so we don't override existing enchants
-         * This also removes those with the same level so they aren't accounted for enchanting time
+         * If override is false, remove those with lower level, so we don't override existing enchants
+         * This also removes those with the same level, so they aren't accounted for enchanting time
          */
         if (!overrideExistingEnchantsLvl.getValue()) {
             enchantments.entrySet().removeIf(e -> target.getEnchantmentLevel(e.getKey()) >= e.getValue());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -34,7 +34,6 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
  * @author Mooy1
  * @author StarWishSama
  * @author martinbrom
- * @author J3fftw1
  *
  * @see AutoDisenchanter
  *
@@ -43,18 +42,11 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
 
     private final ItemSetting<Boolean> overrideExistingEnchantsLvl = new ItemSetting<>(this, "override-existing-enchants-lvl", false);
 
-    /*
-    * Default value is -1, Minecraft doesn't limit enchants by default.
-    * -1 means its disabled and doesn't check for a max number of enchantments.
-    */
-    private final ItemSetting<Integer> maxEnchants = new ItemSetting<>(this, "max-enchants", -1);
-
     @ParametersAreNonnullByDefault
     public AutoEnchanter(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
         addItemSetting(overrideExistingEnchantsLvl);
-        addItemSetting(maxEnchants);
     }
 
     @Override
@@ -128,7 +120,7 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
          * When maxEnchants is set to -1 it will be ignored. When it's set to 0 it will not allow any enchants to go
          * on an item. When maxEnchants is set to any other value it will allow that many enchants to go on the item.
          */
-        if (maxEnchants.getValue() != -1 && target.getEnchantments().size() >= maxEnchants.getValue()) {
+        if (IsEnchantmentAmountAllowed(target)) {
             return null;
         }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This pr adds a way to sets a limit of how many enchants can go on an item.
Default is false
Default of the max enchants when its enabled is 10.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added an item setting that checks for a limit on how many enchants can go on an item.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3447 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
