### PR TITLE
Deobfuscate blocks when gold panning

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/OrebfuscatorIntegration.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/OrebfuscatorIntegration.java
@@ -18,7 +18,7 @@ import io.github.thebusybiscuit.slimefun4.api.events.ExplosiveToolBreakBlocksEve
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.ReactorExplodeEvent;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.items.tools.GoldPan;
 
 import net.imprex.orebfuscator.api.OrebfuscatorService;
 
@@ -68,8 +68,7 @@ class OrebfuscatorIntegration implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onGoldPanUse(PlayerRightClickEvent event) {
         if (event.getSlimefunItem().isPresent() && event.getClickedBlock().isPresent()) {
-            String id = event.getSlimefunItem().get().getId();
-            if (id.equals(SlimefunItems.GOLD_PAN.getItemId()) || id.equals(SlimefunItems.NETHER_GOLD_PAN.getItemId())) {
+            if (event.getSlimefunItem().get() instanceof GoldPan) {
                 this.service.deobfuscate(List.of(event.getClickedBlock().get()));
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/OrebfuscatorIntegration.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/OrebfuscatorIntegration.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.integrations;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -14,8 +15,10 @@ import org.bukkit.event.Listener;
 
 import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.ExplosiveToolBreakBlocksEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.ReactorExplodeEvent;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 
 import net.imprex.orebfuscator.api.OrebfuscatorService;
 
@@ -60,5 +63,15 @@ class OrebfuscatorIntegration implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onReactorExplode(ReactorExplodeEvent event) {
         this.service.deobfuscate(Arrays.asList(event.getLocation().getBlock()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onGoldPanUse(PlayerRightClickEvent event) {
+        if (event.getSlimefunItem().isPresent() && event.getClickedBlock().isPresent()) {
+            String id = event.getSlimefunItem().get().getId();
+            if (id.equals(SlimefunItems.GOLD_PAN.getItemId()) || id.equals(SlimefunItems.NETHER_GOLD_PAN.getItemId())) {
+                this.service.deobfuscate(List.of(event.getClickedBlock().get()));
+            }
+        }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/OrebfuscatorIntegration.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/OrebfuscatorIntegration.java
@@ -67,10 +67,8 @@ class OrebfuscatorIntegration implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onGoldPanUse(PlayerRightClickEvent event) {
-        if (event.getSlimefunItem().isPresent() && event.getClickedBlock().isPresent()) {
-            if (event.getSlimefunItem().get() instanceof GoldPan) {
-                this.service.deobfuscate(List.of(event.getClickedBlock().get()));
-            }
+        if (event.getSlimefunItem().isPresent() && event.getClickedBlock().isPresent() && event.getSlimefunItem().get() instanceof GoldPan) {
+            this.service.deobfuscate(List.of(event.getClickedBlock().get()));
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When using the gold pan with orebfuscator it doesn't update the obfuscated blocks

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add an event handler for the gold pan to ``OrebfuscatorIntegration.java`` that deobfuscates the blocks

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3764

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
