### PR TITLE
Fix Soulbound Runes not working 

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/SoulboundRune.java
@@ -117,7 +117,7 @@ public class SoulboundRune extends SimpleSlimefunItem<ItemDropHandler> {
      */
     private boolean findCompatibleItem(@Nonnull Entity entity) {
         if (entity instanceof Item item) {
-            return item.getPickupDelay() == 0 && !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
+            return item.getPickupDelay() <= 0 && !SlimefunUtils.isSoulbound(item.getItemStack()) && !isItem(item.getItemStack());
         }
 
         return false;


### PR DESCRIPTION
## Description
Soulbound Runes can work properly.

## Proposed changes
In #3659 , `itemPickupDelay()`have been changed 'to ensure item can be picked up by players before the soulbound code converts the item'.

However, it produced another problem. In some Minecraft server core, Spigot for example, `Item.getPickupDelay()` (which was added in #3659 ) can return NEGATIVE values to show that the item is able to be picked up.

As a result, In some server, Soulbound Runes seldom work properly, distinct from other servers.

So i make a small change to fix it.

## Related Issues (if applicable)
Resolves #3876 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [I I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
