### PR TITLE
Changed the registry to use world UUIDs

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -85,7 +85,7 @@ public final class SlimefunRegistry {
     private final KeyMap<GEOResource> geoResources = new KeyMap<>();
 
     private final Map<UUID, PlayerProfile> profiles = new ConcurrentHashMap<>();
-    private final Map<String, BlockStorage> worlds = new ConcurrentHashMap<>();
+    private final Map<UUID, BlockStorage> worlds = new ConcurrentHashMap<>();
     private final Map<String, BlockInfoConfig> chunks = new HashMap<>();
     private final Map<SlimefunGuideMode, SlimefunGuideImplementation> guides = new EnumMap<>(SlimefunGuideMode.class);
     private final Map<EntityType, Set<ItemStack>> mobDrops = new EnumMap<>(EntityType.class);
@@ -350,7 +350,7 @@ public final class SlimefunRegistry {
     }
 
     @Nonnull
-    public Map<String, BlockStorage> getWorlds() {
+    public Map<UUID, BlockStorage> getWorlds() {
         return worlds;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -428,7 +429,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         });
 
         // Save all registered Worlds
-        for (Map.Entry<String, BlockStorage> entry : getRegistry().getWorlds().entrySet()) {
+        for (Map.Entry<UUID, BlockStorage> entry : getRegistry().getWorlds().entrySet()) {
             try {
                 entry.getValue().saveAndRemove();
             } catch (Exception x) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -67,12 +67,12 @@ public class BlockStorage {
 
     @Nullable
     public static BlockStorage getStorage(@Nonnull World world) {
-        return Slimefun.getRegistry().getWorlds().get(world.getName());
+        return Slimefun.getRegistry().getWorlds().get(world.getUID());
     }
 
     @Nonnull
     public static BlockStorage getOrCreate(@Nonnull World world) {
-        BlockStorage storage = Slimefun.getRegistry().getWorlds().get(world.getName());
+        BlockStorage storage = Slimefun.getRegistry().getWorlds().get(world.getUID());
 
         if (storage == null) {
             return new BlockStorage(world);
@@ -136,7 +136,7 @@ public class BlockStorage {
         if (!Slimefun.instance().isUnitTest()) {
             loadInventories();
         }
-        Slimefun.getRegistry().getWorlds().put(world.getName(), this);
+        Slimefun.getRegistry().getWorlds().put(world.getUID(), this);
     }
 
     private void loadBlocks(File directory) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -114,7 +114,7 @@ public class BlockStorage {
             throw new IllegalArgumentException("Slimefun cannot deal with World names that contain a dot: " + w.getName());
         }
 
-        if (Slimefun.getRegistry().getWorlds().containsKey(w.getName())) {
+        if (Slimefun.getRegistry().getWorlds().containsKey(w.getUID())) {
             // Cancel the loading process if the world was already loaded
             return;
         }
@@ -771,7 +771,7 @@ public class BlockStorage {
     }
 
     public static boolean isWorldLoaded(@Nonnull World world) {
-        return Slimefun.getRegistry().getWorlds().containsKey(world.getName());
+        return Slimefun.getRegistry().getWorlds().containsKey(world.getUID());
     }
 
     public BlockMenu loadInventory(Location l, BlockMenuPreset preset) {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockBreakEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockBreakEvent.java
@@ -60,7 +60,7 @@ class TestSlimefunBlockBreakEvent {
         World world = server.addSimpleWorld("my_world");
         Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, 1, 1, 1));
 
-        Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
+        Slimefun.getRegistry().getWorlds().put(world.getUID(), new BlockStorage(world));
         BlockStorage.addBlockInfo(block, "id", "FOOD_COMPOSTER");
 
         server.getPluginManager().callEvent(new BlockBreakEvent(block, player));
@@ -77,7 +77,7 @@ class TestSlimefunBlockBreakEvent {
         World world = server.addSimpleWorld("my_world");
         Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, 1, 1, 1));
 
-        Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
+        Slimefun.getRegistry().getWorlds().put(world.getUID(), new BlockStorage(world));
         BlockStorage.addBlockInfo(block, "id", "FOOD_COMPOSTER");
 
         server.getPluginManager().callEvent(new BlockBreakEvent(block, player));
@@ -108,7 +108,7 @@ class TestSlimefunBlockBreakEvent {
         World world = server.addSimpleWorld("my_world");
         Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, 1, 1, 1));
 
-        Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
+        Slimefun.getRegistry().getWorlds().put(world.getUID(), new BlockStorage(world));
         BlockStorage.addBlockInfo(block, "id", "FOOD_COMPOSTER");
 
         BlockBreakEvent blockBreakEvent = new BlockBreakEvent(block, player);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockPlaceEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockPlaceEvent.java
@@ -65,7 +65,7 @@ public class TestSlimefunBlockPlaceEvent {
         Block blockAgainst = new BlockMock(Material.GRASS, new Location(world, 1, 0, 1));
         BlockStorage.clearBlockInfo(block);
 
-        Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
+        Slimefun.getRegistry().getWorlds().put(world.getUID(), new BlockStorage(world));
 
         BlockPlaceEvent blockPlaceEvent  = new BlockPlaceEvent(
             block, block.getState(), blockAgainst, itemStack, player, true, EquipmentSlot.HAND
@@ -87,7 +87,7 @@ public class TestSlimefunBlockPlaceEvent {
         Block blockAgainst = new BlockMock(Material.GRASS, new Location(world, 1, 0, 1));
         BlockStorage.clearBlockInfo(block);
 
-        Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
+        Slimefun.getRegistry().getWorlds().put(world.getUID(), new BlockStorage(world));
 
         BlockPlaceEvent blockPlaceEvent  = new BlockPlaceEvent(
             block, block.getState(), blockAgainst, itemStack, player, true, EquipmentSlot.HAND
@@ -123,7 +123,7 @@ public class TestSlimefunBlockPlaceEvent {
         Block blockAgainst = new BlockMock(Material.GRASS, new Location(world, 1, 0, 1));
         BlockStorage.clearBlockInfo(block);
 
-        Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
+        Slimefun.getRegistry().getWorlds().put(world.getUID(), new BlockStorage(world));
 
         BlockPlaceEvent blockPlaceEvent  = new BlockPlaceEvent(
             block, block.getState(), blockAgainst, itemStack, player, true, EquipmentSlot.HAND


### PR DESCRIPTION
## Description
I have recently run into an issue where a world, when created quickly enough after deletion of a world with the same name, will not store data. I have tested this extensively and narrowed the issue down to [this](https://github.com/Slimefun/Slimefun4/blob/master/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java#L102) ticker code and [this](https://github.com/Slimefun/Slimefun4/blob/master/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java#L116) check for the world's existence. Since the ticker code only runs every half second, it does not remove the world from the registry until up to a Slimefun tick later and therefore causes issues in the constructor.

An easy way to recreate this issue is to delete a world and immediately create a new one with the same name.

Full credits go to @gecko10000 for some reason (my git skills most likely) his PR got closed while i tried to update it.

## Proposed changes
This PR changes the registry to use UUIDs instead of the world names themselves. This _does not_ affect the storage location in files and therefore these are not breaking changes.

This may not be the ideal way to do it; it may be better to remove the world from the registry [here](https://github.com/Slimefun/Slimefun4/blob/master/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/WorldListener.java#L28) instead.

## Related Issues (if applicable)
No issue opened

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
