### PR TITLE
Adjust ticker times to show correct time on config changes for custom-ticker-delay

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang.Validate;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
-
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
 
 /**
@@ -40,7 +40,15 @@ public class CraftingOperation implements MachineOperation {
     @Override
     public void addProgress(int num) {
         Validate.isTrue(num > 0, "Progress must be positive.");
-        currentTicks += num;
+
+        /**
+         * Normalize the tickrate to the config value custom-ticker-delay.
+         * This makes the machines run nearly the same speed on changing the delay.
+         */
+        int tickRate = Slimefun.getTickerTask().getTickRate();
+        int normalizedTickRate = (int) Math.round((tickRate / 10.0D) * num);
+
+        currentTicks += Math.max(normalizedTickRate, num);
     }
 
     public @Nonnull ItemStack[] getIngredients() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -181,7 +181,7 @@ public final class NumberUtils {
         int seconds = ticksLeft;
 
         if (normalScale < 0) {
-            //Adjust for positive change
+            // Adjust for positive change
             seconds = (int) (ticksLeft * (normalScale / 2 + 1.0D));
         } else if (normalScale > 0) {
             // Adjust for negative change

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -170,11 +170,9 @@ public final class NumberUtils {
         }
     }
 
-    public static @Nonnull String getTimeLeft(int ticksLeft) {
-        String timeleft = "";
-
+    public static @Nonnull String getTimeLeftFromTick(int ticksLeft) {
         /**
-         * This is the amount calculated in addProgress(). 
+         * This is the amount calculated in addProgress().
          * This will be the scale used for timer.
          */
         double timeScale = Slimefun.getTickerTask().getTickRate() / 10.0D;
@@ -186,9 +184,15 @@ public final class NumberUtils {
             //Adjust for positive change
             seconds = (int) (ticksLeft * (normalScale / 2 + 1.0D));
         } else if (normalScale > 0) {
-            // Adjust for negative change 
+            // Adjust for negative change
             seconds = (int) (ticksLeft * (normalScale + 1.0D));
         }
+
+        return getTimeLeft(seconds);
+    }
+
+    public static @Nonnull String getTimeLeft(int seconds) {
+        String timeleft = "";
 
         int minutes = (int) (seconds / 60L);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -25,7 +25,6 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
  *
  */
 public final class NumberUtils {
-
     /**
      * This is our {@link DecimalFormat} for decimal values.
      * This instance is not thread-safe!
@@ -171,8 +170,25 @@ public final class NumberUtils {
         }
     }
 
-    public static @Nonnull String getTimeLeft(int seconds) {
+    public static @Nonnull String getTimeLeft(int ticksLeft) {
         String timeleft = "";
+
+        /**
+         * This is the amount calculated in addProgress(). 
+         * This will be the scale used for timer.
+         */
+        double timeScale = Slimefun.getTickerTask().getTickRate() / 10.0D;
+        double normalScale = timeScale - Math.round(timeScale);
+
+        int seconds = ticksLeft;
+
+        if (normalScale < 0) {
+            //Adjust for positive change
+            seconds = (int) (ticksLeft * (normalScale / 2 + 1.0D));
+        } else if (normalScale > 0) {
+            // Adjust for negative change 
+            seconds = (int) (ticksLeft * (normalScale + 1.0D));
+        }
 
         int minutes = (int) (seconds / 60L);
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->

This PR adjust the tick rate based on the config value for custom-ticker-delay.
It will try to keep the tickers execution at a similar speed as to when the default value is used.

I also adjust the displayed time based on the difference of execution time.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

Changed CraftingOperation to take into account the new ticks config. Normalize the value to the default one of one operation per 10 ticks. 

Changed NumberUtils. Added logic that calculates the time new changes will take to finish the operation.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

Not sure if there is na issue open.

Here is how to reproduce the issue:
1. Adjust custom-ticker-delay to 20.
2. Run a ticker ingame.
3. The display timer will be wrong the execution slows down by 1/2 so the secounds and minutes are not synced to the actual values.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.14.* - 1.19.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
