### PR TITLE
Stop errors on forks

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate:
-
+    if: github.repository == 'Slimefun/Slimefun4'
     name: Check for merge conflicts
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Description
Currently forks get annoying and useless emails/workflow failures due to the merge-conflicts workflow.

See: <https://github.com/Sefiraat/Slimefun4/actions/runs/5501235305/jobs/10024683718>

## Proposed changes
Simply don't allow it to run on forks. Unsure if this will/could have detrimental effects?

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
