### PR TITLE
Add new methods in BlockStorage and TickerTask for clearing all block info in a chunk

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -238,11 +238,14 @@ public class TickerTask implements Runnable {
 
     @ParametersAreNonnullByDefault
     public void queueDelete(Collection<Location> locations, boolean destroy) {
-        Map<Location, Boolean> toDelete = new HashMap<>(locations.size());
+        Validate.notNull(locations, "Locations must not be null");
+
+        Map<Location, Boolean> toDelete = new HashMap<>(locations.size(), 1.0F);
         for (Location location : locations) {
+            Validate.notNull(location, "Locations must not contain null locations");
             toDelete.put(location, destroy);
         }
-        queueDelete(toDelete);
+        deletionQueue.putAll(toDelete);
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -1,6 +1,8 @@
 package io.github.thebusybiscuit.slimefun4.implementation.tasks;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -231,6 +233,26 @@ public class TickerTask implements Runnable {
         Validate.notNull(l, "Location must not be null!");
 
         deletionQueue.put(l, destroy);
+    }
+
+
+    @ParametersAreNonnullByDefault
+    public void queueDelete(Collection<Location> locations, boolean destroy) {
+        Map<Location, Boolean> toDelete = new HashMap<>(locations.size());
+        for (Location location : locations) {
+            toDelete.put(location, destroy);
+        }
+        queueDelete(toDelete);
+    }
+
+    @ParametersAreNonnullByDefault
+    public void queueDelete(Map<Location, Boolean> locations) {
+        Validate.notNull(locations, "Locations must not be null");
+        for (Map.Entry<Location, Boolean> entry : locations.entrySet()) {
+            Validate.notNull(entry.getKey(), "Location in locations cannot be null");
+            Validate.notNull(entry.getValue(), "Boolean toDestroy in locations cannot be null");
+        }
+        deletionQueue.putAll(locations);
     }
 
     /**

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -605,6 +607,24 @@ public class BlockStorage {
 
     public static void clearBlockInfo(Location l, boolean destroy) {
         Slimefun.getTickerTask().queueDelete(l, destroy);
+    }
+
+    public static void clearAllBlockInfoAtChunk(Chunk chunk, boolean destroy) {
+        clearAllBlockInfoAtChunk(chunk.getWorld(), chunk.getX(), chunk.getZ(), destroy);
+    }
+
+    public static void clearAllBlockInfoAtChunk(World world, int chunkX, int chunkZ, boolean destroy) {
+        BlockStorage blockStorage = getStorage(world);
+        if (blockStorage == null) {
+            return;
+        }
+        Map<Location, Boolean> toClear = new HashMap<>(blockStorage.storage.size());
+        for (Location location : blockStorage.storage.keySet()) {
+            if (location.getBlockX() >> 4 == chunkX && location.getBlockZ() >> 4 == chunkZ) {
+                toClear.put(location, destroy);
+            }
+        }
+        Slimefun.getTickerTask().queueDelete(toClear);
     }
 
     /**

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -618,7 +618,8 @@ public class BlockStorage {
             return;
         }
         Map<Location, Boolean> toClear = new HashMap<>();
-        for (Location location : blockStorage.storage.keySet()) {
+        Map<Location, Config> storage = blockStorage.getRawStorage();
+        for (Location location : storage.keySet()) {
             if (location.getBlockX() >> 4 == chunkX && location.getBlockZ() >> 4 == chunkZ) {
                 toClear.put(location, destroy);
             }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -6,7 +6,6 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -617,7 +617,7 @@ public class BlockStorage {
         if (blockStorage == null) {
             return;
         }
-        Map<Location, Boolean> toClear = new HashMap<>(blockStorage.storage.size());
+        Map<Location, Boolean> toClear = new HashMap<>();
         for (Location location : blockStorage.storage.keySet()) {
             if (location.getBlockX() >> 4 == chunkX && location.getBlockZ() >> 4 == chunkZ) {
                 toClear.put(location, destroy);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Saw #3432 and wanted to implement changes based on TheBusyBiscuit's line of thinking

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Adds two new methods in `BlockStorage` 
- `void clearAllBlockInfoAtChunk(Chunk chunk, boolean destroy)`
- `void clearAllBlockInfoAtChunk(World world, int chunkX, int chunkZ, boolean destroy)`

Adds two new methods in `TickerTask`
- `void queueDelete(Collection<Location> locations, boolean destroy)`
- `void queueDelete(Map<Location, Boolean> locations)`

Given that both `BlockStorage` and `TickerTask` are going to be rewritten anyway, I haven't added any more convenience methods that I otherwise could for bulk operations. 

In summary, the changes allow the caller to perform a bulk version of `clearBlockInfo` for locations in a specific chunk. I'm not sure how much this will reduce hitting locks within the `ConcurrentHashMap` implementation, however, I am sure this will prevent multiple table-resizing operations from occurring as the use of `Map#putAll` means the hashtable is only resized once if needed. 

I haven't performed any benchmarks just yet but the theory should be that it's faster to use `BlockStorage#clearAllBlockInfoAtChunk` than it would be to perform the same manually i.e: 
```java
public void clearAllBlockInfoAtChunk(Chunk chunk) {
     BlockStorage blockStorage = BlockStorage.getStorage(chunk.getWorld());
    if (blockStorage == null) {
        return;
    }
    int chunkX = chunk.getX();
    int chunkZ = chunk.getZ();
    Map<Location, Config> storage = blockStorage.getRawStorage();
    for (Location location : storage.keySet()) {
         if (location.getBlockX() >> 4 == chunkX && location.getBlockZ() >> 4 == chunkZ) {
              BlockStorage.clearBlockInfo(location);
         }
    }
}
```
I intend on attaching benchmarks as I'm not entirely sure if this will be faster. I've decided to make the PR just so I can have some feedback on implementing something which can perhaps reduce the impact of #3432

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3432

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
