### PR TITLE
Add grace periods to RadiationTask

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/RadioactivityListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/RadioactivityListener.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.implementation.tasks.armor.RadiationTask;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -24,5 +25,6 @@ public class RadioactivityListener implements Listener {
     @EventHandler
     public void onPlayerDeath(@Nonnull PlayerDeathEvent e) {
         RadiationUtils.clearExposure(e.getEntity());
+        RadiationTask.addGracePeriod(e.getEntity());
     }
 }


### PR DESCRIPTION
## Description
Currently when a server has KeepInventory on (or a player dies on their respawn location) they can get caught in a tricky death-loop.

## Proposed changes
We add a 15 second grace period after dying before radiation effects trigger again. This gives more than enough time to remove the offending item(s) and/or put on the relevant armor. It is also short enough to discourage using this grace period to 'zerg' their way to their intended end result.

Tested quickly on 1.19.4 and worked well.

## Related Issues (if applicable)
Fixes #3901 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
