### PR TITLE
exploded sf blocks now drop their sf item

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/SimpleBlockBreakHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/SimpleBlockBreakHandler.java
@@ -10,8 +10,11 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.events.AndroidMineEvent;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.androids.MinerAndroid;
+
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 
 /**
  * This simple implementation of {@link BlockBreakHandler} will execute the same code
@@ -54,6 +57,9 @@ public abstract class SimpleBlockBreakHandler extends BlockBreakHandler {
     @Override
     public void onExplode(Block b, List<ItemStack> drops) {
         onBlockBreak(b);
+        SlimefunItem sfItem = BlockStorage.check(b);
+        if (sfItem != null)
+            drops.addAll(sfItem.getDrops());
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/SimpleBlockBreakHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/SimpleBlockBreakHandler.java
@@ -58,8 +58,9 @@ public abstract class SimpleBlockBreakHandler extends BlockBreakHandler {
     public void onExplode(Block b, List<ItemStack> drops) {
         onBlockBreak(b);
         SlimefunItem sfItem = BlockStorage.check(b);
-        if (sfItem != null)
+        if (sfItem != null) {
             drops.addAll(sfItem.getDrops());
+        }
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ExplosionsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ExplosionsListener.java
@@ -9,6 +9,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -82,7 +83,7 @@ public class ExplosionsListener implements Listener {
     private void removeResistantBlock(@Nonnull Block block, @Nonnull SlimefunItem slimefunItem) {
         // Fixes #3414 - This check removes the ghost block created by withers.
         if (!(slimefunItem instanceof WitherProof)
-            && !slimefunItem.callItemHandler(BlockBreakHandler.class, handler -> handleExplosion(handler, block, slimefunItem))
+            && !slimefunItem.callItemHandler(BlockBreakHandler.class, handler -> handleExplosion(handler, block))
         ) {
             BlockStorage.clearBlockInfo(block);
             block.setType(Material.AIR);
@@ -90,7 +91,7 @@ public class ExplosionsListener implements Listener {
     }
 
     @ParametersAreNonnullByDefault
-    private void handleExplosion(BlockBreakHandler handler, Block block, SlimefunItem sfItem) {
+    private void handleExplosion(BlockBreakHandler handler, Block block) {
         if (handler.isExplosionAllowed(block)) {
             BlockStorage.clearBlockInfo(block);
             block.setType(Material.AIR);
@@ -98,7 +99,7 @@ public class ExplosionsListener implements Listener {
             List<ItemStack> drops = new ArrayList<>();
             handler.onExplode(block, drops);
 
-            for (ItemStack drop : sfItem.getDrops()) {
+            for (ItemStack drop : drops) {
                 if (drop != null && !drop.getType().isAir()) {
                     block.getWorld().dropItemNaturally(block.getLocation(), drop);
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ExplosionsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ExplosionsListener.java
@@ -9,7 +9,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -83,7 +82,7 @@ public class ExplosionsListener implements Listener {
     private void removeResistantBlock(@Nonnull Block block, @Nonnull SlimefunItem slimefunItem) {
         // Fixes #3414 - This check removes the ghost block created by withers.
         if (!(slimefunItem instanceof WitherProof)
-            && !slimefunItem.callItemHandler(BlockBreakHandler.class, handler -> handleExplosion(handler, block))
+            && !slimefunItem.callItemHandler(BlockBreakHandler.class, handler -> handleExplosion(handler, block, slimefunItem))
         ) {
             BlockStorage.clearBlockInfo(block);
             block.setType(Material.AIR);
@@ -91,7 +90,7 @@ public class ExplosionsListener implements Listener {
     }
 
     @ParametersAreNonnullByDefault
-    private void handleExplosion(BlockBreakHandler handler, Block block) {
+    private void handleExplosion(BlockBreakHandler handler, Block block, SlimefunItem sfItem) {
         if (handler.isExplosionAllowed(block)) {
             BlockStorage.clearBlockInfo(block);
             block.setType(Material.AIR);
@@ -99,7 +98,7 @@ public class ExplosionsListener implements Listener {
             List<ItemStack> drops = new ArrayList<>();
             handler.onExplode(block, drops);
 
-            for (ItemStack drop : drops) {
+            for (ItemStack drop : sfItem.getDrops()) {
                 if (drop != null && !drop.getType().isAir()) {
                     block.getWorld().dropItemNaturally(block.getLocation(), drop);
                 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Slimefun blocks didn't drop when exploded because the ``drops`` argument in ``BlockBreakHandler::onExplode`` did nothing.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
~~Pass the ``SlimefunItem`` to the ``handleEplosion`` method in ``ExplosionsListener.java`` and drop the item there.~~

~~Other changes:~~
~~Removed unused import.~~

~~I didn't change the method signature for ``BlockBreakHandler::onExplode`` since it's a public method and that seemed like a bad idea to change.~~

EDIT: Changed approach completely. Now added drops logic to ``SimpleBlockBreakHandler::onExplode``.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3601
Also resolves Slimefun blocks not dropping from explosions, but somehow there was no issue open
 
## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
