### PR TITLE
Fixed 1.16 compat

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/sounds/SoundService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/sounds/SoundService.java
@@ -1,6 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.core.services.sounds;
 
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -42,7 +41,7 @@ public class SoundService {
         );
         // @formatter:on
 
-        config.getConfiguration().options().parseComments(true);
+        config.getConfiguration().options().copyHeader();
     }
 
     /**


### PR DESCRIPTION
## Description
Fixed 1.16.5 compat

This has been tested e2e on 1.16.5 paper

## Proposed changes
#parseComments does not exist on 1.16.5 so changed to the deprecated #copyHeader.

## Related Issues (if applicable)
N/A

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
