### PR TITLE
Deny placement when deletion is queued

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -90,20 +90,34 @@ public class BlockListener implements Listener {
             Slimefun.getProtectionManager().logAction(e.getPlayer(), e.getBlock(), Interaction.PLACE_BLOCK);
         }
         if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
-            if (!sfItem.canUse(e.getPlayer(), true)) {
+            Player player = e.getPlayer();
+
+            if (!sfItem.canUse(player, true)) {
                 e.setCancelled(true);
             } else {
-                SlimefunBlockPlaceEvent placeEvent = new SlimefunBlockPlaceEvent(e.getPlayer(), item, e.getBlock(), sfItem);
+                Block block = e.getBlockPlaced();
+
+                /*
+                 * Resolves an issue when placing a block in a location currently in the deletion queue
+                 * TODO This can be safely removed if/when the deletion no longer has a delay associated with it.
+                 */
+                if (Slimefun.getTickerTask().isDeletedSoon(block.getLocation())) {
+                    Slimefun.getLocalization().sendMessage(player, "messages.await-deletion");
+                    e.setCancelled(true);
+                    return;
+                }
+
+                SlimefunBlockPlaceEvent placeEvent = new SlimefunBlockPlaceEvent(player, item, block, sfItem);
                 Bukkit.getPluginManager().callEvent(placeEvent);
 
                 if (placeEvent.isCancelled()) {
                     e.setCancelled(true);
                 } else {
-                    if (Slimefun.getBlockDataService().isTileEntity(e.getBlock().getType())) {
-                        Slimefun.getBlockDataService().setBlockData(e.getBlock(), sfItem.getId());
+                    if (Slimefun.getBlockDataService().isTileEntity(block.getType())) {
+                        Slimefun.getBlockDataService().setBlockData(block, sfItem.getId());
                     }
 
-                    BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getId(), true);
+                    BlockStorage.addBlockInfo(block, "id", sfItem.getId(), true);
                     sfItem.callItemHandler(BlockPlaceHandler.class, handler -> handler.onPlayerPlace(e));
                 }
             }

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -172,6 +172,7 @@ messages:
   bee-suit-slow-fall: '&eYour Bee Wings will help you to get back to the ground safe and slow'
   deprecated-item: '&4This item has been deprecated and will be removed from Slimefun soon.'
   researching-is-disabled: '&cResearching has been disabled on this server. Everything is unlocked by default!'
+  await-deletion: '&cYou cannot place a Slimefun block so soon after breaking one. Try again shortly.'
 
   multi-tool:
     mode-change: '&b%device% mode changed to: &9%mode%'

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockBreakEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockBreakEvent.java
@@ -58,7 +58,7 @@ class TestSlimefunBlockBreakEvent {
         Player player = new PlayerMock(server, "SomePlayer");
 
         World world = server.addSimpleWorld("my_world");
-        Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, 1, 1, 1));
+        Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, TestUtilities.randomInt(), 100, TestUtilities.randomInt()));
 
         Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
         BlockStorage.addBlockInfo(block, "id", "FOOD_COMPOSTER");
@@ -75,7 +75,7 @@ class TestSlimefunBlockBreakEvent {
         player.getInventory().setItemInMainHand(itemStack);
 
         World world = server.addSimpleWorld("my_world");
-        Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, 1, 1, 1));
+        Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, TestUtilities.randomInt(), 100, TestUtilities.randomInt()));
 
         Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
         BlockStorage.addBlockInfo(block, "id", "FOOD_COMPOSTER");
@@ -106,7 +106,7 @@ class TestSlimefunBlockBreakEvent {
         player.getInventory().setItemInMainHand(itemStack);
 
         World world = server.addSimpleWorld("my_world");
-        Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, 1, 1, 1));
+        Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, TestUtilities.randomInt(), 100, TestUtilities.randomInt()));
 
         Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
         BlockStorage.addBlockInfo(block, "id", "FOOD_COMPOSTER");
@@ -118,5 +118,25 @@ class TestSlimefunBlockBreakEvent {
             Assertions.assertTrue(blockBreakEvent.isCancelled());
             return true;
         });
+    }
+
+    @Test
+    @DisplayName("Test that breaking a Slimefun block gets queued for deletion")
+    void testBlockBreaksGetQueuedForDeletion() {
+        Player player = new PlayerMock(server, "SomePlayer");
+        ItemStack itemStack = new ItemStack(Material.IRON_PICKAXE);
+        player.getInventory().setItemInMainHand(itemStack);
+
+        World world = server.addSimpleWorld("my_world");
+        Block block = new BlockMock(Material.GREEN_TERRACOTTA, new Location(world, TestUtilities.randomInt(), 100, TestUtilities.randomInt()));
+
+        Slimefun.getRegistry().getWorlds().put("my_world", new BlockStorage(world));
+        BlockStorage.addBlockInfo(block, "id", "FOOD_COMPOSTER");
+
+        BlockBreakEvent blockBreakEvent = new BlockBreakEvent(block, player);
+        server.getPluginManager().callEvent(blockBreakEvent);
+        server.getPluginManager().assertEventFired(SlimefunBlockBreakEvent.class, e -> true);
+
+        Assertions.assertTrue(Slimefun.getTickerTask().isDeletedSoon(block.getLocation()));
     }
 }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.test;
 
 import static org.mockito.Mockito.when;
 
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -29,6 +30,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.test.mocks.MockSlimefunItem;
 
 public final class TestUtilities {
+
+    private static final Random random = new Random();
 
     private TestUtilities() {}
 
@@ -75,5 +78,15 @@ public final class TestUtilities {
 
         latch.await(2, TimeUnit.SECONDS);
         return ref.get();
+    }
+
+    @ParametersAreNonnullByDefault
+    public static @Nonnull int randomInt() {
+        return random.nextInt(Integer.MAX_VALUE);
+    }
+
+    @ParametersAreNonnullByDefault
+    public static @Nonnull int randomInt(int upperBound) {
+        return random.nextInt(upperBound);
     }
 }


### PR DESCRIPTION
## Description
When breaking/placing blocks too quickly you can place a block and have the BlockStorage data subsequently removed resulting in loss of items. This has also caused fringe cases of blocks with multiple BlockMenus, ghost blocks and other oddities.

## Proposed changes
If a block is placed and the location is still queued for deletion, deny the block placement with a message to the player to let them know why it was denied.

This is a bit of a patch job, but a true resolution would be part of the BlockStorage rewrite and I feel is important enough to warrant a fix prior to that to ease server owners burdens.

Tested on 1.19.4 and no issues, worked as intended. But given the scope of potential effects community testing here would be wonderful :)

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
