### PR TITLE
Fix Disabled Items Shifting Multiblock Recipes

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -9,7 +9,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.commons.lang.Validate;
+
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -104,7 +107,8 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     @Override
     public void load() {
         super.load();
-        
+
+        Preconditions.checkArgument(displayRecipes.size() % 2 == 0, "This MultiBlockMachine's display recipes were illegally modified!");
         for (int i = 0; i < displayRecipes.size(); i += 2) {
             ItemStack inputStack = displayRecipes.get(i);
             ItemStack outputStack = displayRecipes.size() >= i + 2 ? displayRecipes.get(i + 1) : null;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -118,7 +118,6 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
 
             SlimefunItem inputItem = SlimefunItem.getByItem(inputStack);
             SlimefunItem outputItem = SlimefunItem.getByItem(outputStack);
-            
             if ((inputItem == null || !inputItem.isDisabled()) && (outputItem == null || !outputItem.isDisabled())) {
                 recipes.add(new ItemStack[] { inputStack });
                 recipes.add(new ItemStack[] { outputStack });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -111,7 +111,13 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         Preconditions.checkArgument(displayRecipes.size() % 2 == 0, "This MultiBlockMachine's display recipes were illegally modified!");
         for (int i = 0; i < displayRecipes.size(); i += 2) {
             ItemStack inputStack = displayRecipes.get(i);
-            ItemStack outputStack = displayRecipes.size() >= i + 2 ? displayRecipes.get(i + 1) : null;
+            ItemStack outputStack:
+            if (displayRecipes.size() >= i + 2) {
+                outputStack = displayRecipes.get(i + 1);
+            } else {
+                outputStack = null;
+            }
+
             SlimefunItem inputItem = SlimefunItem.getByItem(inputStack);
             SlimefunItem outputItem = SlimefunItem.getByItem(outputStack);
             

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -111,11 +111,9 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         Preconditions.checkArgument(displayRecipes.size() % 2 == 0, "This MultiBlockMachine's display recipes were illegally modified!");
         for (int i = 0; i < displayRecipes.size(); i += 2) {
             ItemStack inputStack = displayRecipes.get(i);
-            ItemStack outputStack;
+            ItemStack outputStack = null;
             if (displayRecipes.size() >= i + 2) {
                 outputStack = displayRecipes.get(i + 1);
-            } else {
-                outputStack = null;
             }
 
             SlimefunItem inputItem = SlimefunItem.getByItem(inputStack);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -111,7 +111,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         Preconditions.checkArgument(displayRecipes.size() % 2 == 0, "This MultiBlockMachine's display recipes were illegally modified!");
         for (int i = 0; i < displayRecipes.size(); i += 2) {
             ItemStack inputStack = displayRecipes.get(i);
-            ItemStack outputStack:
+            ItemStack outputStack;
             if (displayRecipes.size() >= i + 2) {
                 outputStack = displayRecipes.get(i + 1);
             } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -117,6 +117,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
 
             if ((inputItem == null || !inputItem.isDisabled()) && (outputItem == null || !outputItem.isDisabled())) {
                 recipes.add(new ItemStack[] { inputStack });
+                recipes.add(new ItemStack[] { outputStack });
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -105,16 +105,12 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     public void load() {
         super.load();
         
-        for (ItemStack inputStack : displayRecipes) {
-            int index = displayRecipes.indexOf(inputStack);
-            if (index % 2 != 0) {
-                continue;
-            }
-            
-            ItemStack outputStack = displayRecipes.size() - 1 < index + 1 ? null : displayRecipes.get(index + 1);
+        for (int i = 0; i < displayRecipes.size(); i += 2) {
+            ItemStack inputStack = displayRecipes.size() >= i + 1 ? displayRecipes.get(i) : null;
+            ItemStack outputStack = displayRecipes.size() >= i + 2 ? displayRecipes.get(i + 1) : null;
             SlimefunItem inputItem = SlimefunItem.getByItem(inputStack);
             SlimefunItem outputItem = SlimefunItem.getByItem(outputStack);
-
+            
             if ((inputItem == null || !inputItem.isDisabled()) && (outputItem == null || !outputItem.isDisabled())) {
                 recipes.add(new ItemStack[] { inputStack });
                 recipes.add(new ItemStack[] { outputStack });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -119,6 +119,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
 
             SlimefunItem inputItem = SlimefunItem.getByItem(inputStack);
             SlimefunItem outputItem = SlimefunItem.getByItem(outputStack);
+            // If the input/output is not a Slimefun item or it's not disabled then it's valid.
             if ((inputItem == null || !inputItem.isDisabled()) && (outputItem == null || !outputItem.isDisabled())) {
                 recipes.add(new ItemStack[] { inputStack });
                 recipes.add(new ItemStack[] { outputStack });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -104,12 +104,19 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     @Override
     public void load() {
         super.load();
+        
+        for (ItemStack inputStack : displayRecipes) {
+            int index = displayRecipes.indexOf(inputStack);
+            if (index % 2 != 0) {
+                continue;
+            }
+            
+            ItemStack outputStack = displayRecipes.size() - 1 < index + 1 ? null : displayRecipes.get(index + 1);
+            SlimefunItem inputItem = SlimefunItem.getByItem(inputStack);
+            SlimefunItem outputItem = SlimefunItem.getByItem(outputStack);
 
-        for (ItemStack recipeItem : displayRecipes) {
-            SlimefunItem item = SlimefunItem.getByItem(recipeItem);
-
-            if (item == null || !item.isDisabled()) {
-                recipes.add(new ItemStack[] { recipeItem });
+            if ((inputItem == null || !inputItem.isDisabled()) && (outputItem == null || !outputItem.isDisabled())) {
+                recipes.add(new ItemStack[] { inputStack });
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -109,6 +109,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         super.load();
 
         Preconditions.checkArgument(displayRecipes.size() % 2 == 0, "This MultiBlockMachine's display recipes were illegally modified!");
+
         for (int i = 0; i < displayRecipes.size(); i += 2) {
             ItemStack inputStack = displayRecipes.get(i);
             ItemStack outputStack = null;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -106,7 +106,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
         super.load();
         
         for (int i = 0; i < displayRecipes.size(); i += 2) {
-            ItemStack inputStack = displayRecipes.size() >= i + 1 ? displayRecipes.get(i) : null;
+            ItemStack inputStack = displayRecipes.get(i);
             ItemStack outputStack = displayRecipes.size() >= i + 2 ? displayRecipes.get(i + 1) : null;
             SlimefunItem inputItem = SlimefunItem.getByItem(inputStack);
             SlimefunItem outputItem = SlimefunItem.getByItem(outputStack);


### PR DESCRIPTION
## Description
If server owners disable specific items it can end up shifting multiblock recipes leading to either minimal or disasterous consequences. This PR aims to solve that.

## Proposed changes
Inside of MultiBlockMachine#load, instead of looping through each itemstack individually (input and output indiviudally), it now handles input and output at the same time. And checks if both are not disabled before adding both to the recipes. Previously it just went through stack at a time, so if an input was disabled the output would become the input and the next recipes input would be come the output. Now if either the input or output are disabled, neither item gets added which stops the shifting.

## Related Issues (if applicable)
Resolves #3286

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
