### PR TITLE
fix getting radiated when not supposed to

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -493,24 +493,17 @@ public class PlayerProfile {
 
         for (HashedArmorpiece armorpiece : armor) {
             Optional<SlimefunArmorPiece> armorPiece = armorpiece.getItem();
-
-            if (!armorPiece.isPresent()) {
-                setId = null;
-            } else if (armorPiece.get() instanceof ProtectiveArmor protectedArmor) {
-                if (setId == null && protectedArmor.isFullSetRequired()) {
-                    setId = protectedArmor.getArmorSetId();
-                }
-
-                for (ProtectionType protectionType : protectedArmor.getProtectionTypes()) {
+            if (armorPiece.isPresent() && armorPiece.get() instanceof ProtectiveArmor protectiveArmor) {
+                for (ProtectionType protectionType : protectiveArmor.getProtectionTypes()) {
                     if (protectionType == type) {
-                        if (setId == null) {
+                        if (!protectiveArmor.isFullSetRequired()) {
                             return true;
-                        } else if (setId.equals(protectedArmor.getArmorSetId())) {
+                        } else if (setId == null || setId.equals(protectiveArmor.getArmorSetId())) {
                             armorCount++;
+                            setId = protectiveArmor.getArmorSetId();
                         }
                     }
                 }
-
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -82,6 +82,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.GrapplingHook
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.HopperListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.ItemDropListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.ItemPickupListener;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.JoinListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.MiddleClickListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.MiningAndroidListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.MultiBlockListener;
@@ -646,6 +647,7 @@ public final class Slimefun extends JavaPlugin implements SlimefunAddon {
         new BeeWingsListener(this, (BeeWings) SlimefunItems.BEE_WINGS.getItem());
         new PiglinListener(this);
         new SmithingTableListener(this);
+        new JoinListener(this);
 
         // Item-specific Listeners
         new CoolerListener(this, (Cooler) SlimefunItems.COOLER.getItem());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/JoinListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/JoinListener.java
@@ -33,8 +33,9 @@ public class JoinListener implements Listener {
             final ItemStack[] armorContents = e.getPlayer().getInventory().getArmorContents();
             final HashedArmorpiece[] hashedArmorpieces = playerProfile.getArmor();
             for (int i = 0; i < 4; i++) {
-                if (armorContents[i] != null && armorContents[i].getType() != Material.AIR && SlimefunItem.getByItem(armorContents[i]) instanceof SlimefunArmorPiece sfArmorPiece) {
-                    hashedArmorpieces[i].update(armorContents[i], sfArmorPiece);
+                final ItemStack armorPiece = armorContents[i];
+                if (armorPiece != null && armorPiece.getType() != Material.AIR && SlimefunItem.getByItem(armorPiece) instanceof SlimefunArmorPiece sfArmorPiece) {
+                    hashedArmorpieces[i].update(armorPiece, sfArmorPiece);
                 }
             }
         });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/JoinListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/JoinListener.java
@@ -1,0 +1,43 @@
+package io.github.thebusybiscuit.slimefun4.implementation.listeners;
+
+import javax.annotation.Nonnull;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.thebusybiscuit.slimefun4.api.items.HashedArmorpiece;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.items.armor.SlimefunArmorPiece;
+import io.github.thebusybiscuit.slimefun4.implementation.tasks.armor.RadiationTask;
+
+/**
+ * This {@link Listener} caches the armor of the player on join.
+ * This is mainly for the {@link RadiationTask}.
+ *
+ * @author iTwins
+ */
+public class JoinListener implements Listener {
+
+    public JoinListener(@Nonnull Slimefun plugin) {
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onJoin(@Nonnull PlayerJoinEvent e) {
+        PlayerProfile.get(e.getPlayer(), playerProfile -> {
+            final ItemStack[] armorContents = e.getPlayer().getInventory().getArmorContents();
+            final HashedArmorpiece[] hashedArmorpieces = playerProfile.getArmor();
+            for (int i = 0; i < 4; i++) {
+                if (armorContents[i] != null && armorContents[i].getType() != Material.AIR && SlimefunItem.getByItem(armorContents[i]) instanceof SlimefunArmorPiece sfArmorPiece) {
+                    hashedArmorpieces[i].update(armorContents[i], sfArmorPiece);
+                }
+            }
+        });
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/RadiationTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/RadiationTask.java
@@ -85,6 +85,8 @@ public class RadiationTask extends AbstractArmorTask {
                 BaseComponent[] components = new ComponentBuilder().append(ChatColors.color(msg)).create();
                 p.spigot().sendMessage(ChatMessageType.ACTION_BAR, components);
             }
+        } else {
+            RadiationUtils.removeExposure(p, 1);
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
There were 3 cases where you would get radiated when you weren't supposed to. The first case was when joining and having radioactive materials in your inventory. The radiation task would run before the armor task, meaning the radiation task would think you weren't wearing protective gear. The second case was ``hasFullProtectionAgainst`` returning false is some cases where it was supposed to return true. Example: infinity leggings with hazmat boots. The third case was when you were exposed to radiation, then put on protective armor, the exposure would stay. Meaning that when you would take your armor of you would get radiated again, even if you hadn't had radioactive materials in your inventory for a while.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
1. Cache armor on join
2. Rewrite ``hasFullProtectionAgainst`` to actually work correctly in all cases.
3. Decay exposure when fully protected

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3945

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
