### PR TITLE
Removed backwards compatiblity mode

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -39,16 +39,12 @@ import io.github.thebusybiscuit.slimefun4.core.SlimefunRegistry;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotConfigurable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Placeable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactive;
-import io.github.thebusybiscuit.slimefun4.core.attributes.Rechargeable;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.core.handlers.GlobalItemHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
-import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.enchanting.AutoDisenchanter;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.enchanting.AutoEnchanter;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -767,13 +767,7 @@ public class SlimefunItem implements Placeable {
             }
         }
 
-        // Backwards compatibility
-        if (Slimefun.getRegistry().isBackwardsCompatible()) {
-            boolean loreInsensitive = this instanceof Rechargeable || this instanceof SlimefunBackpack || id.equals("BROKEN_SPAWNER") || id.equals("REINFORCED_SPAWNER");
-            return SlimefunUtils.isItemSimilar(item, this.itemStackTemplate, !loreInsensitive);
-        } else {
-            return false;
-        }
+        return false;
     }
 
     /**
@@ -1179,33 +1173,8 @@ public class SlimefunItem implements Placeable {
 
         Optional<String> itemID = Slimefun.getItemDataService().getItemData(item);
 
-        if (itemID.isPresent()) {
-            return getById(itemID.get());
-        }
+        return itemID.map(SlimefunItem::getById).orElse(null);
 
-        // Backwards compatibility
-        if (Slimefun.getRegistry().isBackwardsCompatible()) {
-            // This wrapper improves the heavy ItemStack#getItemMeta() call by caching it.
-            ItemStackWrapper wrapper = ItemStackWrapper.wrap(item);
-
-            /*
-             * Quite expensive performance-wise.
-             * But necessary for supporting legacy items
-             */
-            for (SlimefunItem sfi : Slimefun.getRegistry().getAllSlimefunItems()) {
-                if (sfi.isItem(wrapper)) {
-                    /*
-                     * If we have to loop all items for the given item, then at least
-                     * set the id via PersistentDataAPI for future performance boosts
-                     */
-                    Slimefun.getItemDataService().setItemData(item, sfi.getId());
-
-                    return sfi;
-                }
-            }
-        }
-
-        return null;
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -65,7 +65,6 @@ public final class SlimefunRegistry {
     private final Set<UUID> researchingPlayers = Collections.synchronizedSet(new HashSet<>());
 
     // TODO: Move this all into a proper "config cache" class
-    private boolean backwardsCompatibility;
     private boolean automaticallyLoadItems;
     private boolean enableResearches;
     private boolean freeCreativeResearches;
@@ -109,7 +108,6 @@ public final class SlimefunRegistry {
 
         researchRanks.addAll(cfg.getStringList("research-ranks"));
 
-        backwardsCompatibility = cfg.getBoolean("options.backwards-compatibility");
         freeCreativeResearches = cfg.getBoolean("researches.free-in-creative-mode");
         researchFireworks = cfg.getBoolean("researches.enable-fireworks");
         disableLearningAnimation = cfg.getBoolean("researches.disable-learning-animation");
@@ -127,29 +125,6 @@ public final class SlimefunRegistry {
      */
     public boolean isAutoLoadingEnabled() {
         return automaticallyLoadItems;
-    }
-
-    /**
-     * This method returns whether backwards-compatibility is enabled.
-     * Backwards compatibility allows Slimefun to recognize items from older versions but comes
-     * at a huge performance cost.
-     * 
-     * @return Whether backwards compatibility is enabled
-     */
-    public boolean isBackwardsCompatible() {
-        return backwardsCompatibility;
-    }
-
-    /**
-     * This method sets the status of backwards compatibility.
-     * Backwards compatibility allows Slimefun to recognize items from older versions but comes
-     * at a huge performance cost.
-     * 
-     * @param compatible
-     *            Whether backwards compatibility should be enabled
-     */
-    public void setBackwardsCompatible(boolean compatible) {
-        backwardsCompatibility = compatible;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -83,18 +83,6 @@ class VersionsCommand extends SubCommand {
 
             addJavaVersion(builder);
 
-            if (Slimefun.getRegistry().isBackwardsCompatible()) {
-                // @formatter:off
-                HoverEvent hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
-                    "Backwards compatibility has a negative impact on performance!\n" +
-                    "We recommend you to disable this setting unless your server still " +
-                    "has legacy Slimefun items (from before summer 2019) in circulation."
-                ));
-                // @formatter:on
-
-                builder.append("\nBackwards compatibility enabled!\n").color(ChatColor.RED).event(hoverEvent);
-            }
-
             builder.append("\n").event((HoverEvent) null);
             addPluginVersions(builder);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/ArmorTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/ArmorTask.java
@@ -130,8 +130,7 @@ public class ArmorTask implements Runnable {
     private void checkForSolarHelmet(@Nonnull Player p) {
         ItemStack helmet = p.getInventory().getHelmet();
 
-        if (Slimefun.getRegistry().isBackwardsCompatible() && !SlimefunUtils.isItemSimilar(helmet, SlimefunItems.SOLAR_HELMET, true, false)) {
-            // Performance saver for slow backwards-compatible versions of Slimefun
+        if (!SlimefunUtils.isItemSimilar(helmet, SlimefunItems.SOLAR_HELMET, true, false)) {
             return;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/ArmorTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/ArmorTask.java
@@ -129,11 +129,6 @@ public class ArmorTask implements Runnable {
 
     private void checkForSolarHelmet(@Nonnull Player p) {
         ItemStack helmet = p.getInventory().getHelmet();
-
-        if (!SlimefunUtils.isItemSimilar(helmet, SlimefunItems.SOLAR_HELMET, true, false)) {
-            return;
-        }
-
         SlimefunItem item = SlimefunItem.getByItem(helmet);
 
         if (item instanceof SolarHelmet solarHelmet && item.canUse(p, true)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/SolarHelmetTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/SolarHelmetTask.java
@@ -39,8 +39,7 @@ public class SolarHelmetTask extends AbstractArmorTask {
     private void checkForSolarHelmet(@Nonnull Player p) {
         ItemStack helmet = p.getInventory().getHelmet();
 
-        if (Slimefun.getRegistry().isBackwardsCompatible() && !SlimefunUtils.isItemSimilar(helmet, SlimefunItems.SOLAR_HELMET, true, false)) {
-            // Performance saver for slow backwards-compatible versions of Slimefun
+        if (!SlimefunUtils.isItemSimilar(helmet, SlimefunItems.SOLAR_HELMET, true, false)) {
             return;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/SolarHelmetTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/SolarHelmetTask.java
@@ -7,14 +7,10 @@ import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffect;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
-import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactive;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
-import io.github.thebusybiscuit.slimefun4.implementation.items.armor.SlimefunArmorPiece;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.gadgets.SolarHelmet;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
@@ -38,11 +34,6 @@ public class SolarHelmetTask extends AbstractArmorTask {
 
     private void checkForSolarHelmet(@Nonnull Player p) {
         ItemStack helmet = p.getInventory().getHelmet();
-
-        if (!SlimefunUtils.isItemSimilar(helmet, SlimefunItems.SOLAR_HELMET, true, false)) {
-            return;
-        }
-
         SlimefunItem item = SlimefunItem.getByItem(helmet);
 
         if (item instanceof SolarHelmet solarHelmet && item.canUse(p, true)) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,6 @@ options:
   # You can download the latest stable build here: https://thebusybiscuit.github.io/builds/TheBusyBiscuit/Slimefun4/stable/
 
   auto-update: true
-  backwards-compatibility: false
   chat-prefix: '&a&lSlimefun 4&7> '
   armor-update-interval: 10
   enable-armor-effects: true

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
@@ -121,13 +121,9 @@ class TestSlimefunItem {
         Assertions.assertFalse(sfItem.isItem(new CustomItemStack(Material.REDSTONE, "&cTest")));
 
         if (compatibility) {
-            Slimefun.getRegistry().setBackwardsCompatible(true);
-
             Assertions.assertEquals(sfItem, SlimefunItem.getByItem(item));
             Assertions.assertTrue(sfItem.isItem(item));
             Assertions.assertTrue(sfItem.isItem(new CustomItemStack(Material.BEACON, "&cItem Test")));
-
-            Slimefun.getRegistry().setBackwardsCompatible(false);
         } else {
             Assertions.assertFalse(sfItem.isItem(item));
             Assertions.assertFalse(sfItem.isItem(new CustomItemStack(Material.BEACON, "&cItem Test")));

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
@@ -105,12 +105,11 @@ class TestSlimefunItem {
         Assertions.assertThrows(IllegalArgumentException.class, () -> item.setRecipeType(null));
     }
 
-    @ParameterizedTest
+    @Test
     @DisplayName("Test SlimefunItem#isItem(...)")
-    @ValueSource(booleans = { true, false })
-    void testIsItem(boolean compatibility) {
+    void testIsItem() {
         ItemStack item = new CustomItemStack(Material.BEACON, "&cItem Test");
-        String id = "IS_ITEM_TEST" + (compatibility ? "_COMPATIBLE" : "");
+        String id = "IS_ITEM_TEST";
         SlimefunItem sfItem = TestUtilities.mockSlimefunItem(plugin, id, item);
         sfItem.register(plugin);
 
@@ -119,15 +118,8 @@ class TestSlimefunItem {
         Assertions.assertFalse(sfItem.isItem(null));
         Assertions.assertFalse(sfItem.isItem(new ItemStack(Material.BEACON)));
         Assertions.assertFalse(sfItem.isItem(new CustomItemStack(Material.REDSTONE, "&cTest")));
-
-        if (compatibility) {
-            Assertions.assertEquals(sfItem, SlimefunItem.getByItem(item));
-            Assertions.assertTrue(sfItem.isItem(item));
-            Assertions.assertTrue(sfItem.isItem(new CustomItemStack(Material.BEACON, "&cItem Test")));
-        } else {
-            Assertions.assertFalse(sfItem.isItem(item));
-            Assertions.assertFalse(sfItem.isItem(new CustomItemStack(Material.BEACON, "&cItem Test")));
-        }
+        Assertions.assertFalse(sfItem.isItem(item));
+        Assertions.assertFalse(sfItem.isItem(new CustomItemStack(Material.BEACON, "&cItem Test")));
 
         Assertions.assertEquals(sfItem, SlimefunItem.getByItem(new SlimefunItemStack(sfItem.getId(), item)));
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
@@ -100,7 +100,6 @@ class TestCargoNodeListener {
     @Test
     @DisplayName("Test non-Cargo node not being affected")
     void testNonCargoNode() {
-        Slimefun.getRegistry().setBackwardsCompatible(true);
         Player player = server.addPlayer();
         Location l = new Location(player.getWorld(), 190, 50, 400);
         Block b = l.getBlock();
@@ -111,7 +110,6 @@ class TestCargoNodeListener {
         BlockPlaceEvent event = new BlockPlaceEvent(b, b.getState(), against, item, player, true, EquipmentSlot.HAND);
         listener.onCargoNodePlace(event);
         Assertions.assertFalse(event.isCancelled());
-        Slimefun.getRegistry().setBackwardsCompatible(false);
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This PR will remove backwards compatiblity mode.
This will be a start of removing old crap to clean up Slimefun code and make new code more sustainable.

Only 2% (58 servers of the 2301 servers) of servers use backwards compatiblity mode. Where i dont think they know they have it on or have given it a thought. We also recommend in our optimizations guide to turn this feature of.
This should speed up those older servers severaly as well.
I havent benchedmarked this at all

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Removed unused imports
Deleted backwards compatiblity mode
Deleted test regarded backwards compatiblity mode
Bit of Summer cleaning on my touched files


## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
