### PR TITLE
Add tradable attribute to SlimefunItem

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -110,6 +110,7 @@ public class SlimefunItem implements Placeable {
     protected boolean disenchantable = true;
     protected boolean hidden = false;
     protected boolean useableInWorkbench = false;
+    protected boolean tradable = false;
 
     private Optional<String> wikiURL = Optional.empty();
 
@@ -736,6 +737,35 @@ public class SlimefunItem implements Placeable {
      */
     public @Nonnull SlimefunItem setUseableInWorkbench(boolean useable) {
         this.useableInWorkbench = useable;
+
+        return this;
+    }
+
+    /**
+     * This method returns whether this {@link SlimefunItem} is allowed to
+     * be traded with villagers or wandering traders.
+     *
+     * Items of type {@link VanillaItem} may be used in workbenches for example.
+     *
+     * @see #setTradable(boolean)
+     *
+     * @return Whether this {@link SlimefunItem} can be traded.
+     */
+    public boolean isTradable() {
+        return tradable;
+    }
+
+    /**
+     * This sets whether this {@link SlimefunItem} is allowed to be
+     * traded with villagers or wandering traders.
+     *
+     * @param tradable
+     *            Whether this {@link SlimefunItem} should be tradable
+     *
+     * @return This instance of {@link SlimefunItem}
+     */
+    public @Nonnull SlimefunItem setTradable(boolean tradable) {
+        this.tradable = tradable;
 
         return this;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/VanillaItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/VanillaItem.java
@@ -44,6 +44,7 @@ public class VanillaItem extends SlimefunItem {
     public VanillaItem(ItemGroup itemGroup, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, id, recipeType, recipe);
 
-        useableInWorkbench = true;
+        setUseableInWorkbench(true);
+        setTradable(true);
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/SyntheticEmerald.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/SyntheticEmerald.java
@@ -27,6 +27,7 @@ public class SyntheticEmerald extends SlimefunItem {
         super(itemGroup, item, recipeType, recipe);
 
         setUseableInWorkbench(true);
+        setTradable(true);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
@@ -48,7 +48,7 @@ public class VillagerTradingListener implements Listener {
             }
 
             if (e.getResult() == Result.DENY) {
-                Slimefun.getLocalization().sendMessage((Player) e.getWhoClicked(), "villagers.no-trading", true);
+                Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "villagers.no-trading", true);
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
@@ -54,6 +54,6 @@ public class VillagerTradingListener implements Listener {
     }
 
     private boolean isUnallowed(@Nullable SlimefunItem item) {
-        return item != null && item.isTradable() && !item.isDisabled();
+        return item != null && !item.isTradable() && !item.isDisabled();
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
@@ -54,6 +54,6 @@ public class VillagerTradingListener implements Listener {
     }
 
     private boolean isUnallowed(@Nullable SlimefunItem item) {
-        return item != null && !(item instanceof VanillaItem) && !(item instanceof SyntheticEmerald) && !item.isDisabled();
+        return item != null && item.isTradable() && !item.isDisabled();
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VillagerTradingListener.java
@@ -3,7 +3,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,7 +13,6 @@ import org.bukkit.inventory.Inventory;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.items.misc.SyntheticEmerald;
 
 /**
@@ -48,7 +46,7 @@ public class VillagerTradingListener implements Listener {
             }
 
             if (e.getResult() == Result.DENY) {
-                Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "villagers.no-trading", true);
+                Slimefun.getLocalization().sendMessage(e.getWhoClicked(), "villagers.no-trading-singular", true);
             }
         }
     }

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -346,7 +346,8 @@ smithing_table:
   not-working: '&4You cannot use a Slimefun item as a smithing material!'
 
 villagers:
-  no-trading: '&4You cannot trade this Slimefun item with Villagers or Wandering Traders!'
+  no-trading: '&4You cannot trade Slimefun items with Villagers!'
+  no-trading-new: '&4You cannot trade this Slimefun item with Villagers or Wandering Traders!'
 
 backpack:
   already-open: '&cSorry, this Backpack is open somewhere else!'

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -346,7 +346,7 @@ smithing_table:
   not-working: '&4You cannot use a Slimefun item as a smithing material!'
 
 villagers:
-  no-trading: '&4You cannot trade Slimefun items with Villagers!'
+  no-trading: '&4You cannot trade this Slimefun item with Villagers or Wandering Traders!'
 
 backpack:
   already-open: '&cSorry, this Backpack is open somewhere else!'

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -347,7 +347,7 @@ smithing_table:
 
 villagers:
   no-trading: '&4You cannot trade Slimefun items with Villagers!'
-  no-trading-new: '&4You cannot trade this Slimefun item with Villagers or Wandering Traders!'
+  no-trading-singular: '&4You cannot trade this Slimefun item with Villagers or Wandering Traders!'
 
 backpack:
   already-open: '&cSorry, this Backpack is open somewhere else!'


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This allows addons to set whether the SlimefunItem is allowed to be traded with villagers and wandering traders.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Add `tradable` attribute to Slimefun, with getter and setter.
- `VanillaItem` and `SyntheticEmerald` have `tradable` set to `true` by default.
- Change the method to determine whether the item is tradable in `VillagerTradingListener`, now it only reads `tradable`.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
