### PR TITLE
fix soulbound listener bugs when death

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SoulboundListener.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Slime;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -16,6 +17,8 @@ import org.bukkit.inventory.ItemStack;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Soulbound;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 
 /**
  * This {@link Listener} is responsible for handling any {@link Soulbound} items.
@@ -58,20 +61,16 @@ public class SoulboundListener implements Listener {
 
         // Remove soulbound items from our drops
         e.getDrops().removeIf(itemStack -> SlimefunUtils.isSoulbound(itemStack, p.getWorld()));
-    }
-
-    @EventHandler
-    public void onRespawn(PlayerRespawnEvent e) {
-        returnSoulboundItems(e.getPlayer());
-    }
-
-    private void returnSoulboundItems(@Nonnull Player p) {
-        Map<Integer, ItemStack> items = soulbound.remove(p.getUniqueId());
-
-        if (items != null) {
-            for (Map.Entry<Integer, ItemStack> entry : items.entrySet()) {
-                p.getInventory().setItem(entry.getKey(), entry.getValue());
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                Map<Integer, ItemStack> items = soulbound.remove(p.getUniqueId());
+                if (items != null) {
+                    for (Map.Entry<Integer, ItemStack> entry : items.entrySet()) {
+                        p.getInventory().setItem(entry.getKey(), entry.getValue());
+                    }
+                }
             }
-        }
+        }.runTaskLater(JavaPlugin.getPlugin(Slimefun.class), 1);
     }
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
To fix soulbound listener bugs when death.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Set items in player inventory 1 tick after death.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Rewsolves #3774 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [√] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [√] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [√] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [√] I followed the existing code standards and didn't mess up the formatting.
- [√] I did my best to add documentation to any public classes or methods I added.
- [√] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [√] I added sufficient Unit Tests to cover my code.
