### PR TITLE
Fix incorrect return in BlockListener

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -129,16 +129,15 @@ public class BlockListener implements Listener {
         ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
         SlimefunItem sfItem = BlockStorage.check(e.getBlock());
 
-        if (sfItem == null) {
-            return;
-        }
+        // If there is a Slimefun Block here, call our BreakEvent and, if cancelled, cancel this event and return
+        if (sfItem != null) {
+            SlimefunBlockBreakEvent breakEvent = new SlimefunBlockBreakEvent(e.getPlayer(), item, e.getBlock(), sfItem);
+            Bukkit.getPluginManager().callEvent(breakEvent);
 
-        SlimefunBlockBreakEvent breakEvent = new SlimefunBlockBreakEvent(e.getPlayer(), item, e.getBlock(), sfItem);
-        Bukkit.getPluginManager().callEvent(breakEvent);
-
-        if (breakEvent.isCancelled()) {
-            e.setCancelled(true);
-            return;
+            if (breakEvent.isCancelled()) {
+                e.setCancelled(true);
+                return;
+            }
         }
 
         if (!e.isCancelled()) {


### PR DESCRIPTION
## Description
A recent merge resulted in an incorrect return if the block being broken was NOT a Slimefun item resulting in tool handlers no longer being called.

## Proposed changes
Change the logic to fire the event ONLY if the Slimefun block exists and then returning within that if statement only.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
