### PR TITLE
skip already substituted parts when formatting message

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/debug/Debug.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/debug/Debug.java
@@ -106,7 +106,7 @@ public final class Debug {
         while ((i = msg.indexOf('{', i)) != -1 && msg.charAt(i + 1) == '}') {
             // Substring up to the opening brace `{`, add the variable for this and add the rest of the message
             msg = msg.substring(0, i) + vars[idx] + msg.substring(i + 2);
-            idx++;
+            i += ("" + vars[idx++]).length();
         }
 
         return msg;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/debug/Debug.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/debug/Debug.java
@@ -106,7 +106,7 @@ public final class Debug {
         while ((i = msg.indexOf('{', i)) != -1 && msg.charAt(i + 1) == '}') {
             // Substring up to the opening brace `{`, add the variable for this and add the rest of the message
             msg = msg.substring(0, i) + vars[idx] + msg.substring(i + 2);
-            i += ("" + vars[idx++]).length();
+            i += String.valueOf(vars[idx++]).length();
         }
 
         return msg;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
``Debug::formatMessage`` doesn't work when ``vars[idx]`` cointains a ``{``
``msg.indexOf('{', i)`` will find the ``{`` that was just substituted in

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
replacing ``idx++;`` with ``i += ("" + vars[idx++]).length();`` should resolve this, because ``i`` will be moved to after anything that was just substituted in.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
