### PR TITLE
Fix #3260

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -143,6 +143,13 @@ public class EnergyNet extends Network implements HologramOwner {
         }
     }
 
+    @Override
+    protected void addLocationToNetwork(@Nonnull Location l) {
+        if (EnergyNet.getNetworkFromLocation(l) == null) {
+            super.addLocationToNetwork(l);
+        }
+    }
+
     public void tick(@Nonnull Block b) {
         AtomicLong timestamp = new AtomicLong(Slimefun.getProfiler().newEntry());
 
@@ -298,8 +305,7 @@ public class EnergyNet extends Network implements HologramOwner {
         }
     }
 
-    @Nullable
-    private static EnergyNetComponent getComponent(@Nonnull Location l) {
+    private static @Nullable EnergyNetComponent getComponent(@Nonnull Location l) {
         SlimefunItem item = BlockStorage.check(l);
 
         if (item instanceof EnergyNetComponent component) {
@@ -318,8 +324,7 @@ public class EnergyNet extends Network implements HologramOwner {
      *
      * @return The {@link EnergyNet} at that {@link Location}, or {@code null}
      */
-    @Nullable
-    public static EnergyNet getNetworkFromLocation(@Nonnull Location l) {
+    public static @Nullable EnergyNet getNetworkFromLocation(@Nonnull Location l) {
         return Slimefun.getNetworkManager().getNetworkFromLocation(l, EnergyNet.class).orElse(null);
     }
 
@@ -332,8 +337,7 @@ public class EnergyNet extends Network implements HologramOwner {
      * 
      * @return The {@link EnergyNet} at that {@link Location}, or a new one
      */
-    @Nonnull
-    public static EnergyNet getNetworkFromLocationOrCreate(@Nonnull Location l) {
+    public static @Nonnull EnergyNet getNetworkFromLocationOrCreate(@Nonnull Location l) {
         Optional<EnergyNet> energyNetwork = Slimefun.getNetworkManager().getNetworkFromLocation(l, EnergyNet.class);
 
         if (energyNetwork.isPresent()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -145,6 +145,7 @@ public class EnergyNet extends Network implements HologramOwner {
 
     @Override
     protected void addLocationToNetwork(@Nonnull Location l) {
+        // TODO: Add a generic fix for all Network implementations
         if (EnergyNet.getNetworkFromLocation(l) == null) {
             super.addLocationToNetwork(l);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -41,7 +41,6 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
  * @see EnergyNetComponent
  * @see EnergyNetProvider
  * @see EnergyNetComponentType
- *
  */
 public class EnergyNet extends Network implements HologramOwner {
 


### PR DESCRIPTION
## Description
I'm making this PR to fix the issues with energy duplicaiton.

## Proposed changes
Inside the EnergyNet class I override the addLocationToNetwork method and check if there is an EnergyNetwork already at it's location. If there isn't then I just call the super.addLocationToNetwork. This fixes the issue as if a generator is already connected to one network. It will find a EnergyNetwork and not add the generator to any new networks.

I also updated the annotations of some methods in EnergyNetwork to fit the code style guidelines.

## Related Issues (if applicable)
Resolves #3260 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
