### PR TITLE
Fix breaking change in LongFallBoots

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/LongFallBoots.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/LongFallBoots.java
@@ -24,6 +24,15 @@ public class LongFallBoots extends SlimefunArmorPiece {
 
     private final SoundEffect soundEffect;
 
+    /**
+     * @deprecated In RC-35, marked for removal in RC-36
+     */
+    @Deprecated
+    @ParametersAreNonnullByDefault
+    public LongFallBoots(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects) {
+        this(itemGroup, item, recipeType, recipe, effects, SoundEffect.SLIME_BOOTS_FALL_SOUND);
+    }
+
     @ParametersAreNonnullByDefault
     public LongFallBoots(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects, SoundEffect soundEffect) {
         super(itemGroup, item, recipeType, recipe, effects);


### PR DESCRIPTION
## Description
The sound system made a breaking change to LongFallBoots causing FoxyMachines to no longer start.

## Proposed changes
Re-add the old constructor and deprecate.

## Related Issues (if applicable)
https://github.com/GallowsDove/FoxyMachines/issues/71

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
