### PR TITLE
Rename amarcais53 to HamtaBot

### DIFF
--- a/src/main/resources/languages/translators.json
+++ b/src/main/resources/languages/translators.json
@@ -10,7 +10,7 @@
         "tnthomastn",
         "Noumaa",
         "ishi-sama",
-        "amarcais53",
+        "HamtaBot",
         "NinoFutur",
         "TheRetix",
         "Aeris1One",


### PR DESCRIPTION
## Description
Fixes this error:
```
[23.06 19:06:06] [Server] [ERROR] [dough: skins] Exception while requesting skin: https://api.mojang.com/users/profiles/minecraft/amarcais53
[23.06 19:06:06] [Server] [WARN] [Slimefun] Attempted to refresh skin cache, got this response: ExecutionException: java.io.FileNotFoundException: https://api.mojang.com/users/profiles/minecraft/amarcais53
```
https://discord.com/channels/565557184348422174/565569196218384385/1121875045308969071
## Proposed changes
Renames amarcais53 to HamtaBot in the translators file

## Related Issues (If applicable)
_None_

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added Nonnull and Nullable annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.