### PR TITLE
fixed grappling hook not working due to bat dying

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GrapplingHook.java
@@ -12,8 +12,6 @@ import org.bukkit.entity.Bat;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import io.github.bakedlibs.dough.items.ItemUtils;
@@ -58,7 +56,7 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
             UUID uuid = p.getUniqueId();
             boolean isConsumed = consumeOnUse.getValue() && p.getGameMode() != GameMode.CREATIVE;
 
-            if (!e.getClickedBlock().isPresent() && !Slimefun.getGrapplingHookListener().isGrappling(uuid)) {
+            if (e.getClickedBlock().isEmpty() && !Slimefun.getGrapplingHookListener().isGrappling(uuid)) {
                 e.cancel();
 
                 if (p.getInventory().getItemInOffHand().getType() == Material.BOW) {
@@ -79,10 +77,11 @@ public class GrapplingHook extends SimpleSlimefunItem<ItemUseHandler> {
                 arrow.setVelocity(direction);
 
                 Bat bat = (Bat) p.getWorld().spawnEntity(p.getLocation(), EntityType.BAT);
+                bat.setInvulnerable(true);
                 bat.setCanPickupItems(false);
                 bat.setAI(false);
                 bat.setSilent(true);
-                bat.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 100000, 100000));
+                bat.setInvisible(true);
                 bat.setLeashHolder(arrow);
 
                 boolean state = item.getType() != Material.SHEARS;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When the grappling hook bat died, the lead was dropped.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Make the bat invulnerable.

Other changes:
replaced invisibility potion effect with ``setInvisible(true)``
replaced ``!isPresent()`` with ``isEmpty()``

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #2352

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
