### PR TITLE
Add API Methods to EnergyNet

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -61,29 +61,32 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * @return An immutable {@link HashMap}
-     * With a Key of {@link Location} to a Value of {@link EnergyNetProvider}
-     * Containing all {@link EnergyNetProvider} in the Energy Network
+     * This creates an Immutable Version of {@link #generators}.
+     * Using a Key of {@link Location} to a Value of {@link EnergyNetProvider}.
+     * This Map contains all the {@link EnergyNetProvider} in this Energy Network
+     * @return {@link HashMap}
      */
     public @Nonnull Map<Location, EnergyNetProvider> getGenerators() {
         return Collections.unmodifiableMap(generators);
     }
     
     /**
-     * @return An immutable {@link HashMap}
-     * With a Key of {@link Location} to a Value of {@link EnergyNetProvider}
-     * Containing all {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CAPACITOR}
-     * in the Energy Network
+     * This creates an Immutable Version of {@link #capacitors}.
+     * Using a Key of {@link Location} to a Value of {@link EnergyNetProvider}.
+     * This Map contains all the {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CAPACITOR}
+     * in this Energy Network
+     * @return {@link Map}
      */
     public @Nonnull Map<Location, EnergyNetComponent> getCapacitors() {
         return Collections.unmodifiableMap(capacitors);
     }
     
     /**
-     * @return An immutable {@link HashMap}
-     * With a Key of {@link Location} to a Value of {@link EnergyNetProvider}
-     * Containing all {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CONSUMER}
-     * in the Energy Network
+     * This creates an Immutable Version of {@link #consumers}.
+     * Using a Key of {@link Location} to a Value of {@link EnergyNetProvider}.
+     * This Map contains all the {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CONSUMER}
+     * in this Energy .
+     * @return {@link Map}
      */
     public @Nonnull Map<Location, EnergyNetComponent> getConsumers() {
         return Collections.unmodifiableMap(consumers);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -61,32 +61,27 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * This creates an Immutable Version of {@link #generators}.
-     * Using a Key of {@link Location} to a Value of {@link EnergyNetProvider}.
-     * This Map contains all the {@link EnergyNetProvider} in this Energy Network
-     * @return {@link HashMap}
+     * This creates an immutable {@link Map} of {@link EnergyNetProvider}s.
+     *
+     * @return An immutable {@link Map} of generators
      */
     public @Nonnull Map<Location, EnergyNetProvider> getGenerators() {
         return Collections.unmodifiableMap(generators);
     }
     
     /**
-     * This creates an Immutable Version of {@link #capacitors}.
-     * Using a Key of {@link Location} to a Value of {@link EnergyNetProvider}.
-     * This Map contains all the {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CAPACITOR}
-     * in this Energy Network
-     * @return {@link Map}
+     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CAPACITOR} {@link EnergyNetComponent}s.
+     *
+     * @return An immutable {@link Map} of capacitors
      */
     public @Nonnull Map<Location, EnergyNetComponent> getCapacitors() {
         return Collections.unmodifiableMap(capacitors);
     }
     
     /**
-     * This creates an Immutable Version of {@link #consumers}.
-     * Using a Key of {@link Location} to a Value of {@link EnergyNetProvider}.
-     * This Map contains all the {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CONSUMER}
-     * in this Energy .
-     * @return {@link Map}
+     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CONSUMER} {@link EnergyNetComponent}s.
+     *
+     * @return An immutable {@link Map} of consumers
      */
     public @Nonnull Map<Location, EnergyNetComponent> getConsumers() {
         return Collections.unmodifiableMap(consumers);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -59,15 +59,32 @@ public class EnergyNet extends Network implements HologramOwner {
     public int getRange() {
         return RANGE;
     }
-
+    
+    /**
+     * @return An immutable {@link HashMap}
+     * With a Key of {@link Location} to a Value of {@link EnergyNetProvider}
+     * Containing all {@link EnergyNetProvider} in the Energy Network
+     */
     public @Nonnull Map<Location, EnergyNetProvider> getGenerators() {
         return Collections.unmodifiableMap(generators);
     }
     
+    /**
+     * @return An immutable {@link HashMap}
+     * With a Key of {@link Location} to a Value of {@link EnergyNetProvider}
+     * Containing all {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CAPACITOR}
+     * in the Energy Network
+     */
     public @Nonnull Map<Location, EnergyNetComponent> getCapacitors() {
         return Collections.unmodifiableMap(capacitors);
     }
     
+    /**
+     * @return An immutable {@link HashMap}
+     * With a Key of {@link Location} to a Value of {@link EnergyNetProvider}
+     * Containing all {@link EnergyNetComponent} with the {@link EnergyNetComponentType#CONSUMER}
+     * in the Energy Network
+     */
     public @Nonnull Map<Location, EnergyNetComponent> getConsumers() {
         return Collections.unmodifiableMap(consumers);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -61,7 +61,7 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * This creates an immutable {@link Map} of {@link EnergyNetProvider}s.
+     * This creates an immutable {@link Map} of {@link EnergyNetProvider}s within this EnergyNet instance.
      *
      * @return An immutable {@link Map} of generators
      */
@@ -70,7 +70,7 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CAPACITOR} {@link EnergyNetComponent}s.
+     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CAPACITOR} {@link EnergyNetComponent}s within this EnergyNet instance.
      *
      * @return An immutable {@link Map} of capacitors
      */
@@ -79,7 +79,7 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CONSUMER} {@link EnergyNetComponent}s.
+     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CONSUMER} {@link EnergyNetComponent}s within this EnergyNet instance.
      *
      * @return An immutable {@link Map} of consumers
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -60,24 +60,20 @@ public class EnergyNet extends Network implements HologramOwner {
         return RANGE;
     }
 
-    @Nonnull
-    public Map<Location, EnergyNetProvider> getGenerators() {
+    public @Nonnull Map<Location, EnergyNetProvider> getGenerators() {
         return Collections.unmodifiableMap(generators);
     }
     
-    @Nonnull
-    public Map<Location, EnergyNetComponent> getCapacitors() {
+    public @Nonnull Map<Location, EnergyNetComponent> getCapacitors() {
         return Collections.unmodifiableMap(capacitors);
     }
     
-    @Nonnull
-    public Map<Location, EnergyNetComponent> getConsumers() {
+    public @Nonnull Map<Location, EnergyNetComponent> getConsumers() {
         return Collections.unmodifiableMap(consumers);
     }
 
-    @Nonnull
     @Override
-    public String getId() {
+    public @Nonnull String getId() {
         return "ENERGY_NETWORK";
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -1,20 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.core.networks.energy;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.LongConsumer;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-
 import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.network.Network;
@@ -25,13 +10,26 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.HologramOwner;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
-
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongConsumer;
 
 /**
  * The {@link EnergyNet} is an implementation of {@link Network} that deals with
- * electrical energy being send from and to nodes.
+ * electrical energy being sent from and to nodes.
  * 
  * @author meiamsome
  * @author TheBusyBiscuit
@@ -58,7 +56,23 @@ public class EnergyNet extends Network implements HologramOwner {
     public int getRange() {
         return RANGE;
     }
+    
+    @Nonnull
+    public Map<Location, EnergyNetProvider> getGenerators() {
+        return Collections.unmodifiableMap(generators);
+    }
+    
+    @Nonnull
+    public Map<Location, EnergyNetComponent> getCapacitors() {
+        return Collections.unmodifiableMap(capacitors);
+    }
+    
+    @Nonnull
+    public Map<Location, EnergyNetComponent> getConsumers() {
+        return Collections.unmodifiableMap(consumers);
+    }
 
+    @Nonnull
     @Override
     public String getId() {
         return "ENERGY_NETWORK";
@@ -96,21 +110,17 @@ public class EnergyNet extends Network implements HologramOwner {
 
         if (component != null) {
             switch (component.getEnergyComponentType()) {
-                case CAPACITOR:
-                    capacitors.put(l, component);
-                    break;
-                case CONSUMER:
-                    consumers.put(l, component);
-                    break;
-                case GENERATOR:
+                case CAPACITOR -> capacitors.put(l, component);
+                case CONSUMER -> consumers.put(l, component);
+                case GENERATOR -> {
                     if (component instanceof EnergyNetProvider provider) {
                         generators.put(l, provider);
                     } else if (component instanceof SlimefunItem item) {
                         item.warn("This Item is marked as a GENERATOR but does not implement the interface EnergyNetProvider!");
                     }
-                    break;
-                default:
-                    break;
+                }
+                default -> {
+                }
             }
         }
     }
@@ -261,10 +271,10 @@ public class EnergyNet extends Network implements HologramOwner {
     private void updateHologram(@Nonnull Block b, double supply, double demand) {
         if (demand > supply) {
             String netLoss = NumberUtils.getCompactDouble(demand - supply);
-            updateHologram(b, "&4&l- &c" + netLoss + " &7J &e\u26A1");
+            updateHologram(b, "&4&l- &c" + netLoss + " &7J &e⚡");
         } else {
             String netGain = NumberUtils.getCompactDouble(supply - demand);
-            updateHologram(b, "&2&l+ &a" + netGain + " &7J &e\u26A1");
+            updateHologram(b, "&2&l+ &a" + netGain + " &7J &e⚡");
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -61,7 +61,7 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * This creates an immutable {@link Map} of {@link EnergyNetProvider}s within this EnergyNet instance.
+     * This creates an immutable {@link Map} of {@link EnergyNetProvider}s within this {@link EnergyNet} instance.
      *
      * @return An immutable {@link Map} of generators
      */
@@ -70,7 +70,7 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CAPACITOR} {@link EnergyNetComponent}s within this EnergyNet instance.
+     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CAPACITOR} {@link EnergyNetComponent}s within this {@link EnergyNet} instance.
      *
      * @return An immutable {@link Map} of capacitors
      */
@@ -79,7 +79,7 @@ public class EnergyNet extends Network implements HologramOwner {
     }
     
     /**
-     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CONSUMER} {@link EnergyNetComponent}s within this EnergyNet instance.
+     * This creates an immutable {@link Map} of {@link EnergyNetComponentType#CONSUMER} {@link EnergyNetComponent}s within this {@link EnergyNet} instance.
      *
      * @return An immutable {@link Map} of consumers
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -1,5 +1,21 @@
 package io.github.thebusybiscuit.slimefun4.core.networks.energy;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongConsumer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+
 import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.network.Network;
@@ -10,22 +26,9 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.HologramOwner;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
+
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.LongConsumer;
 
 /**
  * The {@link EnergyNet} is an implementation of {@link Network} that deals with
@@ -56,7 +59,7 @@ public class EnergyNet extends Network implements HologramOwner {
     public int getRange() {
         return RANGE;
     }
-    
+
     @Nonnull
     public Map<Location, EnergyNetProvider> getGenerators() {
         return Collections.unmodifiableMap(generators);
@@ -110,17 +113,21 @@ public class EnergyNet extends Network implements HologramOwner {
 
         if (component != null) {
             switch (component.getEnergyComponentType()) {
-                case CAPACITOR -> capacitors.put(l, component);
-                case CONSUMER -> consumers.put(l, component);
-                case GENERATOR -> {
+                case CAPACITOR:
+                    capacitors.put(l, component);
+                    break;
+                case CONSUMER:
+                    consumers.put(l, component);
+                    break;
+                case GENERATOR:
                     if (component instanceof EnergyNetProvider provider) {
                         generators.put(l, provider);
                     } else if (component instanceof SlimefunItem item) {
                         item.warn("This Item is marked as a GENERATOR but does not implement the interface EnergyNetProvider!");
                     }
-                }
-                default -> {
-                }
+                    break;
+                default:
+                    break;
             }
         }
     }
@@ -271,10 +278,10 @@ public class EnergyNet extends Network implements HologramOwner {
     private void updateHologram(@Nonnull Block b, double supply, double demand) {
         if (demand > supply) {
             String netLoss = NumberUtils.getCompactDouble(demand - supply);
-            updateHologram(b, "&4&l- &c" + netLoss + " &7J &e⚡");
+            updateHologram(b, "&4&l- &c" + netLoss + " &7J &e\u26A1");
         } else {
             String netGain = NumberUtils.getCompactDouble(supply - demand);
-            updateHologram(b, "&2&l+ &a" + netGain + " &7J &e⚡");
+            updateHologram(b, "&2&l+ &a" + netGain + " &7J &e\u26A1");
         }
     }
 


### PR DESCRIPTION
## Description
I am making this pull request to add 3 API methods to the EnergyNet class.
This would allow either Core Slimefun or Addons to access what is a part of a given energy network allowing for the addition of multiple approved suggestions as well as QOL additions.

## Proposed changes
Added three getter methods that return an unmodifiable version of the three custom Maps available in the EnergyNet class. Those being, getGenerators, getCapacitors, getConsumers.
Fixed a typo in the java docs.
Annotated getId to be Nonnull as it was not already

## Related Issues (if applicable)
There are no Related issues however these API changes can be used to implement, for example, https://discord.com/channels/565557184348422174/627048923122499584/1068050940294340608

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
