### PR TITLE
Fix android move task

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -895,7 +895,11 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
             Slimefun.runSync(() -> {
                 PlayerSkin skin = PlayerSkin.fromBase64(texture);
-                PlayerHead.setSkin(block, skin, true);
+                Material type = block.getType();
+                // Ensure that this Block is still a Player Head
+                if (type == Material.PLAYER_HEAD || type == Material.PLAYER_WALL_HEAD) {
+                    PlayerHead.setSkin(block, skin, true);
+                }
             });
 
             b.setType(Material.AIR);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
During periods of server lag, an android may no longer be where it was previously after a move was made for any reason. This prevents the task that runs on a later tick from setting the skin of the Android and causes a console error. This change wraps a check around the setSkin in the same way as Capacitor skin updating does.

Potentially could include the conversion from base64 inside the check to save some CPU in the very rare case that the Android is not actually there.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Check if the android is actually still at the block location before trying to set a skin on it.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3443 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
