### PR TITLE
Fix #3724

### DIFF
--- a/src/main/resources/tags/mangrove_base_blocks.json
+++ b/src/main/resources/tags/mangrove_base_blocks.json
@@ -2,6 +2,9 @@
   "values" : [
     "#slimefun:dirt_variants",
     "minecraft:clay",
-    "minecraft:mud"
+    {
+      "id" : "minecraft:mud",
+      "required" : false
+    }
   ]
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Fixes error at startup saying mud is not a valid minecraft item on 1.16 and 1.17

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
make mud not required so 1.16 and 1.17 will not show an error

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3724

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
