### PR TITLE
Improve performance of clearAllBlockInfoAtChunk, don't get immutable map

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -621,8 +621,8 @@ public class BlockStorage {
             return;
         }
         Map<Location, Boolean> toClear = new HashMap<>();
-        Map<Location, Config> storage = blockStorage.getRawStorage();
-        for (Location location : storage.keySet()) {
+        // Unsafe: get raw storage for this world
+        for (Location location : blockStorage.storage.keySet()) {
             if (location.getBlockX() >> 4 == chunkX && location.getBlockZ() >> 4 == chunkZ) {
                 toClear.put(location, destroy);
             }


### PR DESCRIPTION
## Description
We're currently getting our ImmutableMap clone in clearAllBlockInfoAtChunk, instead we can _unsafely_ get the storage and save the overhead of duplicating the map (which for large servers is _massive_).

Right now it's taking basically all of the compute time:
![image](https://github.com/Slimefun/Slimefun4/assets/8492901/50f980e2-383e-48cd-bca4-d4534bee9fd9)

## Proposed changes
Unsafely get the raw storage instead of our safe ImmutableMap.

## Related Issues (if applicable)
Resolves #3432

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
