### PR TITLE
Fix for blocks attached to custom blocks not dropping item

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -175,7 +175,10 @@ public class BlockListener implements Listener {
             // Fixes #2560
             if (e.isDropItems()) {
                 // Disable normal block drops
-                e.setDropItems(false);
+                // replace broken block with air so connected blocks (like signs) can drop, Fixes #3831
+                e.setCancelled(true);
+                e.getBlock().setType(Material.AIR);
+                e.setDropItems(true);
 
                 for (ItemStack drop : drops) {
                     // Prevent null or air from being dropped


### PR DESCRIPTION
fix for issue #3831
fixed by setting the block to air and reenabling regular drops

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This is a fix for issue #3831
## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
i replaced 
`e.setDropItems(false);`
with
```
e.setCancelled(true);
e.getBlock().setType(Material.AIR);
e.setDropItems(true);
```
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
#3831
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
