### PR TITLE
don't consume bookbinder inputs if the output is worse than the input

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
@@ -57,6 +57,20 @@ public class BookBinder extends AContainer {
 
                 // Just return if no enchantments exist. This shouldn't ever happen. :NotLikeThis:
                 if (enchantments.size() > 0) {
+                    // If any of the books contain an enchantment level higher that the configured maximum: don't consume the items
+                    for (Map.Entry<Enchantment, Integer> entry : storedItemEnchantments.entrySet()) {
+                        int maxLevel = bypassVanillaMaxLevel.getValue() ? customMaxLevel.getValue() : entry.getKey().getMaxLevel();
+                        if (entry.getValue() > maxLevel) {
+                            return null;
+                        }
+                    }
+                    for (Map.Entry<Enchantment, Integer> entry : storedTargetEnchantments.entrySet()) {
+                        int maxLevel = bypassVanillaMaxLevel.getValue() ? customMaxLevel.getValue() : entry.getKey().getMaxLevel();
+                        if (entry.getValue() > maxLevel) {
+                            return null;
+                        }
+                    }
+
                     ItemStack book = new ItemStack(Material.ENCHANTED_BOOK);
 
                     EnchantmentStorageMeta enchantMeta = (EnchantmentStorageMeta) book.getItemMeta();
@@ -67,6 +81,11 @@ public class BookBinder extends AContainer {
 
                     // Make sure we never return an enchanted book with no enchantments.
                     if (enchantMeta.getStoredEnchants().isEmpty()) {
+                        return null;
+                    }
+
+                    // If the output is the same as one of the inputs: don't consume items
+                    if (enchantMeta.getStoredEnchants().equals(storedItemEnchantments) || enchantMeta.getStoredEnchants().equals(storedTargetEnchantments)) {
                         return null;
                     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
@@ -57,18 +57,8 @@ public class BookBinder extends AContainer {
 
                 // Just return if no enchantments exist. This shouldn't ever happen. :NotLikeThis:
                 if (enchantments.size() > 0) {
-                    // If any of the books contain an enchantment level higher that the configured maximum: don't consume the items
-                    for (Map.Entry<Enchantment, Integer> entry : storedItemEnchantments.entrySet()) {
-                        int maxLevel = bypassVanillaMaxLevel.getValue() ? customMaxLevel.getValue() : entry.getKey().getMaxLevel();
-                        if (entry.getValue() > maxLevel) {
-                            return null;
-                        }
-                    }
-                    for (Map.Entry<Enchantment, Integer> entry : storedTargetEnchantments.entrySet()) {
-                        int maxLevel = bypassVanillaMaxLevel.getValue() ? customMaxLevel.getValue() : entry.getKey().getMaxLevel();
-                        if (entry.getValue() > maxLevel) {
-                            return null;
-                        }
+                    if (hasIllegalEnchants(storedItemEnchantments) || hasIllegalEnchants(storedTargetEnchantments)) {
+                        return null;
                     }
 
                     ItemStack book = new ItemStack(Material.ENCHANTED_BOOK);
@@ -114,6 +104,20 @@ public class BookBinder extends AContainer {
 
     private boolean isCompatible(@Nullable ItemStack item) {
         return item != null && item.getType() == Material.ENCHANTED_BOOK;
+    }
+
+    private boolean hasIllegalEnchants(@Nullable Map<Enchantment, Integer> enchantments) {
+        if (enchantments == null) {
+            return false;
+        }
+
+        for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
+            int maxLevel = bypassVanillaMaxLevel.getValue() ? customMaxLevel.getValue() : entry.getKey().getMaxLevel();
+            if (entry.getValue() > maxLevel) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/BookBinder.java
@@ -112,8 +112,7 @@ public class BookBinder extends AContainer {
         }
 
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
-            int maxLevel = bypassVanillaMaxLevel.getValue() ? customMaxLevel.getValue() : entry.getKey().getMaxLevel();
-            if (entry.getValue() > maxLevel) {
+            if (bypassVanillaMaxLevel.getValue() && entry.getValue() > customMaxLevel.getValue() || !bypassVanillaMaxLevel.getValue() && entry.getValue() > entry.getKey().getMaxLevel()) {
                 return true;
             }
         }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The bookbinder used to accept any book and just reset any level higher that the configured max back to the max.
For example protection 10 + protection 10 = protection 4

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
If any of the books contains an enchantment level higher than the configured max: don't consume the items
If the output would be the same any of the inputs: don't consume the items

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3247

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
