### PR TITLE
Fix Compressor doubling output

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -92,15 +92,15 @@ public class Compressor extends MultiBlockMachine {
             int j = i;
 
             Slimefun.runSync(() -> {
-                // TODO: Convert this mess into Sound Effects
                 if (j < 3) {
                     if (j == 1) {
                         SoundEffect.COMPRESSOR_CRAFT_CONTRACT_SOUND.playFor(p);
                     } else {
                         SoundEffect.COMPRESSOR_CRAFT_EXTEND_SOUND.playFor(p);
-                        handleCraftedItem(output, dispenser, dispInv);
                     }
-                 }
+                 } else {
+                    handleCraftedItem(output, dispenser, dispInv);
+                }
             }, i * 20L);
         }
     }


### PR DESCRIPTION
## Description
Quick fix to fix a bug introduced with the sound system changes

## Proposed changes
move the handle crafted output back to the else clause it was originally in before the sound system

## Related Issues (if applicable)
No related issues, reported on discord

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
