### PR TITLE
Fix ghost BlockStorage blocks due to iron golems, snow golems and wither spawning

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.CreatureBuildListener;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
@@ -636,6 +637,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         new BeeWingsListener(this, (BeeWings) SlimefunItems.BEE_WINGS.getItem());
         new PiglinListener(this);
         new SmithingTableListener(this);
+        new CreatureBuildListener(this);
 
         // Item-specific Listeners
         new CoolerListener(this, (Cooler) SlimefunItems.COOLER.getItem());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/CreatureBuildListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/CreatureBuildListener.java
@@ -1,0 +1,66 @@
+package io.github.thebusybiscuit.slimefun4.implementation.listeners.entity;
+
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.blockpattern.TShapedBlockPattern;
+import io.github.thebusybiscuit.slimefun4.utils.blockpattern.WitherBuildPattern;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * This {@link Listener} makes sure that iron golems, snowman (snowmen) and withers cannot be
+ * built/spawned by the player if the blocks which are used to build the creature are tracked by
+ * {@link BlockStorage}
+ */
+public class CreatureBuildListener implements Listener {
+
+    public CreatureBuildListener(Slimefun plugin) {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        // We only care about building iron golems, snowmen and withers
+        if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.BUILD_IRONGOLEM
+                && event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.BUILD_SNOWMAN
+                && event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.BUILD_WITHER) {
+            return;
+        }
+        Location location = event.getLocation();
+        Collection<Block> removedBlocks;
+        if (event.getEntityType() == EntityType.IRON_GOLEM) {
+            // Add the iron blocks
+            removedBlocks = TShapedBlockPattern.getMatchingBlocks(Material.IRON_BLOCK, location);
+            // Add the carved pumpkin head
+            removedBlocks.add(location.getBlock().getRelative(BlockFace.UP, 2));
+        } else if (event.getEntityType() == EntityType.SNOWMAN) {
+            // Add the two snow blocks and the carved pumpkin head
+            Block base = location.getBlock();
+            removedBlocks = Arrays.asList(base, base.getRelative(BlockFace.UP), base.getRelative(BlockFace.UP, 2));
+        } else if (event.getEntityType() == EntityType.WITHER) {
+            // Add the soul sand and wither skulls
+            removedBlocks = WitherBuildPattern.getMatchingBlocks(location);
+        } else {
+            // This should not happen as we checked the SpawnReason earlier
+            // This return statement is just to make the compiler happy
+            return;
+        }
+        for (Block block : removedBlocks) {
+            if (BlockStorage.hasBlockInfo(block)) {
+                // We have found a special block; we should deny the creature spawn
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/blockpattern/TShapedBlockPattern.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/blockpattern/TShapedBlockPattern.java
@@ -1,0 +1,120 @@
+package io.github.thebusybiscuit.slimefun4.utils.blockpattern;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This utility class holds methods relating to a pattern of blocks in a T-shape
+ *
+ * @author md5sha256
+ */
+@ParametersAreNonnullByDefault
+public class TShapedBlockPattern {
+
+    private TShapedBlockPattern() {
+    }
+
+    /**
+     * Get the blocks of a specified material which are in a T-shape pattern at a given location.
+     * <br>
+     * <strong>NOTE: The T-Shape is defined as 3 blocks wide and 2 blocks tall</strong>
+     * <br>
+     * This method will always check in the east-west direction before the north-south direction.
+     * The reasoning behind east-west first is to match vanilla when iron golems or withers are spawned and
+     * both directions contain a valid T-shape, the east-west direction is always preferred.
+     *
+     * @param material The {@link Material} which the blocks should match
+     * @param location The {@link Location} of the lowest block at the center, aka the base block of the T-shape
+     * @return Returns non-null {@link Collection} of {@link Block}s which match the specified {@link Material} and are
+     * in a T-Shape in no particular order
+     */
+    public static @Nonnull Collection<Block> getMatchingBlocks(Material material, Location location) {
+        Collection<Block> eastWest = getTShapeEastWest(location);
+        if (matches(material, eastWest)) {
+            return eastWest;
+        }
+        Collection<Block> northSouth = getTShapeNorthSouth(location);
+        if (matches(material, northSouth)) {
+            return northSouth;
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Check whether all the {@link Block}s in a {@link Collection} are of a specified {@link Material}
+     *
+     * @param material The material to check
+     * @param blocks   THe blocks to check
+     * @return True if all blocks are of the specified material, false otherwise
+     */
+    public static boolean matches(Material material, Collection<Block> blocks) {
+        for (Block block : blocks) {
+            if (block.getType() != material) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get the blocks which make up at T-shape facing east-west
+     *
+     * @param location The {@link Location} of the lowest block at the center, aka the base block of the T-shape
+     * @return Returns a {@link Collection} of {@link Block}s which match the T-shape
+     */
+    public static @Nonnull Collection<Block> getTShapeEastWest(Location location) {
+        Block base = location.getBlock();
+        Block center = base.getRelative(BlockFace.UP);
+        Collection<Block> blocks = new ArrayList<>(getLineEastWest(center));
+        blocks.add(base);
+        return blocks;
+    }
+
+    /**
+     * Get the blocks which make up at T-shape facing north-south
+     *
+     * @param location The {@link Location} of the lowest block at the center, aka the base block of the T-shape
+     * @return Returns a {@link Collection} of {@link Block}s which match the T-shape
+     */
+    public static @Nonnull Collection<Block> getTShapeNorthSouth(Location location) {
+        Block base = location.getBlock();
+        Block center = base.getRelative(BlockFace.UP);
+        Collection<Block> blocks = new ArrayList<>(getLineNorthSouth(center));
+        blocks.add(base);
+        return blocks;
+    }
+
+    /**
+     * Gets the blocks which are in a 3-block line facing north-south
+     *
+     * @param center The block at the center of the line
+     * @return Returns a {@link Collection} of {@link Block}s comprised of the 3 blocks
+     */
+    public static @Nonnull Collection<Block> getLineNorthSouth(Block center) {
+        Block north = center.getRelative(BlockFace.NORTH);
+        Block south = center.getRelative(BlockFace.SOUTH);
+        return Arrays.asList(center, north, south);
+    }
+
+    /**
+     * Gets the blocks which are in a 3-block line facing east-west
+     *
+     * @param center The block at the center of the line
+     * @return Returns a {@link Collection} of {@link Block}s comprised of the 3 blocks
+     */
+    public static Collection<Block> getLineEastWest(Block center) {
+        Block east = center.getRelative(BlockFace.EAST);
+        Block west = center.getRelative(BlockFace.WEST);
+        return Arrays.asList(center, east, west);
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/blockpattern/WitherBuildPattern.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/blockpattern/WitherBuildPattern.java
@@ -1,0 +1,94 @@
+package io.github.thebusybiscuit.slimefun4.utils.blockpattern;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This utility class holds methods relating to a pattern of blocks which can be used to build/spawn the wither.
+ * <br>
+ * The pattern to test for is the following: <br>
+ * $ represents a wither skeleton skull and # represents soul sand
+ * <br>
+ * $$$ <br>
+ * ### <br>
+ * &nbsp #<br>
+ * <br>
+ *
+ * @author md5sha256
+ */
+@ParametersAreNonnullByDefault
+public class WitherBuildPattern {
+
+    private WitherBuildPattern() {
+    }
+
+    /**
+     * Get the blocks which match the build pattern for a wither.
+     * <br>
+     * This method will always check in the east-west direction before the north-south direction.
+     * The reasoning behind east-west first is to match vanilla when withers are spawned and
+     * both directions contain a valid T-shape, the east-west direction is always preferred.
+     * <br>
+     * <strong>This method should not be used to test if a Wither can be spawned at this location as it does not
+     * check whether the other blocks within the pattern are air blocks.</strong>
+     *
+     * @param location The {@link Location} of the lowest block at the center, aka the base block of the build pattern
+     * @return Returns non-null {@link Collection} of {@link Block}s which are eligible for creating a wither
+     */
+    public static @Nonnull Collection<Block> getMatchingBlocks(Location location) {
+        Collection<Block> baseEastWest = TShapedBlockPattern.getTShapeEastWest(location);
+        if (TShapedBlockPattern.matches(Material.SOUL_SAND, baseEastWest)) {
+            Collection<Block> blocks = new ArrayList<>(getWitherHeadsEastWest(location));
+            if (!TShapedBlockPattern.matches(Material.WITHER_SKELETON_SKULL, blocks)) {
+                return Collections.emptyList();
+            }
+            blocks.addAll(baseEastWest);
+            return blocks;
+        }
+
+        Collection<Block> baseNorthSouth = TShapedBlockPattern.getTShapeNorthSouth(location);
+        if (TShapedBlockPattern.matches(Material.SOUL_SAND, baseNorthSouth)) {
+            Collection<Block> blocks = new ArrayList<>(getWitherHeadsNorthSouth(location));
+            if (!TShapedBlockPattern.matches(Material.WITHER_SKELETON_SKULL, blocks)) {
+                return Collections.emptyList();
+            }
+            blocks.addAll(baseNorthSouth);
+            return blocks;
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Get the blocks which should contain wither heads if the structure is facing east-west
+     *
+     * @param location The base of the wither structure
+     * @return Returns the line of blocks facing east-west
+     */
+    private static @Nonnull Collection<Block> getWitherHeadsEastWest(Location location) {
+        Block base = location.getBlock();
+        Block center = base.getRelative(BlockFace.UP, 2);
+        return TShapedBlockPattern.getLineEastWest(center);
+    }
+
+    /**
+     * Get the blocks which should contain wither heads if the structure is facing north-south
+     *
+     * @param location The base of the wither structure
+     * @return Returns the line of blocks facing north-south
+     */
+    private static @Nonnull Collection<Block> getWitherHeadsNorthSouth(Location location) {
+        Block base = location.getBlock();
+        Block center = base.getRelative(BlockFace.UP, 2);
+        return TShapedBlockPattern.getLineNorthSouth(center);
+    }
+
+
+}


### PR DESCRIPTION
## Description
Fix ghost `BlockStorage` blocks due to players building/spawning iron golems, snow golems, and withers.\

<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Fixes 2425 (tagged below)

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Adds a new listener (`CreatureBuildListener`) which cancels `CreatureSpawnEvents` if one of the blocks used to build 
either an iron golem, snow golem (EntityType#SNOWMAN), or wither is tracked by `BlockStorage` (`BlockStorage#hasInfo == true`)

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #2425

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
