### PR TITLE
Fix #3931

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/RainbowArmorTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/RainbowArmorTask.java
@@ -7,7 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 
-import io.github.thebusybiscuit.slimefun4.api.items.HashedArmorpiece;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.implementation.items.armor.RainbowArmorPiece;
 
@@ -30,15 +30,10 @@ public class RainbowArmorTask extends AbstractArmorTask {
     protected void onPlayerTick(Player p, PlayerProfile profile) {
         for (int i = 0; i < 4; i++) {
             ItemStack item = p.getInventory().getArmorContents()[i];
+            SlimefunItem sfItem = SlimefunItem.getByItem(item);
 
-            if (item != null && item.hasItemMeta()) {
-                HashedArmorpiece armorPiece = profile.getArmor()[i];
-
-                armorPiece.getItem().ifPresent(sfArmorPiece -> {
-                    if (sfArmorPiece instanceof RainbowArmorPiece rainbowArmorPiece && rainbowArmorPiece.canUse(p, true)) {
-                        updateRainbowArmor(item, rainbowArmorPiece);
-                    }
-                });
+            if (sfItem instanceof RainbowArmorPiece rainbowArmorPiece && rainbowArmorPiece.canUse(p, true)) {
+                updateRainbowArmor(item, rainbowArmorPiece);
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Due to a desync in ``SlimefunArmorTask`` and ``RainbowArmorTask`` other leather armor could be recolored.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Compare against the item the player is currently wearing instead of the cached item.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves https://github.com/Slimefun/Slimefun4/issues/3931

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
