### PR TITLE
Feature/block drop creative

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -207,7 +208,9 @@ public class BlockListener implements Listener {
                 for (ItemStack drop : drops) {
                     // Prevent null or air from being dropped
                     if (drop != null && drop.getType() != Material.AIR) {
-                        e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
+                        if (e.getPlayer().getGameMode() == GameMode.CREATIVE && Slimefun.getCfg().getBoolean("options.drop-block-creative")) {
+                            e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
+                        }
                     }
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -208,7 +208,7 @@ public class BlockListener implements Listener {
                 for (ItemStack drop : drops) {
                     // Prevent null or air from being dropped
                     if (drop != null && drop.getType() != Material.AIR) {
-                        if (e.getPlayer().getGameMode() == GameMode.CREATIVE && Slimefun.getCfg().getBoolean("options.drop-block-creative")) {
+                        if (e.getPlayer().getGameMode() != GameMode.CREATIVE || Slimefun.getCfg().getBoolean("options.drop-block-creative")) {
                             e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
                         }
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -207,7 +208,7 @@ public class BlockListener implements Listener {
                 for (ItemStack drop : drops) {
                     // Prevent null or air from being dropped
                     if (drop != null && drop.getType() != Material.AIR) {
-                        if (Slimefun.getCfg().getBoolean("options.drop-block-creative")) {
+                        if (e.getPlayer().getGameMode() == GameMode.CREATIVE && Slimefun.getCfg().getBoolean("options.drop-block-creative")) {
                             e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
                         }
                     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,7 @@ options:
   burn-players-when-radioactive: true
   drop-excess-sf-give-items: false
   backup-data: true
+  drop-block-creative: true
 
 guide:
   show-vanilla-recipes: true


### PR DESCRIPTION
## Description
Allows owners to configure whether slimefun blocks should drop when broken by players in creative mode.

## Proposed changes
Added a creative and config check when dropping sf block.

## Related Issues (if applicable)
n/a

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
