### PR TITLE
Download artifact by ID, it isn't available in the workflow_run

### DIFF
--- a/.github/workflows/preview-builds.yml
+++ b/.github/workflows/preview-builds.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Kinda jank way to grab the PR and run ID
-      # However, not sure a better way
-      - name: Grab PR and run ID
+      # Kinda jank way to grab the PR and run ID and then download the artifact
+      # TODO: Move this code to our own mini-action
+      - name: Grab PR & run ID and download the artifact
         uses: actions/github-script@v5
         with:
           script: |
@@ -38,21 +38,32 @@ jobs:
                   `\nWORKFLOW_PR_ID=${match[1]}` +
                     `\nWORKFLOW_RUN_ID=${context.payload.workflow_run.id}`
                 );
+
+                const download = await github.rest.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                  archive_format: 'zip',
+                });
+                require('fs').writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview.zip`, Buffer.from(download.data))
+
                 break;
               }
             }
 
-      # Download the artifact from the build workflow
-      - uses: actions/download-artifact@v3
-        with:
-          name: slimefun-${{ env.WORKFLOW_PR_ID }}
+      # Unzip the artifact
+      - name: Unzip
+        run: |
+          unzip preview.zip
+          rm preview.zip
+          mv 'Slimefun v4.9-UNOFFICIAL.jar' preview.jar
 
       - name: Upload to preview service
         run: |
           curl -v -X POST \
             -H 'Authorization: ${{ secrets.PUBLISH_TOKEN }}' \
-            -H "X-Checksum: $(sha256sum 'target/Slimefun v4.9-UNOFFICIAL.jar' | awk '{print $1}')" \
-            --data-binary '@target/Slimefun v4.9-UNOFFICIAL.jar' \
+            -H "X-Checksum: $(sha256sum 'preview.jar' | awk '{print $1}')" \
+            --data-binary '@preview.jar' \
             https://preview-builds.walshy.dev/upload/Slimefun/${{ env.WORKFLOW_PR_ID }}/${{ env.WORKFLOW_RUN_ID }}
 
       - name: Post comment


### PR DESCRIPTION
## Description
Apparently, download-artifact just checks the current workflow for it and not the run.

## Proposed changes
In our run-script, let's download the artifact as well. We know this is picking up the PR correctly: https://github.com/Slimefun/Slimefun4/actions/runs/5364131229/jobs/9732129940
So... this should work

## Related Issues (if applicable)
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
