### PR TITLE
[API] Add ShouldSave Parameter to BlockMenuPreset and BlockMenus

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -757,9 +757,7 @@ public class BlockStorage {
         }
 
         BlockMenu menu = new BlockMenu(preset, l);
-        if (!menu.isDisplay()) {
-            inventories.put(l, menu);
-        }
+        inventories.put(l, menu);
         return menu;
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -757,7 +757,9 @@ public class BlockStorage {
         }
 
         BlockMenu menu = new BlockMenu(preset, l);
-        inventories.put(l, menu);
+        if (!menu.isDisplay()) {
+            inventories.put(l, menu);
+        }
         return menu;
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -22,17 +22,13 @@ public class BlockMenu extends DirtyChestMenu {
         return l.getWorld().getName() + ';' + l.getBlockX() + ';' + l.getBlockY() + ';' + l.getBlockZ();
     }
     
-    public BlockMenu(BlockMenuPreset preset, Location l, boolean display) {
+    public BlockMenu(BlockMenuPreset preset, Location l) {
         super(preset);
         this.location = l;
-        this.display = display;
+        this.display = preset.isDisplay();
         
         preset.clone(this);
         this.getContents();
-    }
-    
-    public BlockMenu(BlockMenuPreset preset, Location l) {
-        this(preset, l, false);
     }
 
     public BlockMenu(BlockMenuPreset preset, Location l, Config cfg) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -32,12 +32,7 @@ public class BlockMenu extends DirtyChestMenu {
     }
     
     public BlockMenu(BlockMenuPreset preset, Location l) {
-        super(preset);
-        this.location = l;
-        this.display = false;
-
-        preset.clone(this);
-        this.getContents();
+        this(preset, l, false);
     }
 
     public BlockMenu(BlockMenuPreset preset, Location l, Config cfg) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -14,9 +14,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 // This class will be deprecated, relocated and rewritten in a future version.
 public class BlockMenu extends DirtyChestMenu {
-
+    
+    private final boolean display;
     private Location location;
-    private boolean display;
 
     private static String serializeLocation(Location l) {
         return l.getWorld().getName() + ';' + l.getBlockX() + ';' + l.getBlockY() + ';' + l.getBlockZ();

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -15,17 +15,17 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 // This class will be deprecated, relocated and rewritten in a future version.
 public class BlockMenu extends DirtyChestMenu {
     
-    private final boolean display;
+    private final boolean shouldSave;
     private Location location;
 
     private static String serializeLocation(Location l) {
         return l.getWorld().getName() + ';' + l.getBlockX() + ';' + l.getBlockY() + ';' + l.getBlockZ();
     }
-    
+
     public BlockMenu(BlockMenuPreset preset, Location l) {
         super(preset);
         this.location = l;
-        this.display = preset.isDisplay();
+        this.shouldSave = preset.willSave();
         
         preset.clone(this);
         this.getContents();
@@ -34,7 +34,7 @@ public class BlockMenu extends DirtyChestMenu {
     public BlockMenu(BlockMenuPreset preset, Location l, Config cfg) {
         super(preset);
         this.location = l;
-        this.display = false;
+        this.shouldSave = true;
 
         for (int i = 0; i < 54; i++) {
             if (cfg.contains(String.valueOf(i))) {
@@ -52,8 +52,7 @@ public class BlockMenu extends DirtyChestMenu {
     }
 
     public void save(Location l) {
-        // If it is not modified or just a display menu, we do not need to save it
-        if (!isDirty() || display) {
+        if (!isDirty() || !shouldSave) {
             return;
         }
 
@@ -95,8 +94,8 @@ public class BlockMenu extends DirtyChestMenu {
         return location;
     }
     
-    public boolean isDisplay() {
-        return display;
+    public boolean shouldSave() {
+        return shouldSave;
     }
 
     /**

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -16,14 +16,25 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 public class BlockMenu extends DirtyChestMenu {
 
     private Location location;
+    private boolean display;
 
     private static String serializeLocation(Location l) {
         return l.getWorld().getName() + ';' + l.getBlockX() + ';' + l.getBlockY() + ';' + l.getBlockZ();
     }
-
+    
+    public BlockMenu(BlockMenuPreset preset, Location l, boolean display) {
+        super(preset);
+        this.location = l;
+        this.display = display;
+        
+        preset.clone(this);
+        this.getContents();
+    }
+    
     public BlockMenu(BlockMenuPreset preset, Location l) {
         super(preset);
         this.location = l;
+        this.display = false;
 
         preset.clone(this);
         this.getContents();
@@ -32,6 +43,7 @@ public class BlockMenu extends DirtyChestMenu {
     public BlockMenu(BlockMenuPreset preset, Location l, Config cfg) {
         super(preset);
         this.location = l;
+        this.display = false;
 
         for (int i = 0; i < 54; i++) {
             if (cfg.contains(String.valueOf(i))) {
@@ -49,7 +61,8 @@ public class BlockMenu extends DirtyChestMenu {
     }
 
     public void save(Location l) {
-        if (!isDirty()) {
+        // If it is not modified or just a display menu, we do not need to save it
+        if (!isDirty() || display) {
             return;
         }
 
@@ -89,6 +102,10 @@ public class BlockMenu extends DirtyChestMenu {
 
     public Location getLocation() {
         return location;
+    }
+    
+    public boolean isDisplay() {
+        return display;
     }
 
     /**

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -94,7 +94,7 @@ public class BlockMenu extends DirtyChestMenu {
         return location;
     }
     
-    public boolean shouldSave() {
+    public boolean willSave() {
         return shouldSave;
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
@@ -30,30 +30,30 @@ public abstract class BlockMenuPreset extends ChestMenu {
 
     // -1 means "automatically update according to the contents"
     private int size = -1;
-    
+
     private final boolean universal;
-    private final boolean display;
+    private final boolean shouldSave;
     private boolean locked;
 
     protected BlockMenuPreset(@Nonnull String id, @Nonnull String title) {
-        this(id, title, false);
+        this(id, title, false, true);
     }
 
     protected BlockMenuPreset(@Nonnull String id, @Nonnull String title, boolean universal) {
-        this(id, title, universal, false);
+        this(id, title, universal, true);
     }
     
-    protected BlockMenuPreset(@Nonnull String id, @Nonnull String title, boolean universal, boolean display) {
+    protected BlockMenuPreset(@Nonnull String id, @Nonnull String title, boolean universal, boolean shouldSave) {
         super(title);
-    
+
         Validate.notNull(id, "You need to specify an id!");
-    
+
         this.id = id;
         this.inventoryTitle = title;
         this.universal = universal;
-        this.display = display;
+        this.shouldSave = shouldSave;
         init();
-    
+
         Slimefun.getRegistry().getMenuPresets().put(id, this);
     }
 
@@ -203,12 +203,12 @@ public abstract class BlockMenuPreset extends ChestMenu {
     }
     
     /**
-     * This method returns whether this {@link BlockMenuPreset} will spawn a {@link BlockMenu} that is Display Only
+     * This method returns whether this {@link BlockMenuPreset} will spawn a {@link BlockMenu} that saves to file
      *
-     * @return Whether this {@link BlockMenuPreset} is Display Only
+     * @return Whether this {@link BlockMenuPreset} should save
      */
-    public boolean isDisplay() {
-        return display;
+    public boolean willSave() {
+        return shouldSave;
     }
 
     @Nonnull

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
@@ -30,8 +30,9 @@ public abstract class BlockMenuPreset extends ChestMenu {
 
     // -1 means "automatically update according to the contents"
     private int size = -1;
-
+    
     private final boolean universal;
+    private final boolean display;
     private boolean locked;
 
     protected BlockMenuPreset(@Nonnull String id, @Nonnull String title) {
@@ -39,15 +40,20 @@ public abstract class BlockMenuPreset extends ChestMenu {
     }
 
     protected BlockMenuPreset(@Nonnull String id, @Nonnull String title, boolean universal) {
+        this(id, title, universal, false);
+    }
+    
+    protected BlockMenuPreset(@Nonnull String id, @Nonnull String title, boolean universal, boolean display) {
         super(title);
-
+    
         Validate.notNull(id, "You need to specify an id!");
-
+    
         this.id = id;
         this.inventoryTitle = title;
         this.universal = universal;
+        this.display = display;
         init();
-
+    
         Slimefun.getRegistry().getMenuPresets().put(id, this);
     }
 
@@ -194,6 +200,15 @@ public abstract class BlockMenuPreset extends ChestMenu {
      */
     public boolean isUniversal() {
         return universal;
+    }
+    
+    /**
+     * This method returns whether this {@link BlockMenuPreset} will spawn a {@link BlockMenu} that is Display Only
+     *
+     * @return Whether this {@link BlockMenuPreset} is Display Only
+     */
+    public boolean isDisplay() {
+        return display;
     }
 
     @Nonnull

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
@@ -6,11 +6,11 @@ import io.github.bakedlibs.dough.config.Config;
 
 // This class will be deprecated, relocated and rewritten in a future version.
 public class UniversalBlockMenu extends DirtyChestMenu {
-    private final boolean display;
+    private final boolean shouldSave;
     
     public UniversalBlockMenu(BlockMenuPreset preset) {
         super(preset);
-        this.display = preset.isDisplay();
+        this.shouldSave = preset.willSave();
         
         preset.clone(this);
 
@@ -19,7 +19,7 @@ public class UniversalBlockMenu extends DirtyChestMenu {
 
     public UniversalBlockMenu(BlockMenuPreset preset, Config cfg) {
         super(preset);
-        this.display = false;
+        this.shouldSave = true;
         
         for (int i = 0; i < 54; i++) {
             if (cfg.contains(String.valueOf(i))) {
@@ -36,8 +36,8 @@ public class UniversalBlockMenu extends DirtyChestMenu {
         this.getContents();
     }
 
-    public void save() {// If it is not modified or just a display menu, we do not need to save it
-        if (!isDirty() || display) {
+    public void save() {
+        if (!isDirty() || !shouldSave) {
             return;
         }
 
@@ -57,7 +57,7 @@ public class UniversalBlockMenu extends DirtyChestMenu {
         changes = 0;
     }
 
-    public boolean isDisplay() {
-        return this.display;
+    public boolean shouldSave() {
+        return this.shouldSave;
     }
 }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
@@ -8,17 +8,13 @@ import io.github.bakedlibs.dough.config.Config;
 public class UniversalBlockMenu extends DirtyChestMenu {
     private final boolean display;
     
-    public UniversalBlockMenu(BlockMenuPreset preset, boolean display) {
+    public UniversalBlockMenu(BlockMenuPreset preset) {
         super(preset);
-        this.display = display;
+        this.display = preset.isDisplay();
         
         preset.clone(this);
 
         save();
-    }
-    
-    public UniversalBlockMenu(BlockMenuPreset preset) {
-        this(preset, false);
     }
 
     public UniversalBlockMenu(BlockMenuPreset preset, Config cfg) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
@@ -57,7 +57,7 @@ public class UniversalBlockMenu extends DirtyChestMenu {
         changes = 0;
     }
 
-    public boolean shouldSave() {
+    public boolean willSave() {
         return this.shouldSave;
     }
 }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
@@ -6,18 +6,25 @@ import io.github.bakedlibs.dough.config.Config;
 
 // This class will be deprecated, relocated and rewritten in a future version.
 public class UniversalBlockMenu extends DirtyChestMenu {
-
-    public UniversalBlockMenu(BlockMenuPreset preset) {
+    private final boolean display;
+    
+    public UniversalBlockMenu(BlockMenuPreset preset, boolean display) {
         super(preset);
-
+        this.display = display;
+        
         preset.clone(this);
 
         save();
     }
+    
+    public UniversalBlockMenu(BlockMenuPreset preset) {
+        this(preset, false);
+    }
 
     public UniversalBlockMenu(BlockMenuPreset preset, Config cfg) {
         super(preset);
-
+        this.display = false;
+        
         for (int i = 0; i < 54; i++) {
             if (cfg.contains(String.valueOf(i))) {
                 addItem(i, cfg.getItem(String.valueOf(i)));
@@ -33,8 +40,8 @@ public class UniversalBlockMenu extends DirtyChestMenu {
         this.getContents();
     }
 
-    public void save() {
-        if (!isDirty()) {
+    public void save() {// If it is not modified or just a display menu, we do not need to save it
+        if (!isDirty() || display) {
             return;
         }
 
@@ -54,4 +61,7 @@ public class UniversalBlockMenu extends DirtyChestMenu {
         changes = 0;
     }
 
+    public boolean isDisplay() {
+        return this.display;
+    }
 }


### PR DESCRIPTION
## Description
Many Slimefun Blocks create menus to only convey information to the player, and they do not need to be saved to a file. This will help save time when saving on shutdown to help prevent the issues we see with BlockStorage taking too long and causing reverts, as well as the normal saving to file overhead no longer being a factor.

## Proposed changes
This PR adds a "shouldSave" parameter to BlockMenuPreset, thus to BlockMenu and UniversalBlockMenu.
Changes methods in BlockMenu and UniversalBlockMenu to only save if "shouldSave" is true

## Related Issues (if applicable)
I don't believe there are any issues

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
