### PR TITLE
fix `/sf versions` permission

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -58,7 +58,7 @@ permissions:
     default: op
   slimefun.command.versions:
     description: Allows you to do /sf versions
-    default: op
+    default: true
   slimefun.command.backpack:
     description: Allows you to do /sf backpack
     default: op


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
everyone can use `/sf versions` command
client plugin [SlimefunEssentials](https://github.com/JustAHuman-xD/SlimefunEssentials) mayve use this command
get addons list

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
`plugins.yml` 
`slimefun.command.versions`
`default: true`

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
