### PR TITLE
possibly fix javadocs

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
@@ -45,7 +45,7 @@ public enum MinecraftVersion {
 
     /**
      * This constant represents Minecraft (Java Edition) Version 1.20
-     * ("The Trails & Tales Update")
+     * ("The Trails &amp; Tales Update")
      */
     MINECRAFT_1_20(20, "1.20.x"),
 


### PR DESCRIPTION
## Description
JavaDocs are currently broken and have been for a year :( 
The current error being spat out is due to this & (HTML y'all)
Latest job error: https://github.com/Slimefun/javadocs/actions/runs/5496270000/jobs/10016191730

## Proposed changes
Replace the & with the HTML entity for it.

## Related Issues (if applicable)
N/A

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
