### PR TITLE
Change Energized GPS Transmitter values to follow the pattern of previous tiers

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1923,12 +1923,12 @@ public final class SlimefunItemSetup {
             
             @Override
             public int getMultiplier(int y) {
-                return y * 64 + 600;
+                return y * 64 + 2100;
             }
 
             @Override
             public int getEnergyConsumption() {
-                return 46;
+                return 43;
             }
             
         }.register(plugin);


### PR DESCRIPTION
## Description
for basic, advanced and carbonado gps transmitters there is a pattern in the values
the multiplier follows ``previous tier * 4`` (1 -> 4 -> 16)
the bonus follows ``previous tier * 4 + 100`` (0 -> 100 -> 500)
the power consumption per blockticker tick follows ``previous tier * 4 - 1`` (1 -> 3 -> 11)

but for the energized gps transmitter this pattern mostly breaks
the multiplier follows the pattern and becomes 64 ``previous tier * 4``
however the bonus becomes 600 ``previous tier + 100``
and the power consumption becomes 46 ``previous tier * 4 + 2``

this means if you compare the 4 carbonado transmitters it takes to craft the energized to the energized, you would be better off with 4 carbonado transmitters rather than 1 energized.
the added complexity for 4 carbonado transmitters is ``4 * (y * 16 + 500) = 64y + 2000`` vs 1 energized ``1 * (y * 64 + 600) = 64y + 600``
and the power consumption per blockticker tick for 4 carbonado transmitters is ``4 * 11 = 44`` vs 1 energized ``1 * 46 = 46``

so you spend 2 blistering ingots, 1 carbonado and 2 nickel to gain less complexity and consume more power, making the energized gps transmitter obsolete in its current state
why not make the energized gps transmitter follow the pattern of the rest of the transmitters to make it actually relevant?

## Proposed changes
change ``getMultiplier(int y)`` to ``y * 64 + 2100`` (16 * 4 = 64 & 500 * 4 + 100 = 2100)
and ``getEnergyConsumption()`` to ``43`` (11 * 4 - 1 = 43)
