### PR TITLE
refactor config handling + added /sf reload

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemSetting.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemSetting.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.lang.Validate;
 
 import io.github.bakedlibs.dough.config.Config;
@@ -163,11 +164,12 @@ public class ItemSetting<T> {
      * 
      */
     @SuppressWarnings("unchecked")
-    public void reload() {
-        Validate.notNull(item, "Cannot apply settings for a non-existing SlimefunItem");
+    public boolean reload() {
+        Preconditions.checkNotNull(item, "Cannot apply settings for a non-existing SlimefunItem");
 
-        Slimefun.getItemCfg().setDefaultValue(item.getId() + '.' + getKey(), getDefaultValue());
-        Object configuredValue = Slimefun.getItemCfg().getValue(item.getId() + '.' + getKey());
+        Config config = Slimefun.getConfigManager().getItemsConfig();
+        config.setDefaultValue(item.getId() + '.' + getKey(), getDefaultValue());
+        Object configuredValue = config.getValue(item.getId() + '.' + getKey());
 
         if (defaultValue.getClass().isInstance(configuredValue) || (configuredValue instanceof List && defaultValue instanceof List)) {
             // We can do an unsafe cast here, we did an isInstance(...) check before!
@@ -175,6 +177,7 @@ public class ItemSetting<T> {
 
             if (validateInput(newValue)) {
                 this.value = newValue;
+                return true;
             } else {
                 // @formatter:off
                 item.warn(
@@ -184,6 +187,7 @@ public class ItemSetting<T> {
                         "\n" + getErrorMessage()
                 );
                 // @formatter:on
+                return false;
             }
         } else {
             this.value = defaultValue;
@@ -197,6 +201,7 @@ public class ItemSetting<T> {
                     "\n  Expected \"" + defaultValue.getClass().getSimpleName() + "\" but found: \"" + found + "\""
             );
             // @formatter:on
+            return false;
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.bakedlibs.dough.config.Config;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -432,13 +433,15 @@ public class SlimefunItem implements Placeable {
             Slimefun.getRegistry().getAllSlimefunItems().add(this);
             Slimefun.getRegistry().getSlimefunItemIds().put(id, this);
 
+            Config config = Slimefun.getConfigManager().getItemsConfig();
+
             // Items that are "not-configurable" cannot be configured.
             if (!(this instanceof NotConfigurable)) {
-                Slimefun.getItemCfg().setDefaultValue(id + ".enabled", true);
-                Slimefun.getItemCfg().setDefaultValue(id + ".can-be-used-in-workbenches", useableInWorkbench);
-                Slimefun.getItemCfg().setDefaultValue(id + ".hide-in-guide", hidden);
-                Slimefun.getItemCfg().setDefaultValue(id + ".allow-enchanting", enchantable);
-                Slimefun.getItemCfg().setDefaultValue(id + ".allow-disenchanting", disenchantable);
+                config.setDefaultValue(id + ".enabled", true);
+                config.setDefaultValue(id + ".can-be-used-in-workbenches", useableInWorkbench);
+                config.setDefaultValue(id + ".hide-in-guide", hidden);
+                config.setDefaultValue(id + ".allow-enchanting", enchantable);
+                config.setDefaultValue(id + ".allow-disenchanting", disenchantable);
 
                 // Load all item settings
                 for (ItemSetting<?> setting : itemSettings) {
@@ -446,7 +449,7 @@ public class SlimefunItem implements Placeable {
                 }
             }
 
-            if (ticking && !Slimefun.getCfg().getBoolean("URID.enable-tickers")) {
+            if (ticking && !Slimefun.getConfigManager().getPluginConfig().getBoolean("URID.enable-tickers")) {
                 state = ItemState.DISABLED;
                 return;
             }
@@ -457,13 +460,13 @@ public class SlimefunItem implements Placeable {
                  * Any other settings will remain as default.
                  */
                 state = ItemState.ENABLED;
-            } else if (Slimefun.getItemCfg().getBoolean(id + ".enabled")) {
+            } else if (config.getBoolean(id + ".enabled")) {
                 // The item has been enabled.
                 state = ItemState.ENABLED;
-                useableInWorkbench = Slimefun.getItemCfg().getBoolean(id + ".can-be-used-in-workbenches");
-                hidden = Slimefun.getItemCfg().getBoolean(id + ".hide-in-guide");
-                enchantable = Slimefun.getItemCfg().getBoolean(id + ".allow-enchanting");
-                disenchantable = Slimefun.getItemCfg().getBoolean(id + ".allow-disenchanting");
+                useableInWorkbench = config.getBoolean(id + ".can-be-used-in-workbenches");
+                hidden = config.getBoolean(id + ".hide-in-guide");
+                enchantable = config.getBoolean(id + ".allow-enchanting");
+                disenchantable = config.getBoolean(id + ".allow-disenchanting");
             } else if (this instanceof VanillaItem) {
                 // This item is a vanilla "mock" but was disabled.
                 state = ItemState.VANILLA_FALLBACK;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/PlayerResearchTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/PlayerResearchTask.java
@@ -109,7 +109,7 @@ public class PlayerResearchTask implements Consumer<PlayerProfile> {
         onFinish(p);
 
         // Check if the Server and the Player have enabled fireworks for researches
-        if (Slimefun.getRegistry().isResearchFireworkEnabled() && SlimefunGuideSettings.hasFireworksEnabled(p)) {
+        if (Slimefun.getConfigManager().isResearchFireworkEnabled() && SlimefunGuideSettings.hasFireworksEnabled(p)) {
             FireworkUtils.launchRandom(p, 1);
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
@@ -89,7 +89,7 @@ public class Research implements Keyed {
      * @return Whether this {@link Research} is enabled or not
      */
     public boolean isEnabled() {
-        return Slimefun.getRegistry().isResearchingEnabled() && enabled;
+        return Slimefun.getConfigManager().isResearchingEnabled() && enabled;
     }
 
     /**
@@ -248,7 +248,7 @@ public class Research implements Keyed {
             return true;
         }
 
-        boolean creativeResearch = p.getGameMode() == GameMode.CREATIVE && Slimefun.getRegistry().isFreeCreativeResearchingEnabled();
+        boolean creativeResearch = p.getGameMode() == GameMode.CREATIVE && Slimefun.getConfigManager().isFreeCreativeResearchingEnabled();
         return creativeResearch || p.getLevel() >= cost;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.bakedlibs.dough.config.Config;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -282,10 +283,11 @@ public class Research implements Keyed {
      * Registers this {@link Research}.
      */
     public void register() {
-        Slimefun.getResearchCfg().setDefaultValue("enable-researching", true);
+        Config pluginConfig = Slimefun.getConfigManager().getPluginConfig();
+        pluginConfig.setDefaultValue("enable-researching", true);
         String path = key.getNamespace() + '.' + key.getKey();
 
-        if (Slimefun.getResearchCfg().contains(path + ".enabled") && !Slimefun.getResearchCfg().getBoolean(path + ".enabled")) {
+        if (pluginConfig.contains(path + ".enabled") && !pluginConfig.getBoolean(path + ".enabled")) {
             for (SlimefunItem item : new ArrayList<>(items)) {
                 if (item != null) {
                     item.setResearch(null);
@@ -296,10 +298,10 @@ public class Research implements Keyed {
             return;
         }
 
-        Slimefun.getResearchCfg().setDefaultValue(path + ".cost", getCost());
-        Slimefun.getResearchCfg().setDefaultValue(path + ".enabled", true);
+        pluginConfig.setDefaultValue(path + ".cost", getCost());
+        pluginConfig.setDefaultValue(path + ".enabled", true);
 
-        setCost(Slimefun.getResearchCfg().getInt(path + ".cost"));
+        setCost(pluginConfig.getInt(path + ".cost"));
         enabled = true;
 
         Slimefun.getRegistry().getResearches().add(this);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -24,13 +24,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.collections.KeyMap;
-import io.github.bakedlibs.dough.config.Config;
 import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemHandler;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.api.researches.Research;
+import io.github.thebusybiscuit.slimefun4.core.config.SlimefunConfigManager;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideMode;
@@ -63,19 +63,11 @@ public final class SlimefunRegistry {
     private final List<Research> researches = new LinkedList<>();
     private final List<String> researchRanks = new ArrayList<>();
     private final Set<UUID> researchingPlayers = Collections.synchronizedSet(new HashSet<>());
-
-    // TODO: Move this all into a proper "config cache" class
-    private boolean automaticallyLoadItems;
-    private boolean enableResearches;
-    private boolean freeCreativeResearches;
-    private boolean researchFireworks;
-    private boolean disableLearningAnimation;
-    private boolean logDuplicateBlockEntries;
-    private boolean talismanActionBarMessages;
-
     private final Set<String> tickers = new HashSet<>();
     private final Set<SlimefunItem> radioactive = new HashSet<>();
     private final Set<ItemStack> barterDrops = new HashSet<>();
+
+    private boolean automaticallyLoadItems;
 
     private NamespacedKey soulboundKey;
     private NamespacedKey itemChargeKey;
@@ -93,26 +85,18 @@ public final class SlimefunRegistry {
     private final Map<String, UniversalBlockMenu> universalInventories = new HashMap<>();
     private final Map<Class<? extends ItemHandler>, Set<ItemHandler>> globalItemHandlers = new HashMap<>();
 
-    public void load(@Nonnull Slimefun plugin, @Nonnull Config cfg) {
+    public void load(@Nonnull Slimefun plugin) {
         Validate.notNull(plugin, "The Plugin cannot be null!");
-        Validate.notNull(cfg, "The Config cannot be null!");
+        plugin.getJavaPlugin();
 
         soulboundKey = new NamespacedKey(plugin, "soulbound");
         itemChargeKey = new NamespacedKey(plugin, "item_charge");
         guideKey = new NamespacedKey(plugin, "slimefun_guide_mode");
 
-        boolean showVanillaRecipes = cfg.getBoolean("guide.show-vanilla-recipes");
-        boolean showHiddenItemGroupsInSearch = cfg.getBoolean("guide.show-hidden-item-groups-in-search");
-        guides.put(SlimefunGuideMode.SURVIVAL_MODE, new SurvivalSlimefunGuide(showVanillaRecipes, showHiddenItemGroupsInSearch));
+        guides.put(SlimefunGuideMode.SURVIVAL_MODE, new SurvivalSlimefunGuide());
         guides.put(SlimefunGuideMode.CHEAT_MODE, new CheatSheetSlimefunGuide());
 
-        researchRanks.addAll(cfg.getStringList("research-ranks"));
-
-        freeCreativeResearches = cfg.getBoolean("researches.free-in-creative-mode");
-        researchFireworks = cfg.getBoolean("researches.enable-fireworks");
-        disableLearningAnimation = cfg.getBoolean("researches.disable-learning-animation");
-        logDuplicateBlockEntries = cfg.getBoolean("options.log-duplicate-block-entries");
-        talismanActionBarMessages = cfg.getBoolean("talismans.use-actionbar");
+        researchRanks.addAll(Slimefun.getConfigManager().getPluginConfig().getStringList("research-ranks"));
     }
 
     /**
@@ -195,34 +179,6 @@ public final class SlimefunRegistry {
         return researchRanks;
     }
 
-    public void setResearchingEnabled(boolean enabled) {
-        enableResearches = enabled;
-    }
-
-    public boolean isResearchingEnabled() {
-        return enableResearches;
-    }
-
-    public void setFreeCreativeResearchingEnabled(boolean enabled) {
-        freeCreativeResearches = enabled;
-    }
-
-    public boolean isFreeCreativeResearchingEnabled() {
-        return freeCreativeResearches;
-    }
-
-    public boolean isResearchFireworkEnabled() {
-        return researchFireworks;
-    }
-
-    /**
-     * Returns whether the research learning animations is disabled
-     *
-     * @return Whether the research learning animations is disabled
-     */
-    public boolean isLearningAnimationDisabled() {
-        return disableLearningAnimation;
-    }
 
     /**
      * This method returns a {@link List} of every enabled {@link MultiBlock}.
@@ -339,14 +295,6 @@ public final class SlimefunRegistry {
         return geoResources;
     }
 
-    public boolean logDuplicateBlockEntries() {
-        return logDuplicateBlockEntries;
-    }
-
-    public boolean useActionbarForTalismans() {
-        return talismanActionBarMessages;
-    }
-
     @Nonnull
     public NamespacedKey getSoulboundDataKey() {
         return soulboundKey;
@@ -362,4 +310,16 @@ public final class SlimefunRegistry {
         return guideKey;
     }
 
+    /**
+     * This has been moved.
+     * Our metrics module accesses this though.
+     *
+     * @deprecated Please use {@link SlimefunConfigManager#isFreeCreativeResearchingEnabled()}
+     *
+     * @return free research in creative?
+     */
+    @Deprecated
+    public boolean isFreeCreativeResearchingEnabled() {
+        return Slimefun.getConfigManager().isFreeCreativeResearchingEnabled();
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
@@ -66,7 +66,9 @@ class GiveCommand extends SubCommand {
             if (amount > 0) {
                 Slimefun.getLocalization().sendMessage(p, "messages.given-item", true, msg -> msg.replace(PLACEHOLDER_ITEM, sfItem.getItemName()).replace(PLACEHOLDER_AMOUNT, String.valueOf(amount)));
                 Map<Integer, ItemStack> excess = p.getInventory().addItem(new CustomItemStack(sfItem.getItem(), amount));
-                if (Slimefun.getCfg().getBoolean("options.drop-excess-sf-give-items") && !excess.isEmpty()) {
+
+                // Check whether we should drop excess items to the ground
+                if (Slimefun.getConfigManager().isExcessCommandItemsDroppingEnabled() && !excess.isEmpty()) {
                     for (ItemStack is : excess.values()) {
                         p.getWorld().dropItem(p.getLocation(), is);
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ReloadCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ReloadCommand.java
@@ -1,0 +1,43 @@
+package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
+
+import org.bukkit.command.CommandSender;
+
+import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
+import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+import javax.annotation.Nonnull;
+
+class ReloadCommand extends SubCommand {
+
+    ReloadCommand(Slimefun plugin, SlimefunCommand cmd) {
+        super(plugin, cmd, "reload", false);
+    }
+
+    @Override
+    protected @Nonnull String getDescription() {
+        return "commands.reload.description";
+    }
+
+    @Override
+    public void onExecute(CommandSender sender, @Nonnull String[] args) {
+        if (sender.hasPermission("slimefun.command.reload")) {
+            Slimefun.getLocalization().sendMessage(sender, "guide.work-in-progress", true);
+            boolean reloaded = Slimefun.getConfigManager().reload();
+            boolean isRestartRequired = Slimefun.getConfigManager().    isRestartRequired();
+
+            if (reloaded) {
+                if (isRestartRequired) {
+                    Slimefun.getLocalization().sendMessage(sender, "commands.reload.restart-required", true);
+                } else {
+                    Slimefun.getLocalization().sendMessage(sender, "commands.reload.success", true);
+                }
+            } else {
+                Slimefun.getLocalization().sendMessage(sender, "commands.reload.errors", true);
+            }
+        } else {
+            Slimefun.getLocalization().sendMessage(sender, "messages.no-permission", true);
+        }
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ResearchCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ResearchCommand.java
@@ -34,7 +34,7 @@ class ResearchCommand extends SubCommand {
     @Override
     public void onExecute(CommandSender sender, String[] args) {
         // Check if researching is even enabled
-        if (!Slimefun.getRegistry().isResearchingEnabled()) {
+        if (!Slimefun.getConfigManager().isResearchingEnabled()) {
             Slimefun.getLocalization().sendMessage(sender, "messages.researching-is-disabled");
             return;
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
@@ -42,6 +42,7 @@ public final class SlimefunSubCommands {
         commands.add(new BackpackCommand(plugin, cmd));
         commands.add(new ChargeCommand(plugin, cmd));
         commands.add(new DebugCommand(plugin, cmd));
+        commands.add(new ReloadCommand(plugin, cmd));
 
         return commands;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/StatsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/StatsCommand.java
@@ -24,7 +24,7 @@ class StatsCommand extends SubCommand {
     @Override
     public void onExecute(CommandSender sender, String[] args) {
         // Check if researching is even enabled
-        if (!Slimefun.getRegistry().isResearchingEnabled()) {
+        if (!Slimefun.getConfigManager().isResearchingEnabled()) {
             Slimefun.getLocalization().sendMessage(sender, "messages.researching-is-disabled");
             return;
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/config/SlimefunConfigManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/config/SlimefunConfigManager.java
@@ -1,0 +1,288 @@
+package io.github.thebusybiscuit.slimefun4.core.config;
+
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.github.bakedlibs.dough.config.Config;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.researches.Research;
+import org.apache.commons.lang.Validate;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+/**
+ * This class manages our {@link Config}, it caches values for faster access
+ * and provides means to reload it.
+ *
+ * @author TheBusyBiscuit
+ *
+ */
+public final class SlimefunConfigManager {
+
+    /**
+     * Our {@link Slimefun} instance
+     */
+    private final Slimefun plugin;
+
+    /**
+     * Our {@link Plugin} {@link Config} (config.yml)
+     */
+    private final Config pluginConfig;
+
+    /**
+     * Our {@link SlimefunItem} {@link Config} (Items.yml)
+     */
+    private final Config itemsConfig;
+
+    /**
+     * Our {@link Research} {@link Config} (Researches.yml)
+     */
+    private final Config researchesConfig;
+
+    /**
+     * This flag marks whether we require a {@link Server} restart to
+     * apply the latest changes.
+     */
+    private boolean isRestartRequired = false;
+
+    // Various booleans we want to cache instead of re-parsing everytime
+    private boolean enableBackwardsCompatibility;
+    private boolean enableResearching;
+    private boolean enableFreeCreativeResearches;
+    private boolean enableResearchFireworks;
+    private boolean enableDuplicateBlockLogging;
+    private boolean enableVanillaRecipesInGuide;
+    private boolean enableGuideOnJoin;
+    private boolean enableHiddenItemGroupInSearch;
+    private boolean enableUpdater;
+    private boolean enableActionbarTalismanMessages;
+    private boolean enableCommandItemDropExcess;
+    private boolean disableLearningAnimations;
+
+    /**
+     * This constructs a new {@link SlimefunConfigManager} for the given instance
+     * of {@link Slimefun}.
+     *
+     * @param plugin
+     *            The {@link Slimefun} instance
+     */
+    public SlimefunConfigManager(@Nonnull Slimefun plugin) {
+        Validate.notNull(plugin, "The Plugin instance cannot be null");
+
+        this.plugin = plugin;
+        pluginConfig = getConfig(plugin, "config", () -> new Config(plugin));
+        itemsConfig = getConfig(plugin, "Items", () -> new Config(plugin, "Items.yml"));
+        researchesConfig = getConfig(plugin, "Researches", () -> new Config(plugin, "Researches.yml"));
+    }
+
+    @Nullable
+    @ParametersAreNonnullByDefault
+    private Config getConfig(Slimefun plugin, String name, Supplier<Config> supplier) {
+        try {
+            return supplier.get();
+        } catch (Exception x) {
+            plugin.getLogger().log(Level.SEVERE, x, () -> "An Exception was thrown while loading the config file \"" + name + ".yml\" for Slimefun v" + plugin.getDescription().getVersion());
+            return null;
+        }
+    }
+
+    /**
+     * This method (re)loads all relevant config values into our cache.
+     * <p>
+     * <strong>Note that this method is not guaranteed to reload all settings.</strong>
+     *
+     * @return Whether the reloading was successful and completed without any errors
+     */
+    public boolean reload() {
+        boolean isSuccessful = true;
+
+        try {
+            pluginConfig.reload();
+            itemsConfig.reload();
+            researchesConfig.reload();
+
+            researchesConfig.setDefaultValue("enable-researching", true);
+
+            enableBackwardsCompatibility = pluginConfig.getBoolean("options.backwards-compatibility");
+            enableResearching = researchesConfig.getBoolean("enable-researching");
+            enableFreeCreativeResearches = pluginConfig.getBoolean("researches.free-in-creative-mode");
+            enableResearchFireworks = pluginConfig.getBoolean("researches.enable-fireworks");
+            enableDuplicateBlockLogging = pluginConfig.getBoolean("options.log-duplicate-block-entries");
+            enableVanillaRecipesInGuide = pluginConfig.getBoolean("guide.show-vanilla-recipes");
+            enableHiddenItemGroupInSearch = pluginConfig.getBoolean("guide.show-hidden-item-groups-in-search");
+            enableGuideOnJoin = pluginConfig.getBoolean("guide.receive-on-first-join");
+            enableUpdater = pluginConfig.getBoolean("options.auto-update");
+            enableActionbarTalismanMessages = pluginConfig.getBoolean("talismans.use-actionbar");
+            enableCommandItemDropExcess = pluginConfig.getBoolean("options.drop-excess-sf-give-items");
+            disableLearningAnimations = pluginConfig.getBoolean("researches.disable-learning-animation");
+
+        } catch (Exception x) {
+            plugin.getLogger().log(Level.SEVERE, x, () -> "An Exception was caught while (re)loading the config files for Slimefun v" + plugin.getDescription().getVersion());
+            isSuccessful = false;
+        }
+
+        // Reload Research costs
+        for (Research research : Slimefun.getRegistry().getResearches()) {
+            try {
+                NamespacedKey key = research.getKey();
+                int cost = researchesConfig.getInt(key.getNamespace() + '.' + key.getKey() + ".cost");
+                research.setCost(cost);
+
+                if (!researchesConfig.getBoolean(key.getNamespace() + '.' + key.getKey() + ".enabled")) {
+                    // Disabling a research requires a restart (for now)
+                    isRestartRequired = true;
+                }
+            } catch (Exception x) {
+                plugin.getLogger().log(Level.SEVERE, x, () -> "Something went wrong while trying to update the cost of a research: " + research);
+                isSuccessful = false;
+            }
+        }
+
+        for (SlimefunItem item : Slimefun.getRegistry().getAllSlimefunItems()) {
+            if (item.isDisabled() == itemsConfig.getBoolean(item.getId() + ".enabled")) {
+                // Enabling/Disabling an item requires a restart (for now)
+                isRestartRequired = true;
+            }
+
+            // Reload Item Settings
+            try {
+                for (ItemSetting<?> setting : item.getItemSettings()) {
+                    // Make sure that the setting was loaded properly
+                    if (!setting.reload()) {
+                        isSuccessful = false;
+                    }
+                }
+            } catch (Exception x) {
+                item.error("Something went wrong while updating the settings for this item!", x);
+                isSuccessful = false;
+            }
+
+            // Reload permissions
+            try {
+                Slimefun.getPermissionsService().update(item, false);
+            } catch (Exception x) {
+                item.error("Something went wrong while updating the permission node for this item!", x);
+                isSuccessful = false;
+            }
+        }
+
+        return isSuccessful;
+    }
+
+    /**
+     * This method returns whether the {@link Server} should be restarted to apply the latest changes.
+     *
+     * @return Whether a restart is required.
+     */
+    public boolean isRestartRequired() {
+        return isRestartRequired;
+    }
+
+    @Nonnull
+    public Config getPluginConfig() {
+        return pluginConfig;
+    }
+
+    @Nonnull
+    public Config getItemsConfig() {
+        return itemsConfig;
+    }
+
+    @Nonnull
+    public Config getResearchConfig() {
+        return researchesConfig;
+    }
+
+    /**
+     * This method saves all our {@link Config} files.
+     */
+    public void saveFiles() {
+        pluginConfig.save();
+        itemsConfig.save();
+        researchesConfig.save();
+    }
+
+    /**
+     * This method returns whether backwards-compatibility is enabled.
+     * Backwards compatibility allows Slimefun to recognize items from older versions but comes
+     * at a huge performance cost.
+     *
+     * @return Whether backwards compatibility is enabled
+     */
+    public boolean isBackwardsCompatible() {
+        return enableBackwardsCompatibility;
+    }
+
+    /**
+     * This method sets the status of backwards compatibility.
+     * Backwards compatibility allows Slimefun to recognize items from older versions but comes
+     * at a huge performance cost.
+     *
+     * @param compatible
+     *            Whether backwards compatibility should be enabled
+     */
+    public void setBackwardsCompatible(boolean compatible) {
+        enableBackwardsCompatibility = compatible;
+    }
+
+    public void setResearchingEnabled(boolean enabled) {
+        enableResearching = enabled;
+    }
+
+    public boolean isResearchingEnabled() {
+        return enableResearching;
+    }
+
+    public void setFreeCreativeResearchingEnabled(boolean enabled) {
+        enableFreeCreativeResearches = enabled;
+    }
+
+    public boolean isFreeCreativeResearchingEnabled() {
+        return enableFreeCreativeResearches;
+    }
+
+    public boolean isResearchFireworkEnabled() {
+        return enableResearchFireworks;
+    }
+
+    public boolean isDuplicateBlockLoggingEnabled() {
+        return enableDuplicateBlockLogging;
+    }
+
+    public boolean isVanillaRecipeShown() {
+        return enableVanillaRecipesInGuide;
+    }
+
+    public boolean isItemGroupHiddenInSearch() {
+        return enableHiddenItemGroupInSearch;
+    }
+
+    public boolean isSlimefunGuideGivenOnJoin() {
+        return enableGuideOnJoin;
+    }
+
+    public boolean isUpdaterEnabled() {
+        return enableUpdater;
+    }
+
+    public boolean isTalismanMessageInActionbar() {
+        return enableActionbarTalismanMessages;
+    }
+
+    public boolean isExcessCommandItemsDroppingEnabled() {
+        return enableCommandItemDropExcess;
+    }
+
+    public boolean isLearningAnimationDisabled() {
+        return disableLearningAnimations;
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
@@ -67,12 +67,16 @@ public interface SlimefunGuideImplementation {
     default void unlockItem(Player p, SlimefunItem sfitem, Consumer<Player> callback) {
         Research research = sfitem.getResearch();
 
-        if (p.getGameMode() == GameMode.CREATIVE && Slimefun.getRegistry().isFreeCreativeResearchingEnabled()) {
+        if (research == null) {
+            return;
+        }
+
+        if (p.getGameMode() == GameMode.CREATIVE && Slimefun.getConfigManager().isFreeCreativeResearchingEnabled()) {
             research.unlock(p, true, callback);
         } else {
             p.setLevel(p.getLevel() - research.getCost());
 
-            boolean skipLearningAnimation = Slimefun.getRegistry().isLearningAnimationDisabled() || !SlimefunGuideSettings.hasLearningAnimationEnabled(p);
+            boolean skipLearningAnimation = Slimefun.getConfigManager().isLearningAnimationDisabled() || !SlimefunGuideSettings.hasLearningAnimationEnabled(p);
             research.unlock(p, skipLearningAnimation, callback);
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.core.guide.options;
 
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.core.config.SlimefunConfigManager;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -13,23 +14,25 @@ import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.core.SlimefunRegistry;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
+import javax.annotation.Nonnull;
+
 class FireworksOption implements SlimefunGuideOption<Boolean> {
 
     @Override
-    public SlimefunAddon getAddon() {
+    public @Nonnull SlimefunAddon getAddon() {
         return Slimefun.instance();
     }
 
     @Override
-    public NamespacedKey getKey() {
+    public @Nonnull NamespacedKey getKey() {
         return new NamespacedKey(Slimefun.instance(), "research_fireworks");
     }
 
     @Override
     public Optional<ItemStack> getDisplayItem(Player p, ItemStack guide) {
-        SlimefunRegistry registry = Slimefun.getRegistry();
+        SlimefunConfigManager configManagerManager = Slimefun.getConfigManager();
 
-        if (registry.isResearchingEnabled() && registry.isResearchFireworkEnabled()) {
+        if (configManagerManager.isResearchingEnabled() && configManagerManager.isResearchFireworkEnabled()) {
             boolean enabled = getSelectedOption(p, guide).orElse(true);
             ItemStack item = new CustomItemStack(Material.FIREWORK_ROCKET, "&bFireworks: &" + (enabled ? "aYes" : "4No"), "", "&7You can now toggle whether you", "&7will be presented with a big firework", "&7upon researching an item.", "", "&7\u21E8 &eClick to " + (enabled ? "disable" : "enable") + " your fireworks");
             return Optional.of(item);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
@@ -11,7 +11,6 @@ import org.bukkit.inventory.ItemStack;
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import io.github.thebusybiscuit.slimefun4.core.SlimefunRegistry;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 import javax.annotation.Nonnull;
@@ -56,7 +55,7 @@ class FireworksOption implements SlimefunGuideOption<Boolean> {
 
     @Override
     public void setSelectedOption(Player p, ItemStack guide, Boolean value) {
-        PersistentDataAPI.setByte(p, getKey(), value.booleanValue() ? (byte) 1 : (byte) 0);
+        PersistentDataAPI.setByte(p, getKey(), value ? (byte) 1 : (byte) 0);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/LearningAnimationOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/LearningAnimationOption.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import io.github.thebusybiscuit.slimefun4.core.SlimefunRegistry;
+import io.github.thebusybiscuit.slimefun4.core.config.SlimefunConfigManager;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 /**
@@ -40,9 +40,9 @@ class LearningAnimationOption implements SlimefunGuideOption<Boolean> {
     @Nonnull
     @Override
     public Optional<ItemStack> getDisplayItem(@Nonnull Player p, @Nonnull ItemStack guide) {
-        SlimefunRegistry registry = Slimefun.getRegistry();
+        SlimefunConfigManager configManager = Slimefun.getConfigManager();
 
-        if (!registry.isResearchingEnabled() || registry.isLearningAnimationDisabled()) {
+        if (!configManager.isResearchingEnabled() || configManager.isLearningAnimationDisabled()) {
             return Optional.empty();
         } else {
             boolean enabled = getSelectedOption(p, guide).orElse(true);
@@ -71,7 +71,7 @@ class LearningAnimationOption implements SlimefunGuideOption<Boolean> {
 
     @Override
     public void setSelectedOption(@Nonnull Player p, @Nonnull ItemStack guide, @Nonnull Boolean value) {
-        PersistentDataAPI.setByte(p, getKey(), (byte) (value.booleanValue() ? 1 : 0));
+        PersistentDataAPI.setByte(p, getKey(), (byte) (value ? 1 : 0));
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
@@ -62,7 +62,7 @@ public class LocalizationService extends SlimefunLocalization {
         languageKey = new NamespacedKey(plugin, LANGUAGE_PATH);
 
         if (serverDefaultLanguage != null) {
-            translationsEnabled = Slimefun.getCfg().getBoolean("options.enable-translations");
+            translationsEnabled = Slimefun.getConfigManager().getPluginConfig().getBoolean("options.enable-translations");
 
             defaultLanguage = new Language(serverDefaultLanguage, "11b3188fd44902f72602bd7c2141f5a70673a411adb3d81862c69e536166b");
             defaultLanguage.setFile(LanguageFile.MESSAGES, getConfig().getConfiguration());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
@@ -1,7 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.core.services;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +9,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.lang.Validate;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permissible;
@@ -57,17 +57,27 @@ public class PermissionsService {
      * @param save
      *            Whether to save the default values to our permissions file
      */
-    public void register(@Nonnull Iterable<SlimefunItem> items, boolean save) {
+    public void update(@Nonnull Iterable<SlimefunItem> items, boolean save) {
         for (SlimefunItem item : items) {
             if (item != null) {
-                String path = item.getId() + ".permission";
-
-                config.setDefaultValue(path, "none");
-                config.setDefaultValue(item.getId() + ".lore", new String[] { "&rYou do not have the permission", "&rto access this item." });
-
-                permissions.put(item.getId(), config.getString(path));
+                update(item, false);
             }
         }
+
+        if (save) {
+            config.save();
+        }
+    }
+
+    public void update(@Nonnull SlimefunItem item, boolean save) {
+        Preconditions.checkNotNull(item, "The Item should not be null!");
+
+        String path = item.getId() + ".permission";
+
+        config.setDefaultValue(path, "none");
+        config.setDefaultValue(item.getId() + ".lore", new String[] { "&rYou do not have the permission", "&rto access this item." });
+
+        permissions.put(item.getId(), config.getString(path));
 
         if (save) {
             config.save();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -134,7 +134,7 @@ public class UpdaterService {
      * @return Whether the {@link PluginUpdater} is enabled
      */
     public boolean isEnabled() {
-        return Slimefun.getCfg().getBoolean("options.auto-update") && updater != null;
+        return Slimefun.getConfigManager().isUpdaterEnabled() && updater != null;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -17,6 +17,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.core.config.SlimefunConfigManager;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.SlimefunGuideListener;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
@@ -657,9 +658,8 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         backpackListener.register(this);
 
 
-        //todo fix later
         // Handle Slimefun Guide being given on Join
-//        new SlimefunGuideListener(this, config.getBoolean("guide.receive-on-first-join"));
+        new SlimefunGuideListener(this, configManager.getPluginConfig().getBoolean("guide.receive-on-first-join"));
 
         // Clear the Slimefun Guide History upon Player Leaving
         new PlayerProfileListener(this);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/CheatSheetSlimefunGuide.java
@@ -34,7 +34,7 @@ public class CheatSheetSlimefunGuide extends SurvivalSlimefunGuide {
     private final ItemStack item;
 
     public CheatSheetSlimefunGuide() {
-        super(false, true);
+        super();
 
         item = new SlimefunGuideItem(this, "&cSlimefun Guide &4(Cheat Sheet)");
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -70,12 +70,8 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
     private final int[] recipeSlots = { 3, 4, 5, 12, 13, 14, 21, 22, 23 };
     private final ItemStack item;
-    private final boolean showVanillaRecipes;
-    private final boolean showHiddenItemGroupsInSearch;
 
-    public SurvivalSlimefunGuide(boolean showVanillaRecipes, boolean showHiddenItemGroupsInSearch) {
-        this.showVanillaRecipes = showVanillaRecipes;
-        this.showHiddenItemGroupsInSearch = showHiddenItemGroupsInSearch;
+    public SurvivalSlimefunGuide() {
         item = new SlimefunGuideItem(this, "&aSlimefun Guide &7(Chest GUI)");
     }
 
@@ -387,7 +383,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
     @ParametersAreNonnullByDefault
     private boolean isItemGroupAccessible(Player p, SlimefunItem slimefunItem) {
-        return showHiddenItemGroupsInSearch || slimefunItem.getItemGroup().isAccessible(p);
+        return Slimefun.getConfigManager().isItemGroupHiddenInSearch() || slimefunItem.getItemGroup().isAccessible(p);
     }
 
     @ParametersAreNonnullByDefault
@@ -412,7 +408,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
             return;
         }
 
-        if (!showVanillaRecipes) {
+        if (!Slimefun.getConfigManager().isVanillaRecipeShown()) {
             return;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -274,7 +274,7 @@ public class Talisman extends SlimefunItem {
             try {
                 String messageKey = "messages.talisman." + getMessageSuffix();
 
-                if (Slimefun.getRegistry().useActionbarForTalismans()) {
+                if (Slimefun.getConfigManager().isTalismanMessageInActionbar()) {
                     // Use the actionbar
                     Slimefun.getLocalization().sendActionbarMessage(p, messageKey, false);
                 } else {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -250,9 +250,10 @@ public class OreCrusher extends MultiBlockMachine {
         }
 
         @Override
-        public void reload() {
-            super.reload();
+        public boolean reload() {
+            boolean isSuccessful = super.reload();
             apply(getValue());
+            return isSuccessful;
         }
 
         public @Nonnull ItemStack getCoal() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -107,8 +107,7 @@ public final class PostSetup {
 
         sender.sendMessage("");
 
-        Slimefun.getItemCfg().save();
-        Slimefun.getResearchCfg().save();
+        Slimefun.getConfigManager().saveFiles();
         Slimefun.getRegistry().setAutoLoadingMode(true);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -165,7 +165,7 @@ public final class PostSetup {
         // Favour 8 Cobblestone -> 1 Sand Recipe over 1 Cobblestone -> 1 Gravel Recipe
         Stream<ItemStack[]> stream = grinderRecipes.stream();
 
-        if (!Slimefun.getCfg().getBoolean("options.legacy-ore-grinder")) {
+        if (!Slimefun.getConfigManager().getPluginConfig().getBoolean("options.legacy-ore-grinder")) {
             stream = stream.sorted((a, b) -> Integer.compare(b[0].getAmount(), a[0].getAmount()));
         }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -145,7 +145,7 @@ public class BlockStorage {
         long done = 0;
         long timestamp = System.currentTimeMillis();
         long totalBlocks = 0;
-        int delay = Slimefun.getCfg().getInt("URID.info-delay");
+        int delay = Slimefun.getConfigManager().getPluginConfig().getInt("URID.info-delay");
 
         try {
             for (File file : directory.listFiles()) {
@@ -200,7 +200,7 @@ public class BlockStorage {
                      * Ignore the new entry if a block is already present and print an
                      * error to the console (if enabled).
                      */
-                    if (Slimefun.getRegistry().logDuplicateBlockEntries()) {
+                    if (Slimefun.getConfigManager().isDuplicateBlockLoggingEnabled()) {
                         Slimefun.logger().log(Level.INFO, "Ignoring duplicate block @ {0}, {1}, {2} ({3} -> {4})", new Object[] { l.getBlockX(), l.getBlockY(), l.getBlockZ(), blockInfo.getString("id"), storage.get(l).getString("id") });
                     }
 

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -14,6 +14,12 @@ commands:
     reset: '&cYou have reset %player%''s Knowledge'
     reset-target: '&cYour Knowledge has been reset'
 
+  reload:
+    description: Reloads our config files
+    restart-required: '&eYour changes have been saved. But some of your changes require a restart to get applied!'
+    success: '&aYour configuration files have been successfully reloaded!'
+    errors: '&cYour configuration files have been reloaded, but some errors have been found! Please check your console for more info.'
+
   backpack:
     description: Retrieve a copy of an existing backpack
     invalid-id: '&4The id must be a non-negative number!'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -83,3 +83,6 @@ permissions:
   slimefun.debugging:
     description: Allows you to use the debugging tool from Slimefun
     default: op
+  slimefun.command.reload:
+    description: Allows you to do /sf reload
+    default: op

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestResearchCommand.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestResearchCommand.java
@@ -42,11 +42,11 @@ class TestResearchCommand {
     @Test
     @DisplayName("Test /sf research all")
     void testResearchAll() throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
 
-        server.executeConsole("slimefun", "research", player.getName(), "all").assertSucceeded();
+        server.executeConsole("sf", "research", player.getName(), "all").assertSucceeded();
 
         Assertions.assertTrue(profile.hasUnlocked(research));
         Assertions.assertTrue(profile.hasUnlocked(research2));
@@ -55,7 +55,7 @@ class TestResearchCommand {
     @Test
     @DisplayName("Test /sf research <research id>")
     void testResearchSpecific() throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
 
@@ -68,7 +68,7 @@ class TestResearchCommand {
     @Test
     @DisplayName("Test /sf research reset")
     void testResearchReset() throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestProfileResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestProfileResearches.java
@@ -37,7 +37,7 @@ class TestProfileResearches {
     @Test
     @DisplayName("Test setting a Research as unlocked")
     void testSetResearched() throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
 
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
@@ -58,7 +58,7 @@ class TestProfileResearches {
     @Test
     @DisplayName("Test checking if Research is unlocked")
     void testHasUnlocked() throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
 
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
@@ -77,14 +77,14 @@ class TestProfileResearches {
 
         // Researches are disabled now, so this method should pass
         // Whether Research#isEnabled() works correctly is covered elsewhere
-        Slimefun.getRegistry().setResearchingEnabled(false);
+        Slimefun.getConfigManager().setResearchingEnabled(false);
         Assertions.assertTrue(profile.hasUnlocked(research));
     }
 
     @Test
     @DisplayName("Test getting all unlocked Researches")
     void testGetResearches() throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
 
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearchUnlocking.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearchUnlocking.java
@@ -56,7 +56,7 @@ class TestResearchUnlocking {
     @DisplayName("Test Unlocking Researches")
     @ValueSource(booleans = { true, false })
     void testUnlock(boolean instant) throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
         Player player = server.addPlayer();
         Research research = new Research(new NamespacedKey(plugin, "unlock_me"), 1842, "Unlock me", 500);
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearches.java
@@ -82,7 +82,7 @@ class TestResearches {
         research.addItems(item, null);
         research.register();
 
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
 
         Assertions.assertTrue(research.isEnabled());
         Assertions.assertEquals(research, item.getResearch());
@@ -101,8 +101,8 @@ class TestResearches {
         SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", new CustomItemStack(Material.TORCH, "&bResearch Test"));
         research.addItems(item);
 
-        Slimefun.getRegistry().setResearchingEnabled(true);
-        Slimefun.getResearchCfg().setValue(key.getNamespace() + '.' + key.getKey() + ".enabled", false);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
+        Slimefun.getConfigManager().getResearchConfig().setValue(key.getNamespace() + '.' + key.getKey() + ".enabled", false);
         research.register();
 
         Assertions.assertFalse(research.isEnabled());
@@ -115,11 +115,11 @@ class TestResearches {
         NamespacedKey key = new NamespacedKey(plugin, "globally_disabled_research");
         Research research = new Research(key, 3, "Test", 100);
 
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
         Assertions.assertTrue(research.isEnabled());
-        Slimefun.getRegistry().setResearchingEnabled(false);
+        Slimefun.getConfigManager().setResearchingEnabled(false);
         Assertions.assertFalse(research.isEnabled());
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
     }
 
     @Test
@@ -138,7 +138,7 @@ class TestResearches {
 
     @Test
     void testPlayerCanUnlockDisabledResearch() {
-        Slimefun.getRegistry().setResearchingEnabled(false);
+        Slimefun.getConfigManager().setResearchingEnabled(false);
 
         Player player = server.addPlayer();
         NamespacedKey key = new NamespacedKey(plugin, "disabled_unlockable_research");
@@ -146,19 +146,19 @@ class TestResearches {
 
         Assertions.assertTrue(research.canUnlock(player));
 
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
     }
 
     @Test
     @DisplayName("Test 'free creative researching' option")
     void testFreeCreativeResearch() {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
 
         Player player = server.addPlayer();
         NamespacedKey key = new NamespacedKey(plugin, "free_creative_research");
         Research research = new Research(key, 153, "Test", 100);
 
-        Slimefun.getRegistry().setFreeCreativeResearchingEnabled(false);
+        Slimefun.getConfigManager().setFreeCreativeResearchingEnabled(false);
 
         player.setGameMode(GameMode.SURVIVAL);
         Assertions.assertFalse(research.canUnlock(player));
@@ -166,7 +166,7 @@ class TestResearches {
         player.setGameMode(GameMode.CREATIVE);
         Assertions.assertFalse(research.canUnlock(player));
 
-        Slimefun.getRegistry().setFreeCreativeResearchingEnabled(true);
+        Slimefun.getConfigManager().setFreeCreativeResearchingEnabled(true);
 
         player.setGameMode(GameMode.SURVIVAL);
         Assertions.assertFalse(research.canUnlock(player));
@@ -190,7 +190,7 @@ class TestResearches {
     @Test
     @DisplayName("Test PlayerPreResearchEvent")
     void testPreCanUnlockResearchEvent() throws InterruptedException {
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
 
         NamespacedKey key = new NamespacedKey(plugin, "simple_research");
         Research research = new Research(key, 250, "Test", 10);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestPermissionsService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestPermissionsService.java
@@ -47,7 +47,7 @@ class TestPermissionsService {
         SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", new CustomItemStack(Material.EMERALD, "&bBad omen"));
 
         if (registered) {
-            service.register(Arrays.asList(item), false);
+            service.update(Arrays.asList(item), false);
         }
 
         Optional<String> permission = service.getPermission(item);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.UnregisteredItemException;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
@@ -90,7 +90,7 @@ class TestItemGroups {
         Assertions.assertFalse(group.isVisible(player));
 
         SlimefunItem disabledItem = TestUtilities.mockSlimefunItem(plugin, "DISABLED_ITEM_GROUP_ITEM", new CustomItemStack(Material.BEETROOT, "&4Disabled"));
-        Slimefun.getItemCfg().setValue("DISABLED_ITEM_GROUP_ITEM.enabled", false);
+        Slimefun.getConfigManager().getItemsConfig().setValue("DISABLED_ITEM_GROUP_ITEM.enabled", false);
         disabledItem.setItemGroup(group);
         disabledItem.register(plugin);
         disabledItem.load();
@@ -174,7 +174,7 @@ class TestItemGroups {
         item.register(plugin);
         item.load();
 
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
         Research research = new Research(new NamespacedKey(plugin, "cant_touch_this"), 432432, "MC Hammer", 90);
         research.addItems(item);
         research.register();

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRegistration.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRegistration.java
@@ -67,14 +67,14 @@ class TestRegistration {
     @MethodSource("allItems")
     @ParameterizedTest(name = "Assert that {0} is enabled")
     void testNoDisabledItems(@Nonnull SlimefunItem item) {
-        Assertions.assertNotEquals(ItemState.UNREGISTERED, item.getState(), item.toString() + " was not registered?");
+        Assertions.assertNotEquals(ItemState.UNREGISTERED, item.getState(), item + " was not registered?");
     }
 
     @Test
     @Order(value = 3)
     @DisplayName("Test whether PostSetup.setupWiki() throws any Exceptions")
     void testWikiSetup() {
-        Assertions.assertDoesNotThrow(() -> PostSetup.setupWiki());
+        Assertions.assertDoesNotThrow(PostSetup::setupWiki);
     }
 
     @Test
@@ -103,19 +103,19 @@ class TestRegistration {
         // Not really ideal but still important to test.
         // Research amount is variable, so we can't test for that.
         // We are really only concerned about any runtime exceptions here.
-        Slimefun.getRegistry().setResearchingEnabled(true);
+        Slimefun.getConfigManager().setResearchingEnabled(true);
 
         // It is important that this is run after item registration
-        Assertions.assertDoesNotThrow(() -> ResearchSetup.setupResearches());
+        Assertions.assertDoesNotThrow(ResearchSetup::setupResearches);
 
         // Running it a second time should NOT be allowed.
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> ResearchSetup.setupResearches());
+        Assertions.assertThrows(UnsupportedOperationException.class, ResearchSetup::setupResearches);
     }
 
     @Test
     @Order(value = 6)
     void testPostSetup() {
-        Assertions.assertDoesNotThrow(() -> PostSetup.loadItems());
+        Assertions.assertDoesNotThrow(PostSetup::loadItems);
     }
 
     @Test


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Supercedes https://github.com/Slimefun/Slimefun4/pull/2822

This pull requests moves the config-related stuff from SlimefunRegistry to a dedicated Config Manager.
It also allows some basic reload functionality,, accessible via `/sf reload` (Many people requested this for a long time).
Note that this is not fully finished though, so not all changes are supported and a lot will still require a restart.

## Changes
<!-- Please list all the changes you have made. -->
* Added /sf reload
* Added Config Manager to handle our configs
* All relevant config files have been moved to this Config Manager class
* All relevant cached data was moved to the Config Manager too

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
