### PR TITLE
Ancient Pedestal Fixes

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -131,8 +131,8 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
     }
     
     private boolean testArmorStand(@Nullable Entity n) {
-        if (n instanceof ArmorStand armorStand && armorStand.isValid()) {
-            String customName = armorStand.getCustomName();
+        if (n instanceof ArmorStand && n.isValid()) {
+            String customName = n.getCustomName();
             return customName != null && customName.startsWith(ITEM_PREFIX);
         } else {
             return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -6,8 +6,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.core.attributes.NotHopperable;
-import io.github.thebusybiscuit.slimefun4.utils.ArmorStandUtils;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Sound;
@@ -27,6 +25,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.core.attributes.NotHopperable;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockDispenseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -34,6 +33,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.handlers.SimpleBlockBre
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.AncientAltarListener;
 import io.github.thebusybiscuit.slimefun4.implementation.tasks.AncientAltarTask;
+import io.github.thebusybiscuit.slimefun4.utils.ArmorStandUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
 /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -181,6 +181,8 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
             entity.setVelocity(new Vector(0, 0.1, 0));
             entity.setCustomNameVisible(true);
             entity.setCustomName(nametag);
+            armorStand.setCustomName(nametag);
+            armorStand.setCustomNameVisible(false);
             armorStand.addPassenger(entity);
             SlimefunUtils.markAsNoPickup(entity, "altar_item");
             p.playSound(b.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.3F, 0.3F);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -141,14 +141,12 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
 
     public @Nonnull ItemStack getOriginalItemStack(@Nonnull Item item) {
         ItemStack stack = item.getItemStack().clone();
+        ItemMeta im = stack.getItemMeta();
         String customName = item.getCustomName();
+        im.setDisplayName(null);
+        stack.setItemMeta(im);
 
-        if (customName != null && customName.equals(ItemUtils.getItemName(new ItemStack(stack.getType())))) {
-            ItemMeta im = stack.getItemMeta();
-            im.setDisplayName(null);
-            stack.setItemMeta(im);
-        } else {
-            ItemMeta im = stack.getItemMeta();
+        if (customName == null || !customName.equals(ItemUtils.getItemName(stack))) {
             im.setDisplayName(customName);
             stack.setItemMeta(im);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -143,7 +143,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
         ItemStack stack = item.getItemStack().clone();
         String customName = item.getCustomName();
 
-        if (customName.equals(ItemUtils.getItemName(new ItemStack(stack.getType())))) {
+        if (customName != null && customName.equals(ItemUtils.getItemName(new ItemStack(stack.getType())))) {
             ItemMeta im = stack.getItemMeta();
             im.setDisplayName(null);
             stack.setItemMeta(im);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -9,7 +9,6 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
@@ -155,6 +154,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
         }
 
         ArmorStand hologram = ArmorStandUtils.spawnArmorStand(l);
+        hologram.setCustomNameVisible(true);
         hologram.setCustomName(nametag);
         return hologram;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.blocks;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.ArmorStandUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -153,21 +154,9 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
             return null;
         }
 
-        ArmorStand hologram = spawnArmorStand(l);
+        ArmorStand hologram = ArmorStandUtils.spawnArmorStand(l);
         hologram.setCustomName(nametag);
         return hologram;
-    }
-
-    private static @Nonnull ArmorStand spawnArmorStand(@Nonnull Location l) {
-        ArmorStand armorStand = (ArmorStand) l.getWorld().spawnEntity(l, EntityType.ARMOR_STAND);
-        armorStand.setVisible(false);
-        armorStand.setSilent(true);
-        armorStand.setMarker(true);
-        armorStand.setGravity(false);
-        armorStand.setBasePlate(false);
-        armorStand.setCustomNameVisible(true);
-        armorStand.setRemoveWhenFarAway(false);
-        return armorStand;
     }
 
     private static void killArmorStand(@Nonnull Block b) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -3,7 +3,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.blocks;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.utils.ArmorStandUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -26,6 +25,7 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.BlockUseHandler;
 import io.github.thebusybiscuit.slimefun4.core.services.holograms.HologramsService;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.handlers.SimpleBlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.utils.ArmorStandUtils;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -152,11 +152,8 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
         if (!createIfNoneExists) {
             return null;
         }
-
-        ArmorStand hologram = ArmorStandUtils.spawnArmorStand(l);
-        hologram.setCustomNameVisible(true);
-        hologram.setCustomName(nametag);
-        return hologram;
+        
+        return ArmorStandUtils.spawnArmorStand(l, nametag);
     }
 
     private static void killArmorStand(@Nonnull Block b) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -1,12 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.utils;
 
-import io.github.thebusybiscuit.slimefun4.core.services.holograms.HologramsService;
-import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientPedestal;
-import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.HologramProjector;
+import javax.annotation.Nonnull;
+
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 
-import javax.annotation.Nonnull;
+import io.github.thebusybiscuit.slimefun4.core.services.holograms.HologramsService;
+import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientPedestal;
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.HologramProjector;
 
 /**
  * This class holds utilities for {@link ArmorStand}, useful for classes

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -1,0 +1,39 @@
+package io.github.thebusybiscuit.slimefun4.utils;
+
+import io.github.thebusybiscuit.slimefun4.core.services.holograms.HologramsService;
+import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientPedestal;
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.HologramProjector;
+import org.bukkit.Location;
+import org.bukkit.entity.ArmorStand;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This class holds utilities for {@link ArmorStand}, useful for classes
+ * dealing with {@link ArmorStand}s that are not from {@link HologramsService}
+ *
+ * @see HologramProjector
+ * @see AncientPedestal
+ *
+ * @author JustAHuman
+ */
+public class ArmorStandUtils {
+    /**
+     * Spawns an {@link ArmorStand} at the given {@link Location}
+     * (Invisible, Silent, Marker, NoGravity, NoBasePlate, Visible CustomName, NoRemoveWhenFarAway)
+     *
+     * @param location The {@link Location} to spawn the {@link ArmorStand}
+     * @return The spawned {@link ArmorStand}
+     */
+    public static ArmorStand spawnArmorStand(@Nonnull Location location) {
+        ArmorStand armorStand = location.getWorld().spawn(location, ArmorStand.class);
+        armorStand.setVisible(false);
+        armorStand.setSilent(true);
+        armorStand.setMarker(true);
+        armorStand.setGravity(false);
+        armorStand.setBasePlate(false);
+        armorStand.setCustomNameVisible(true);
+        armorStand.setRemoveWhenFarAway(false);
+        return armorStand;
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -22,7 +22,8 @@ public class ArmorStandUtils {
 
     /**
      * Spawns an {@link ArmorStand} at the given {@link Location} with the given custom name
-     * (Invisible, Silent, Marker, NoGravity, NoBasePlate, NoRemoveWhenFarAway, VisibleCustomName)
+     * <br>
+     * Set Properties: Invisible, Silent, Marker, No-Gravity, No Base Plate, Don't Remove When Far Away
      *
      * @param location The {@link Location} to spawn the {@link ArmorStand}
      * @param customName The {@link String} custom name the {@link ArmorStand} should display
@@ -38,7 +39,8 @@ public class ArmorStandUtils {
     
     /**
      * Spawns an {@link ArmorStand} at the given {@link Location}
-     * (Invisible, Silent, Marker, NoGravity, NoBasePlate, NoRemoveWhenFarAway)
+     * <br>
+     * Set Properties: Invisible, Silent, Marker, No-Gravity, No Base Plate, Don't Remove When Far Away
      *
      * @param location The {@link Location} to spawn the {@link ArmorStand}
      *

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -19,6 +19,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.HologramPr
  * @author JustAHuman
  */
 public class ArmorStandUtils {
+
     /**
      * Spawns an {@link ArmorStand} at the given {@link Location} with the given custom name
      * (Invisible, Silent, Marker, NoGravity, NoBasePlate, NoRemoveWhenFarAway, VisibleCustomName)

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -28,8 +28,7 @@ public class ArmorStandUtils {
      *
      * @return The spawned {@link ArmorStand}
      */
-    @Nonnull
-    public static ArmorStand spawnArmorStand(@Nonnull Location location, @Nonnull String customName) {
+    public static @Nonnull ArmorStand spawnArmorStand(@Nonnull Location location, @Nonnull String customName) {
         ArmorStand armorStand = spawnArmorStand(location);
         armorStand.setCustomName(customName);
         armorStand.setCustomNameVisible(true);
@@ -44,8 +43,7 @@ public class ArmorStandUtils {
      *
      * @return The spawned {@link ArmorStand}
      */
-    @Nonnull
-    public static ArmorStand spawnArmorStand(@Nonnull Location location) {
+    public static @Nonnull ArmorStand spawnArmorStand(@Nonnull Location location) {
         return location.getWorld().spawn(location, ArmorStand.class, armorStand -> {
             armorStand.setVisible(false);
             armorStand.setSilent(true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -19,12 +19,31 @@ import javax.annotation.Nonnull;
  */
 public class ArmorStandUtils {
     /**
+     * Spawns an {@link ArmorStand} at the given {@link Location} with the given custom name
+     * (Invisible, Silent, Marker, NoGravity, NoBasePlate, NoRemoveWhenFarAway, VisibleCustomName)
+     *
+     * @param location The {@link Location} to spawn the {@link ArmorStand}
+     * @param customName The {@link String} custom name the {@link ArmorStand} should display
+     *
+     * @return The spawned {@link ArmorStand}
+     */
+    @Nonnull
+    public static ArmorStand spawnArmorStand(@Nonnull Location location, @Nonnull String customName) {
+        ArmorStand armorStand = spawnArmorStand(location);
+        armorStand.setCustomName(customName);
+        armorStand.setCustomNameVisible(true);
+        return armorStand;
+    }
+    
+    /**
      * Spawns an {@link ArmorStand} at the given {@link Location}
      * (Invisible, Silent, Marker, NoGravity, NoBasePlate, NoRemoveWhenFarAway)
      *
      * @param location The {@link Location} to spawn the {@link ArmorStand}
+     *
      * @return The spawned {@link ArmorStand}
      */
+    @Nonnull
     public static ArmorStand spawnArmorStand(@Nonnull Location location) {
         ArmorStand armorStand = location.getWorld().spawn(location, ArmorStand.class);
         armorStand.setVisible(false);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 public class ArmorStandUtils {
     /**
      * Spawns an {@link ArmorStand} at the given {@link Location}
-     * (Invisible, Silent, Marker, NoGravity, NoBasePlate, Visible CustomName, NoRemoveWhenFarAway)
+     * (Invisible, Silent, Marker, NoGravity, NoBasePlate, NoRemoveWhenFarAway)
      *
      * @param location The {@link Location} to spawn the {@link ArmorStand}
      * @return The spawned {@link ArmorStand}
@@ -32,7 +32,6 @@ public class ArmorStandUtils {
         armorStand.setMarker(true);
         armorStand.setGravity(false);
         armorStand.setBasePlate(false);
-        armorStand.setCustomNameVisible(true);
         armorStand.setRemoveWhenFarAway(false);
         return armorStand;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -46,13 +46,13 @@ public class ArmorStandUtils {
      */
     @Nonnull
     public static ArmorStand spawnArmorStand(@Nonnull Location location) {
-        ArmorStand armorStand = location.getWorld().spawn(location, ArmorStand.class);
-        armorStand.setVisible(false);
-        armorStand.setSilent(true);
-        armorStand.setMarker(true);
-        armorStand.setGravity(false);
-        armorStand.setBasePlate(false);
-        armorStand.setRemoveWhenFarAway(false);
-        return armorStand;
+        return location.getWorld().spawn(location, ArmorStand.class, armorStand -> {
+            armorStand.setVisible(false);
+            armorStand.setSilent(true);
+            armorStand.setMarker(true);
+            armorStand.setGravity(false);
+            armorStand.setBasePlate(false);
+            armorStand.setRemoveWhenFarAway(false);
+        });
     }
 }


### PR DESCRIPTION
## Description
To fix the various problems people can encounter with the ancient pedestal, this is my re-write of #3637 

## Proposed changes
- Added ArmorStandUtils.java
- Added ArmorStandUtils#createArmorStand
- HologramProjector now uses ArmorStandUtils#createArmorStand
- Ancient Pedestal now implements NotHopperable
- Ancient Pedestal now uses ArmorStandUtils#createArmorStand to create an invisible armorstand, and sets the item as its passenger to prevent it from being moved by things like fluids and falling blocks
- Marked the item for an ancient pedestal be Invulnerable & UnlimitedLifeTime (To fix items despawning and making players loose their items)

## Related Issues (if applicable)
Resolves #2940 
Resolves #3147
Resolves #3444
Resolves #3507 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
