### PR TITLE
Revert header changes

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
@@ -38,10 +38,10 @@ public class PermissionsService {
 
         // @formatter:off
         config.getConfiguration().options().header(
-                "This file is used to assign permission nodes to items from Slimefun or any of its addons.\n" +
-                "To assign an item a certain permission node you simply have to set the 'permission' attribute\n" +
-                "to your desired permission node.\n" +
-                "You can also customize the text that is displayed when a Player does not have that permission."
+            "This file is used to assign permission nodes to items from Slimefun or any of its addons.\n" +
+            "To assign an item a certain permission node you simply have to set the 'permission' attribute\n" +
+            "to your desired permission node.\n" +
+            "You can also customize the text that is displayed when a Player does not have that permission."
         );
         // @formatter:on
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
@@ -37,12 +37,11 @@ public class PermissionsService {
         config = new Config(plugin, "permissions.yml");
 
         // @formatter:off
-        config.getConfiguration().options().setHeader(Collections.singletonList("""
-            This file is used to assign permission nodes to items from Slimefun or any of its addons.
-            To assign an item a certain permission node you simply have to set the 'permission' attribute
-            to your desired permission node.
-            You can also customize the text that is displayed when a Player does not have that permission.
-            """)
+        config.getConfiguration().options().header(
+                "This file is used to assign permission nodes to items from Slimefun or any of its addons.\n" +
+                "To assign an item a certain permission node you simply have to set the 'permission' attribute\n" +
+                "to your desired permission node.\n" +
+                "You can also customize the text that is displayed when a Player does not have that permission."
         );
         // @formatter:on
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/sounds/SoundService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/sounds/SoundService.java
@@ -35,11 +35,10 @@ public class SoundService {
         config = new Config(plugin, "sounds.yml");
 
         // @formatter:off
-        config.getConfiguration().options().setHeader(Collections.singletonList("""
-                This file is used to assign the sounds which Slimefun will play.
-                You can fully customize any sound you want and even change their pitch
-                and volume. To disable a sound, simply set the volume to zero.
-                """)
+        config.getConfiguration().options().header(
+                "This file is used to assign the sounds which Slimefun will play.\n" +
+                "You can fully customize any sound you want and even change their pitch\n" +
+                "and volume. To disable a sound, simply set the volume to zero.\n"
         );
         // @formatter:on
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/sounds/SoundService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/sounds/SoundService.java
@@ -36,9 +36,9 @@ public class SoundService {
 
         // @formatter:off
         config.getConfiguration().options().header(
-                "This file is used to assign the sounds which Slimefun will play.\n" +
-                "You can fully customize any sound you want and even change their pitch\n" +
-                "and volume. To disable a sound, simply set the volume to zero.\n"
+            "This file is used to assign the sounds which Slimefun will play.\n" +
+            "You can fully customize any sound you want and even change their pitch\n" +
+            "and volume. To disable a sound, simply set the volume to zero.\n"
         );
         // @formatter:on
 


### PR DESCRIPTION
## Description
Fixes a compatibility error introduced in the sound system pr's. 
The setHeader method does not exist in 1.16, so I am reverting it to use the deprecated method.

## Proposed changes
Revert the changes that changed `header` to `setHeader`

## Related Issues (if applicable)
No github issues yet

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
