### PR TITLE
Change typo and logic issues with Enchant Amount problems

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
@@ -40,7 +40,7 @@ abstract class AbstractEnchantmentMachine extends AContainer {
     private final ItemSetting<Boolean> useLevelLimit = new ItemSetting<>(this, "use-enchant-level-limit", false);
     private final IntRangeSetting levelLimit = new IntRangeSetting(this, "enchant-level-limit", 0, 10, Short.MAX_VALUE);
     private final ItemSetting<Integer> maxEnchants = new IntRangeSetting(this, "max-enchants", 0, 10, Short.MAX_VALUE);
-    private final ItemSetting<Boolean> useMaxEnchants= new ItemSetting<>(this, "use-max-encahnts", false);
+    private final ItemSetting<Boolean> useMaxEnchants= new ItemSetting<>(this, "use-max-enchants", false);
     private final ItemSetting<Boolean> useIgnoredLores = new ItemSetting<>(this, "use-ignored-lores", false);
     private final ItemSetting<List<String>> ignoredLores = new ItemSetting<>(this, "ignored-lores", Collections.singletonList("&7- &cCan't be used in " + this.getItemName()));
 
@@ -91,7 +91,10 @@ abstract class AbstractEnchantmentMachine extends AContainer {
         return false;
     }
 
-    protected boolean isEnchantmentAmountAllowed(@Nonnull ItemStack item ) {
-        return !useMaxEnchants.getValue() || item.getEnchantments().size() >= maxEnchants.getValue();
+    protected boolean isEnchantmentAmountAllowed(int numberOfEnchants) {
+        if (!useMaxEnchants.getValue()) {
+            return true;
+        }
+        return numberOfEnchants <= maxEnchants.getValue();
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoDisenchanter.java
@@ -94,7 +94,7 @@ public class AutoDisenchanter extends AbstractEnchantmentMachine {
             }
         }
 
-        if (isEnchantmentAmountAllowed(item)) {
+        if (!isEnchantmentAmountAllowed(enchantments.size())) {
             return null;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AutoEnchanter.java
@@ -120,7 +120,15 @@ public class AutoEnchanter extends AbstractEnchantmentMachine {
          * When maxEnchants is set to -1 it will be ignored. When it's set to 0 it will not allow any enchants to go
          * on an item. When maxEnchants is set to any other value it will allow that many enchants to go on the item.
          */
-        if (isEnchantmentAmountAllowed(target)) {
+        int preExistingEnchants = 0;
+        for (Map.Entry<Enchantment, Integer> entry : target.getEnchantments().entrySet()) {
+            if (meta.hasEnchant(entry.getKey())) {
+                preExistingEnchants++;
+            }
+        }
+        int totalEnchants = enchantments.size() + preExistingEnchants;
+
+        if (!isEnchantmentAmountAllowed(totalEnchants)) {
             return null;
         }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->

PR #3749 Introduced a bug in which normal enchanter/disenchanter behaviour would no longer function as expected. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

This PR changes the behaviour to work correctly both when the config option is on and off.
It also resolves an uncaught typo in the configuration item name as well as does a quick check to combine the total enchants from the target and the incumbent.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3846 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
