### PR TITLE
reactor actually explode option

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -255,8 +255,15 @@ public class EnergyNet extends Network implements HologramOwner {
                     BlockStorage.clearBlockInfo(loc);
 
                     Slimefun.runSync(() -> {
+                        io.github.bakedlibs.dough.config.Config cfg = Slimefun.getCfg();
+
+                        if (cfg.getBoolean("networks.reactor.explode-on-meltdown")) {
+                            loc.getWorld().createExplosion(loc, cfg.getFloat("networks.reactor.power"), cfg.getBoolean("networks.reactor.fire"), cfg.getBoolean("networks.reactor.break-blocks"));
+                        } else {
+                            loc.getWorld().createExplosion(loc, 0F, false);
+                        }
+
                         loc.getBlock().setType(Material.LAVA);
-                        loc.getWorld().createExplosion(loc, 0F, false);
                     });
                 } else {
                     supply = NumberUtils.flowSafeAddition(supply, energy);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,6 +42,11 @@ networks:
   cargo-ticker-delay: 0
   enable-visualizer: true
   delete-excess-items: false
+  reactor:
+    explode-on-meltdown: false
+    power: 4 # 4 = TNT
+    fire: true
+    break-blocks: true
 
 talismans:
   use-actionbar: true


### PR DESCRIPTION
## Description
Allows owners to choose whether they want reactors to actually explode on meltdown.

## Proposed changes
Added explosion to the meltdown logic.

## Related Issues (if applicable)
n/a

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
