### PR TITLE
Fix Energy Nets Over&Underflowing

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -159,7 +159,7 @@ public class EnergyNet extends Network implements HologramOwner {
         } else {
             int generatorsSupply = tickAllGenerators(timestamp::getAndAdd);
             int capacitorsSupply = tickAllCapacitors();
-            int supply = flowSafeAddition(generatorsSupply, capacitorsSupply);
+            int supply = NumberUtils.flowSafeAddition(generatorsSupply, capacitorsSupply);
             int remainingEnergy = supply;
             int demand = 0;
 
@@ -171,7 +171,7 @@ public class EnergyNet extends Network implements HologramOwner {
 
                 if (charge < capacity) {
                     int availableSpace = capacity - charge;
-                    demand = flowSafeAddition(demand, availableSpace);
+                    demand = NumberUtils.flowSafeAddition(demand, availableSpace);
 
                     if (remainingEnergy > 0) {
                         if (remainingEnergy > availableSpace) {
@@ -247,7 +247,7 @@ public class EnergyNet extends Network implements HologramOwner {
                 int energy = provider.getGeneratedOutput(loc, data);
 
                 if (provider.isChargeable()) {
-                    energy = flowSafeAddition(energy, provider.getCharge(loc, data));
+                    energy = NumberUtils.flowSafeAddition(energy, provider.getCharge(loc, data));
                 }
 
                 if (provider.willExplode(loc, data)) {
@@ -259,7 +259,7 @@ public class EnergyNet extends Network implements HologramOwner {
                         loc.getWorld().createExplosion(loc, 0F, false);
                     });
                 } else {
-                    supply = flowSafeAddition(supply, energy);
+                    supply = NumberUtils.flowSafeAddition(supply, energy);
                 }
             } catch (Exception | LinkageError throwable) {
                 explodedBlocks.add(loc);
@@ -282,28 +282,10 @@ public class EnergyNet extends Network implements HologramOwner {
         int supply = 0;
 
         for (Map.Entry<Location, EnergyNetComponent> entry : capacitors.entrySet()) {
-            supply = flowSafeAddition(supply, entry.getValue().getCharge(entry.getKey()));
+            supply = NumberUtils.flowSafeAddition(supply, entry.getValue().getCharge(entry.getKey()));
         }
 
         return supply;
-    }
-    
-    /**
-     * This detects if 2 integers will overflow/underflow and if they will, returns the corresponding value
-     * @param i1 the first integer
-     * @param i2 the second integer
-     * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of i1 and i2
-     */
-    private int flowSafeAddition(int i1, int i2) {
-        boolean willOverflow = (i1 == Integer.MAX_VALUE && i2 > 0 || i2 == Integer.MAX_VALUE && i1 > 0) || i1 > 0 && i2 > Integer.MAX_VALUE - i1;
-        boolean willUnderflow = (i1 == Integer.MIN_VALUE && i2 < 0 || i2 == Integer.MIN_VALUE && i1 < 0) || i1 < 0 && i2 < Integer.MIN_VALUE - i1;
-        if (willOverflow) {
-            return Integer.MAX_VALUE;
-        } else if (willUnderflow) {
-            return Integer.MIN_VALUE;
-        } else {
-            return i1 + i2;
-        }
     }
 
     private void updateHologram(@Nonnull Block b, double supply, double demand) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -295,8 +295,8 @@ public class EnergyNet extends Network implements HologramOwner {
      * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of i1 and i2
      */
     private int flowSafeAddition(int i1, int i2) {
-        boolean willOverflow = (i1 == Integer.MAX_VALUE && i2 > 0|| i2 == Integer.MAX_VALUE && i1 > 0) || i1 > 0 && i2 > Integer.MAX_VALUE - i1;
-        boolean willUnderflow = (i1 == Integer.MIN_VALUE && i2 < 0|| i2 == Integer.MIN_VALUE && i1 < 0) || i1 < 0 && i2 < Integer.MIN_VALUE - i1;
+        boolean willOverflow = (i1 == Integer.MAX_VALUE && i2 > 0 || i2 == Integer.MAX_VALUE && i1 > 0) || i1 > 0 && i2 > Integer.MAX_VALUE - i1;
+        boolean willUnderflow = (i1 == Integer.MIN_VALUE && i2 < 0 || i2 == Integer.MIN_VALUE && i1 < 0) || i1 < 0 && i2 < Integer.MIN_VALUE - i1;
         if (willOverflow) {
             return Integer.MAX_VALUE;
         } else if (willUnderflow) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -289,18 +289,18 @@ public final class NumberUtils {
      * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of a and b
      */
     public static int flowSafeAddition(int a, int b) {
-        return limitedAddition(a, b, Integer.MAX_VALUE, Integer.MIN_VALUE);
+        return limitedAddition(a, b, Integer.MIN_VALUE, Integer.MAX_VALUE);
     }
     
     /**
      * This detects if 2 integers will overflow/underflow past a maximum or minimum value and if they will, returns the corresponding value
      * @param a the first integer
      * @param b the second integer
-     * @param max the maximum value for the operation
      * @param min the minimum value for the operation
+     * @param max the maximum value for the operation
      * @return max if overflow detected, min if underflow detected, otherwise the sum of a and b
      */
-    public static int limitedAddition(int a, int b, int max, int min) {
+    public static int limitedAddition(int a, int b, int min, int max) {
         boolean willOverflow = (a == max && b > 0 || b == max && a > 0) || a > 0 && b > max - a;
 
         if (willOverflow) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -302,10 +302,14 @@ public final class NumberUtils {
      */
     public static int limitedAddition(int a, int b, int max, int min) {
         boolean willOverflow = (a == max && b > 0 || b == max && a > 0) || a > 0 && b > max - a;
-        boolean willUnderflow = (a == min && b < 0 || b == min && a < 0) || a < 0 && b < min - a;
+
         if (willOverflow) {
             return max;
-        } else if (willUnderflow) {
+        }
+
+        boolean willUnderflow = (a == min && b < 0 || b == min && a < 0) || a < 0 && b < min - a;
+
+        if (willUnderflow) {
             return min;
         } else {
             return a + b;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -286,7 +286,7 @@ public final class NumberUtils {
      * This detects if 2 integers will overflow/underflow and if they will, returns the corresponding value
      * @param a the first integer
      * @param b the second integer
-     * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of i1 and i2
+     * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of a and b
      */
     public static int flowSafeAddition(int a, int b) {
         return limitedAddition(a, b, Integer.MAX_VALUE, Integer.MIN_VALUE);
@@ -298,7 +298,7 @@ public final class NumberUtils {
      * @param b the second integer
      * @param max the maximum value for the operation
      * @param min the minimum value for the operation
-     * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of i1 and i2
+     * @return max if overflow detected, min if underflow detected, otherwise the sum of a and b
      */
     public static int limitedAddition(int a, int b, int max, int min) {
         boolean willOverflow = (a == max && b > 0 || b == max && a > 0) || a > 0 && b > max - a;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -281,4 +281,34 @@ public final class NumberUtils {
             return 0;
         }
     }
+    
+    /**
+     * This detects if 2 integers will overflow/underflow and if they will, returns the corresponding value
+     * @param a the first integer
+     * @param b the second integer
+     * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of i1 and i2
+     */
+    public static int flowSafeAddition(int a, int b) {
+        return limitedAddition(a, b, Integer.MAX_VALUE, Integer.MIN_VALUE);
+    }
+    
+    /**
+     * This detects if 2 integers will overflow/underflow past a maximum or minimum value and if they will, returns the corresponding value
+     * @param a the first integer
+     * @param b the second integer
+     * @param max the maximum value for the operation
+     * @param min the minimum value for the operation
+     * @return {@link Integer#MAX_VALUE} if overflow detected, {@link Integer#MIN_VALUE} if underflow detected, otherwise the sum of i1 and i2
+     */
+    public static int limitedAddition(int a, int b, int max, int min) {
+        boolean willOverflow = (a == max && b > 0 || b == max && a > 0) || a > 0 && b > max - a;
+        boolean willUnderflow = (a == min && b < 0 || b == min && a < 0) || a < 0 && b < min - a;
+        if (willOverflow) {
+            return max;
+        } else if (willUnderflow) {
+            return min;
+        } else {
+            return a + b;
+        }
+    }
 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestNumberUtils.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestNumberUtils.java
@@ -91,4 +91,29 @@ class TestNumberUtils {
         Assertions.assertEquals("-2Q", NumberUtils.getCompactDouble(-2000000000000000.0));
     }
 
+    @Test
+    @DisplayName("Test flow safe addition")
+    void testFlowSafeAddition() {
+        Assertions.assertEquals(Integer.MAX_VALUE, NumberUtils.flowSafeAddition(Integer.MAX_VALUE, 1));
+        Assertions.assertEquals(Integer.MAX_VALUE, NumberUtils.flowSafeAddition(1, Integer.MAX_VALUE));
+        Assertions.assertEquals(Integer.MAX_VALUE, NumberUtils.flowSafeAddition(Integer.MAX_VALUE - 1, 2));
+        Assertions.assertEquals(Integer.MAX_VALUE, NumberUtils.flowSafeAddition(2, Integer.MAX_VALUE - 1));
+        Assertions.assertEquals(Integer.MIN_VALUE, NumberUtils.flowSafeAddition(Integer.MIN_VALUE, -1));
+        Assertions.assertEquals(Integer.MIN_VALUE, NumberUtils.flowSafeAddition(-1, Integer.MIN_VALUE));
+        Assertions.assertEquals(Integer.MIN_VALUE, NumberUtils.flowSafeAddition(Integer.MIN_VALUE + 1, -2));
+        Assertions.assertEquals(Integer.MIN_VALUE, NumberUtils.flowSafeAddition(-2, Integer.MIN_VALUE + 1));
+    }
+    
+    @Test
+    @DisplayName("Test limited addition")
+    void testLimitedAddition() {
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(1000, 1, 1000, -1000));
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(1, 1000, 1000, -1000));
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(999, 2, 1000, -1000));
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(2, 999, 1000, -1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-1000, -1, 1000, -1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-1, -1000, 1000, -1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-999, -2, 1000, -1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-2, -999, 1000, -1000));
+    }
 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestNumberUtils.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestNumberUtils.java
@@ -107,13 +107,13 @@ class TestNumberUtils {
     @Test
     @DisplayName("Test limited addition")
     void testLimitedAddition() {
-        Assertions.assertEquals(1000, NumberUtils.limitedAddition(1000, 1, 1000, -1000));
-        Assertions.assertEquals(1000, NumberUtils.limitedAddition(1, 1000, 1000, -1000));
-        Assertions.assertEquals(1000, NumberUtils.limitedAddition(999, 2, 1000, -1000));
-        Assertions.assertEquals(1000, NumberUtils.limitedAddition(2, 999, 1000, -1000));
-        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-1000, -1, 1000, -1000));
-        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-1, -1000, 1000, -1000));
-        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-999, -2, 1000, -1000));
-        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-2, -999, 1000, -1000));
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(1000, 1, -1000, 1000));
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(1, 1000, -1000, 1000));
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(999, 2, -1000, 1000));
+        Assertions.assertEquals(1000, NumberUtils.limitedAddition(2, 999, -1000, 1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-1000, -1, -1000, 1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-1, -1000, -1000, 1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-999, -2, -1000, 1000));
+        Assertions.assertEquals(-1000, NumberUtils.limitedAddition(-2, -999, -1000, 1000));
     }
 }


### PR DESCRIPTION
## Description
As a player it can get really frustrating when all of your energy just gets voided due to overflow and if someone somehow achieves underflow that would be free energy which we do not want.

## Proposed changes
Added NumberUtils#limitedAddition()
Added NumberUtils#flowSafeAddition() and change the corresponding += and -= to use that method

## Related Issues (if applicable)
Resolves #3758

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
