### PR TITLE
fix: uncorrect exp spending on unlocking research

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.ExperienceUtils;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -70,7 +71,11 @@ public interface SlimefunGuideImplementation {
         if (p.getGameMode() == GameMode.CREATIVE && Slimefun.getRegistry().isFreeCreativeResearchingEnabled()) {
             research.unlock(p, true, callback);
         } else {
-            p.setLevel(p.getLevel() - research.getCost());
+            float currentExp = ExperienceUtils.getPlayerCurrentExp(p.getLevel(), p.getExp());
+            float requiredExp = ExperienceUtils.convertLevelToFloatExp(research.getCost());
+            Number[] result = ExperienceUtils.convertExpToLevelAndProgress(currentExp - requiredExp);
+            p.setLevel((int) result[0]);
+            p.setExp((float) result[1]);
 
             boolean skipLearningAnimation = Slimefun.getRegistry().isLearningAnimationDisabled() || !SlimefunGuideSettings.hasLearningAnimationEnabled(p);
             research.unlock(p, skipLearningAnimation, callback);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ExperienceUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ExperienceUtils.java
@@ -1,0 +1,71 @@
+package io.github.thebusybiscuit.slimefun4.utils;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * Some helper methods for dealing with experience converting.
+ *
+ * @author kingdom84521
+ *
+ * @see io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation
+ * @see <a href="https://minecraft.fandom.com/wiki/Experience"></>
+ *
+ */
+public final class ExperienceUtils {
+
+    /**
+     * Helper method to calculate the level to exact xp
+     *
+     * @param level
+     *            The level to convert ( in type of {@link Integer} )
+     *
+     * @return xp in type {@link Float}
+     */
+
+    public static @Nonnull float convertLevelToFloatExp(@Nonnull int level) {
+        if (level > 31) {
+            return (float) (4.5 * level * level - 162.5 * level + 2220);
+        } else if (level > 16) {
+            return (float) (2.5 * level * level - 40.5 * level + 360);
+        } else {
+            return level * level + 6 * level;
+        }
+    }
+
+    private static @Nonnull float getExpToNextLevel(@Nonnull int currentLevel) {
+        if (currentLevel > 30) {
+            return (float) 9 * currentLevel - 158;
+        } else if (currentLevel > 15) {
+            return (float) 5 * currentLevel - 38;
+        } else {
+            return (float) 2 * currentLevel + 7;
+        }
+    }
+
+    public static @Nonnull float getPlayerCurrentExp(@Nonnull int level, @Nonnull float progress) {
+        return convertLevelToFloatExp(level) + (getExpToNextLevel(level) * progress);
+    }
+
+    private static @Nonnull float convertExpToLevel(@Nonnull float exp) {
+        if (exp >= 1508) {
+            return (float) (325 + Math.sqrt(72 * exp - 54215)) / 18;
+        } else if (exp >= 353) {
+            return (float) (81 + Math.sqrt(40 * exp - 7839)) / 10;
+        } else {
+            return (float) Math.sqrt(exp + 9) - 3;
+        }
+    }
+
+    public static @Nonnull Number[] convertExpToLevelAndProgress(@Nonnull float exp) {
+        int level = (int) Math.floor(convertExpToLevel(exp));
+        float progress = convertExpToLevel(exp) - level;
+
+        Number[] levelAndProgress = new Number[2];
+
+        levelAndProgress[0] = level;
+        levelAndProgress[1] = progress;
+
+        return levelAndProgress;
+    }
+}

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestExperienceUtils.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestExperienceUtils.java
@@ -1,0 +1,20 @@
+package io.github.thebusybiscuit.slimefun4.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class TestExperienceUtils {
+    @Test
+    @DisplayName("Test ExperienceUtils.convertLevelToXp")
+    void testConvertLevelToXp() {
+        // case: level >= 32
+        Assertions.assertEquals(5345F, ExperienceUtils.convertLevelToFloatExp(50));
+
+        // case: level >= 17 && level <= 31
+        Assertions.assertEquals(910F, ExperienceUtils.convertLevelToFloatExp(25));
+
+        // case: level <= 16
+        Assertions.assertEquals(160F, ExperienceUtils.convertLevelToFloatExp(10));
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The amount of experience spending on unlocking researches is incorrect, since this process is done by Player.setLevel only.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
1. Add some formula utils for calculating the proper value for unlocking
2. Refactor the original setLevel to new utils

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [v] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [v] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [v] I followed the existing code standards and didn't mess up the formatting.
- [v] I did my best to add documentation to any public classes or methods I added.
- [v] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
