### PR TITLE
Patch for #3922

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -94,7 +94,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
     public @Nonnull Optional<Item> getPlacedItem(@Nonnull Block pedestal) {
         Location l = pedestal.getLocation().add(0.5, 1.2, 0.5);
 
-        for (Entity n : l.getWorld().getNearbyEntities(l, 0.5, 0.5, 0.5, this::testItem)) {
+        for (Entity n : l.getWorld().getNearbyEntities(l, 0.5, 0.5, 0.5, AncientPedestal::testItem)) {
             if (n instanceof Item item) {
                 return Optional.of(item);
             }
@@ -120,7 +120,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
         return createIfNoneExists ? ArmorStandUtils.spawnArmorStand(l) : null;
     }
 
-    private boolean testItem(@Nullable Entity n) {
+    public static boolean testItem(@Nullable Entity n) {
         if (n instanceof Item item && n.isValid()) {
             ItemMeta meta = item.getItemStack().getItemMeta();
 
@@ -172,7 +172,6 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
         if (entity != null) {
             ArmorStand armorStand = getArmorStand(b, true);
             entity.setInvulnerable(true);
-            entity.setUnlimitedLifetime(true);
             entity.setVelocity(new Vector(0, 0.1, 0));
             entity.setCustomNameVisible(true);
             entity.setCustomName(nametag);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -364,5 +364,4 @@ public class AncientAltarListener implements Listener {
             e.setCancelled(true);
         }
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -24,6 +24,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.items.CustomItemStack;
@@ -355,6 +356,13 @@ public class AncientAltarListener implements Listener {
         }
 
         return Optional.empty();
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onItemDespawn(ItemDespawnEvent e) {
+        if (AncientPedestal.testItem(e.getEntity())) {
+            e.setCancelled(true);
+        }
     }
 
 }


### PR DESCRIPTION
## Description
Making this PR to remove a version dependent method that was missed with the ancient altar fix PR

## Proposed changes
Resolves #3922 

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
