### PR TITLE
newInstance hook for createPreset

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
@@ -20,8 +20,7 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 /**
  * 
- * @deprecated This interface is not designed to be used by addons. The entire
- *             inventory system will be replaced
+ * @deprecated This interface is not designed to be used by addons. The entire inventory system will be replaced
  *             eventually.
  *
  */

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
@@ -51,9 +51,7 @@ public interface InventoryBlock {
         createPreset(item, title, null, setup);
     }
 
-    default void createPreset(SlimefunItem item, String title,
-            @Nullable BiFunction<@Nonnull BlockMenu, @Nonnull Block, Void> onNewInstance,
-            Consumer<BlockMenuPreset> setup) {
+    default void createPreset(SlimefunItem item, String title, @Nullable BiFunction<@Nonnull BlockMenu, @Nonnull Block, Void> onNewInstance, Consumer<BlockMenuPreset> setup) {
         new BlockMenuPreset(item.getId(), title) {
 
             @Override

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
@@ -75,8 +75,7 @@ public interface InventoryBlock {
                 if (p.hasPermission("slimefun.inventory.bypass")) {
                     return true;
                 } else {
-                    return item.canUse(p, false) && Slimefun.getProtectionManager().hasPermission(p, b.getLocation(),
-                            Interaction.INTERACT_BLOCK);
+                    return item.canUse(p, false) && Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK);
                 }
             }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
@@ -1,7 +1,11 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces;
 
 import java.lang.reflect.Array;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -10,13 +14,14 @@ import org.bukkit.inventory.Inventory;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 /**
  * 
- * @deprecated This interface is not designed to be used by addons. The entire inventory system will be replaced
+ * @deprecated This interface is not designed to be used by addons. The entire
+ *             inventory system will be replaced
  *             eventually.
  *
  */
@@ -43,6 +48,12 @@ public interface InventoryBlock {
     }
 
     default void createPreset(SlimefunItem item, String title, Consumer<BlockMenuPreset> setup) {
+        createPreset(item, title, null, setup);
+    }
+
+    default void createPreset(SlimefunItem item, String title,
+            @Nullable BiFunction<@Nonnull BlockMenu, @Nonnull Block, Void> onNewInstance,
+            Consumer<BlockMenuPreset> setup) {
         new BlockMenuPreset(item.getId(), title) {
 
             @Override
@@ -64,7 +75,15 @@ public interface InventoryBlock {
                 if (p.hasPermission("slimefun.inventory.bypass")) {
                     return true;
                 } else {
-                    return item.canUse(p, false) && Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK);
+                    return item.canUse(p, false) && Slimefun.getProtectionManager().hasPermission(p, b.getLocation(),
+                            Interaction.INTERACT_BLOCK);
+                }
+            }
+
+            @Override
+            public void newInstance(@Nonnull BlockMenu menu, @Nonnull Block b) {
+                if (onNewInstance != null) {
+                    onNewInstance.apply(menu, b);
                 }
             }
         };


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
createPreset is a very useful function when writing addons, it allows us to not worry about re-writing the canOpen method that handles block permissions. The only downside for common use is that you can't bind menu click events easily since there's no support for newInstance without actually creating your own BlockMenuPreset instance directly. The problem with that is you must then overwrite canOpen yourself too - which is dangerous as an Addon developer. There are reasons you might want  to do that still (such as private machines only the placer can open), but for generic use it feels quite dangerous since responding to inventory clicks is quite a common use when you add custom functionality like collecting a non-item resource manually from machines (such as XP, or maybe money)

There is probably a much better way of doing this, it's more a "proof of concept" so I didn't worry too much about formatting being messed up or fully testing this.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
An additional override for createPreset that allows passing a function to newInstance directly, thus negating the downsides for most common uses of createPreset.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

