### PR TITLE
fix sadle dupe

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -21,6 +21,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Ravager;
 import org.bukkit.entity.Trident;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -194,6 +195,15 @@ public class TalismanListener implements Listener {
                     items.remove(item);
                 }
             }
+        }
+
+        /*
+         * Fixes #3254
+         * Prevents saddle duplication from entities that don't drop
+         * saddle from their loot table
+         */
+        if (!(entity instanceof Ravager)) {
+            items.removeIf(item -> item.getType() == Material.SADDLE);
         }
 
         /*


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Fixes the saddle dupe for talisman of the hunter, removes the duplicated saddle from the #getExtraDrops if the entity is given a saddle and killed by a player while the talisman procs. Ravagers drop saddle from their default loot table unlike pigs, strider, horses, etc. Tested the changes many times but will like to hear from you guys if there are other cases.

Full credit go to @FN-FAL113 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Fix the saddle duplication associated with Talisman of the hunter.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3254 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
