### PR TITLE
Fixes duplication glitch with explosive tools in combination with itemsadder

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -6,7 +6,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import dev.lone.itemsadder.api.CustomBlock;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -138,7 +138,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             return false;
         } else if (!b.getWorld().getWorldBorder().isInside(b.getLocation())) {
             return false;
-        } else if (Slimefun.getIntegrations().isCustomBlock(b)) {
+        } else if (CustomBlock.byAlreadyPlaced(b) != null) {
             return false;
         } else {
             return Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.BREAK_BLOCK);
@@ -173,9 +173,6 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
                 b.setType(Material.AIR);
                 BlockStorage.clearBlockInfo(b);
             }
-        // Fixes #3836
-        } else if (CustomBlock.byAlreadyPlaced(b) != null) {
-            return;
         } else {
             b.breakNaturally(item);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -138,7 +138,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             return false;
         } else if (!b.getWorld().getWorldBorder().isInside(b.getLocation())) {
             return false;
-        } else if (CustomBlock.byAlreadyPlaced(b) == null) {
+        } else if (Slimefun.getIntegrations().isCustomBlock(b)) {
             return false;
         } else {
             return Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.BREAK_BLOCK);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -84,7 +84,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             if (!blockExplodeEvent.isCancelled()) {
                 for (Block block : blockExplodeEvent.blockList()) {
                     if (canBreak(p, block)) {
-                        if (CustomBlock.byAlreadyPlaced(block) != null) {
+                        if (Slimefun.getIntegrations().isCustomBlock(block)) {
                             drops.addAll(CustomBlock.byAlreadyPlaced(block).getLoot());
                             CustomBlock.remove(block.getLocation());
                         }
@@ -95,7 +95,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         } else {
             for (Block block : blocks) {
                 if (canBreak(p, block)) {
-                    if (CustomBlock.byAlreadyPlaced(block) != null) {
+                    if (Slimefun.getIntegrations().isCustomBlock(block)) {
                         drops.addAll(CustomBlock.byAlreadyPlaced(block).getLoot());
                         CustomBlock.remove(block.getLocation());
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import dev.lone.itemsadder.api.CustomBlock;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -35,9 +36,9 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 
 /**
  * This {@link SlimefunItem} is a super class for items like the {@link ExplosivePickaxe} or {@link ExplosiveShovel}.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see ExplosivePickaxe
  * @see ExplosiveShovel
  *
@@ -83,6 +84,10 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             if (!blockExplodeEvent.isCancelled()) {
                 for (Block block : blockExplodeEvent.blockList()) {
                     if (canBreak(p, block)) {
+                        if (CustomBlock.byAlreadyPlaced(block) != null) {
+                            drops.addAll(CustomBlock.byAlreadyPlaced(block).getLoot());
+                            CustomBlock.remove(block.getLocation());
+                        }
                         blocksToDestroy.add(block);
                     }
                 }
@@ -90,6 +95,10 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         } else {
             for (Block block : blocks) {
                 if (canBreak(p, block)) {
+                    if (CustomBlock.byAlreadyPlaced(block) != null) {
+                        drops.addAll(CustomBlock.byAlreadyPlaced(block).getLoot());
+                        CustomBlock.remove(block.getLocation());
+                    }
                     blocksToDestroy.add(block);
                 }
             }
@@ -136,8 +145,6 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         } else if (SlimefunTag.UNBREAKABLE_MATERIALS.isTagged(b.getType())) {
             return false;
         } else if (!b.getWorld().getWorldBorder().isInside(b.getLocation())) {
-            return false;
-        } else if (Slimefun.getIntegrations().isCustomBlock(b)) {
             return false;
         } else {
             return Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.BREAK_BLOCK);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -138,7 +138,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
             return false;
         } else if (!b.getWorld().getWorldBorder().isInside(b.getLocation())) {
             return false;
-        } else if (CustomBlock.byAlreadyPlaced(b) != null) {
+        } else if (CustomBlock.byAlreadyPlaced(b) == null) {
             return false;
         } else {
             return Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.BREAK_BLOCK);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import dev.lone.itemsadder.api.CustomBlock;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -172,6 +173,9 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
                 b.setType(Material.AIR);
                 BlockStorage.clearBlockInfo(b);
             }
+        // Fixes #3836
+        } else if (CustomBlock.byAlreadyPlaced(b) != null) {
+            return;
         } else {
             b.breakNaturally(item);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/IntegrationsManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/IntegrationsManager.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import dev.lone.itemsadder.api.CustomBlock;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
@@ -236,7 +237,7 @@ public class IntegrationsManager {
     public boolean isCustomBlock(@Nonnull Block block) {
         if (isItemsAdderInstalled) {
             try {
-                return ItemsAdder.isCustomBlock(block);
+                return CustomBlock.byAlreadyPlaced(block) != null;
             } catch (Exception | LinkageError x) {
                 logError("ItemsAdder", x);
             }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This PR resolves a duplication glitch with the Items adder plugin and Slimefun.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Disable blockbreak when its a custom block from items adder.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3836 


## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
