### PR TITLE
Adds a TalismanActivatedEvent which fires when a Player uses a Talisman.

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
@@ -1,0 +1,76 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.magical.talismans.Talisman;
+
+/**
+ * 
+ * This {@link PlayerEvent} is called when a {@link Player} activates a {@link Talisman}
+ * 
+ * @author cworldstar
+ *
+ */
+
+public class TalismanActivatedEvent extends PlayerEvent {
+
+	private static HandlerList Handlers = new HandlerList();
+	private Talisman Talisman;
+	private ItemStack TalismanItem;
+	
+	
+	/**
+	 * 
+	 * @param who
+	 * 		The {@link Player} who activated the talisman.
+	 * 
+	 * @param talisman
+	 * 		The {@link Talisman} that was activated.
+	 * 
+	 * @param talismanItem
+	 * 		The {@link ItemStack} corresponding to the Talisman.
+	 */
+	@ParametersAreNonnullByDefault
+	public TalismanActivatedEvent(Player who, Talisman talisman, ItemStack talismanItem) {
+		super(who);
+		this.Talisman = talisman;
+		this.TalismanItem = talismanItem;
+		// TODO Auto-generated constructor stub
+	}
+	/**
+	 * 
+	 * @return The {@link Talisman} used.
+	 *
+	 */
+	@Nonnull
+	public Talisman getTalisman() {
+		return this.Talisman;
+	}
+	/**
+	 * 
+	 * @return The {@link ItemStack} of the used {@link Talisman}.
+	 */
+	@Nonnull
+	public ItemStack getTalismanItem() {
+		return this.TalismanItem;
+	}
+
+	public static HandlerList getHandlerList() {
+		return Handlers;
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		// TODO Auto-generated method stub
+		return getHandlerList();
+	}
+
+	
+	
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
@@ -18,11 +19,12 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.magical.talismans
  *
  */
 
-public class TalismanActivatedEvent extends PlayerEvent {
+public class TalismanActivatedEvent extends PlayerEvent implements Cancellable {
 
 	private static HandlerList Handlers = new HandlerList();
 	private Talisman Talisman;
 	private ItemStack TalismanItem;
+	private boolean cancelled;
 	
 	
 	/**
@@ -69,6 +71,16 @@ public class TalismanActivatedEvent extends PlayerEvent {
 	public HandlerList getHandlers() {
 		// TODO Auto-generated method stub
 		return getHandlerList();
+	}
+	@Override
+	public boolean isCancelled() {
+		// TODO Auto-generated method stub
+		return this.cancelled;
+	}
+	@Override
+	public void setCancelled(boolean cancel) {
+		// TODO Auto-generated method stub
+		this.cancelled = cancel;
 	}
 
 	

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
@@ -22,14 +22,14 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.magical.talismans
 public class TalismanActivatedEvent extends PlayerEvent implements Cancellable {
 
 	private static HandlerList Handlers = new HandlerList();
-	private Talisman Talisman;
-	private ItemStack TalismanItem;
+	private Talisman talisman;
+	private ItemStack talismanItemStack;
 	private boolean cancelled;
 	
 	
 	/**
 	 * 
-	 * @param who
+	 * @param player
 	 * 		The {@link Player} who activated the talisman.
 	 * 
 	 * @param talisman
@@ -39,11 +39,10 @@ public class TalismanActivatedEvent extends PlayerEvent implements Cancellable {
 	 * 		The {@link ItemStack} corresponding to the Talisman.
 	 */
 	@ParametersAreNonnullByDefault
-	public TalismanActivatedEvent(Player who, Talisman talisman, ItemStack talismanItem) {
-		super(who);
-		this.Talisman = talisman;
-		this.TalismanItem = talismanItem;
-		// TODO Auto-generated constructor stub
+	public TalismanActivatedEvent(Player player, Talisman talisman, ItemStack talismanItem) {
+		super(player);
+		this.talisman = talisman;
+		this.talismanItemStack = talismanItem;
 	}
 	/**
 	 * 
@@ -52,7 +51,7 @@ public class TalismanActivatedEvent extends PlayerEvent implements Cancellable {
 	 */
 	@Nonnull
 	public Talisman getTalisman() {
-		return this.Talisman;
+		return this.talisman;
 	}
 	/**
 	 * 
@@ -60,7 +59,7 @@ public class TalismanActivatedEvent extends PlayerEvent implements Cancellable {
 	 */
 	@Nonnull
 	public ItemStack getTalismanItem() {
-		return this.TalismanItem;
+		return this.talismanItemStack;
 	}
 
 	public static HandlerList getHandlerList() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/TalismanActivatedEvent.java
@@ -68,17 +68,14 @@ public class TalismanActivatedEvent extends PlayerEvent implements Cancellable {
 	
 	@Override
 	public HandlerList getHandlers() {
-		// TODO Auto-generated method stub
 		return getHandlerList();
 	}
 	@Override
 	public boolean isCancelled() {
-		// TODO Auto-generated method stub
 		return this.cancelled;
 	}
 	@Override
 	public void setCancelled(boolean cancel) {
-		// TODO Auto-generated method stub
 		this.cancelled = cancel;
 	}
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -206,7 +206,7 @@ public class Talisman extends SlimefunItem {
         consumeItem(inv, talisman, talismanItem);
         applyTalismanEffects(p, talisman);
         cancelEvent(e, talisman);
-
+        Bukkit.getServer().getPluginManager().callEvent(new TalismanActivatedEvent(p, talisman, talismanItem));
         if (sendMessage) {
             talisman.sendMessage(p);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -207,7 +207,7 @@ public class Talisman extends SlimefunItem {
     private static void activateTalisman(Event e, Player p, Inventory inv, Talisman talisman, ItemStack talismanItem, boolean sendMessage) {
         TalismanActivatedEvent TalismanEvent = new TalismanActivatedEvent(p, talisman, talismanItem);
         Bukkit.getPluginManager().callEvent(TalismanEvent);
-        if(!TalismanEvent.isCancelled()) {
+        if (!TalismanEvent.isCancelled()) {
             consumeItem(inv, talisman, talismanItem);
             applyTalismanEffects(p, talisman);
             cancelEvent(e, talisman);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -211,6 +211,7 @@ public class Talisman extends SlimefunItem {
             consumeItem(inv, talisman, talismanItem);
             applyTalismanEffects(p, talisman);
             cancelEvent(e, talisman);
+
             if (sendMessage) {
                 talisman.sendMessage(p);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -27,6 +28,7 @@ import org.bukkit.potion.PotionEffect;
 
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.api.events.TalismanActivatedEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -206,7 +208,8 @@ public class Talisman extends SlimefunItem {
         consumeItem(inv, talisman, talismanItem);
         applyTalismanEffects(p, talisman);
         cancelEvent(e, talisman);
-        Bukkit.getServer().getPluginManager().callEvent(new TalismanActivatedEvent(p, talisman, talismanItem));
+        TalismanActivatedEvent TalismanEvent = new TalismanActivatedEvent(p, talisman, talismanItem);
+        Bukkit.getServer().getPluginManager().callEvent(TalismanEvent);
         if (sendMessage) {
             talisman.sendMessage(p);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -205,13 +205,15 @@ public class Talisman extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
     private static void activateTalisman(Event e, Player p, Inventory inv, Talisman talisman, ItemStack talismanItem, boolean sendMessage) {
-        consumeItem(inv, talisman, talismanItem);
-        applyTalismanEffects(p, talisman);
-        cancelEvent(e, talisman);
         TalismanActivatedEvent TalismanEvent = new TalismanActivatedEvent(p, talisman, talismanItem);
         Bukkit.getPluginManager().callEvent(TalismanEvent);
-        if (sendMessage) {
-            talisman.sendMessage(p);
+        if(!TalismanEvent.isCancelled()) {
+            consumeItem(inv, talisman, talismanItem);
+            applyTalismanEffects(p, talisman);
+            cancelEvent(e, talisman);
+            if (sendMessage) {
+                talisman.sendMessage(p);
+            }
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -212,6 +212,7 @@ public class Talisman extends SlimefunItem {
             applyTalismanEffects(p, talisman);
             cancelEvent(e, talisman);
 
+
             if (sendMessage) {
                 talisman.sendMessage(p);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -209,7 +209,7 @@ public class Talisman extends SlimefunItem {
         applyTalismanEffects(p, talisman);
         cancelEvent(e, talisman);
         TalismanActivatedEvent TalismanEvent = new TalismanActivatedEvent(p, talisman, talismanItem);
-        Bukkit.getServer().getPluginManager().callEvent(TalismanEvent);
+        Bukkit.getPluginManager().callEvent(TalismanEvent);
         if (sendMessage) {
             talisman.sendMessage(p);
         }


### PR DESCRIPTION
## Description
I found it odd that there wasn't an event to listen for when Talismans are activated, and thought it would be
helpful for one to be added.

## Proposed changes
Added TalismanActivationEvent, which extends PlayerEvent.
It is fired when the static function activateTalisman is called.

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
