### PR TITLE
Fix PR labels action perms

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,7 +1,7 @@
 name: Pull Request Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
## Description
Previously, the workflow did not have the proper perms since it was running from the fork for external contributors. With the `pull_request_target` event, we resolve this.

Ref: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
Security ref: https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests

## Proposed changes
Change the event from `pull_request` -> `pull_request_target`

## Related Issues (if applicable)
N/A

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
