### PR TITLE
fix geo miner voiding resources

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineOperation.java
@@ -57,4 +57,10 @@ public interface MachineOperation {
         return getRemainingTicks() <= 0;
     }
 
+    /**
+     * This method is called when a {@link MachineOperation} is interrupted before finishing.
+     * Implement to specify behaviour that should happen in this case.
+     */
+    default void cancel() {}
+
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineProcessor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineProcessor.java
@@ -6,7 +6,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -46,7 +47,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *            The owner of this {@link MachineProcessor}.
      */
     public MachineProcessor(@Nonnull MachineProcessHolder<T> owner) {
-        Validate.notNull(owner, "The MachineProcessHolder cannot be null.");
+        Preconditions.checkArgument(owner != null, "The MachineProcessHolder cannot be null.");
 
         this.owner = owner;
     }
@@ -93,8 +94,8 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} has already been started at that {@link Location}.
      */
     public boolean startOperation(@Nonnull Location loc, @Nonnull T operation) {
-        Validate.notNull(loc, "The location must not be null");
-        Validate.notNull(operation, "The operation cannot be null");
+        Preconditions.checkArgument(loc != null, "The location must not be null");
+        Preconditions.checkArgument(operation != null, "The operation cannot be null");
 
         return startOperation(new BlockPosition(loc), operation);
     }
@@ -111,8 +112,8 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} has already been started at that {@link Block}.
      */
     public boolean startOperation(@Nonnull Block b, @Nonnull T operation) {
-        Validate.notNull(b, "The Block must not be null");
-        Validate.notNull(operation, "The machine operation cannot be null");
+        Preconditions.checkArgument(b != null, "The Block must not be null");
+        Preconditions.checkArgument(operation != null, "The machine operation cannot be null");
 
         return startOperation(new BlockPosition(b), operation);
     }
@@ -129,8 +130,8 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} has already been started at that {@link BlockPosition}.
      */
     public boolean startOperation(@Nonnull BlockPosition pos, @Nonnull T operation) {
-        Validate.notNull(pos, "The BlockPosition must not be null");
-        Validate.notNull(operation, "The machine operation cannot be null");
+        Preconditions.checkArgument(pos != null, "The BlockPosition must not be null");
+        Preconditions.checkArgument(operation != null, "The machine operation cannot be null");
 
         return machines.putIfAbsent(pos, operation) == null;
     }
@@ -144,7 +145,7 @@ public class MachineProcessor<T extends MachineOperation> {
      * @return The current {@link MachineOperation} or null.
      */
     public @Nullable T getOperation(@Nonnull Location loc) {
-        Validate.notNull(loc, "The location cannot be null");
+        Preconditions.checkArgument(loc != null, "The location cannot be null");
 
         return getOperation(new BlockPosition(loc));
     }
@@ -158,15 +159,13 @@ public class MachineProcessor<T extends MachineOperation> {
      * @return The current {@link MachineOperation} or null.
      */
     public @Nullable T getOperation(@Nonnull Block b) {
-        Validate.notNull(b, "The Block cannot be null");
+        Preconditions.checkArgument(b != null, "The Block cannot be null");
 
         return getOperation(new BlockPosition(b));
     }
 
     /**
      * This returns the current {@link MachineOperation} at that given {@link BlockPosition}.
-     * We don't need to validate our input here as that is already
-     * covered in our public methods.
      * 
      * @param pos
      *            The {@link BlockPosition} at which our machine is located.
@@ -174,7 +173,7 @@ public class MachineProcessor<T extends MachineOperation> {
      * @return The current {@link MachineOperation} or null.
      */
     public @Nullable T getOperation(@Nonnull BlockPosition pos) {
-        Validate.notNull(pos, "The BlockPosition must not be null");
+        Preconditions.checkArgument(pos != null, "The BlockPosition must not be null");
 
         return machines.get(pos);
     }
@@ -189,7 +188,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} to begin with.
      */
     public boolean endOperation(@Nonnull Location loc) {
-        Validate.notNull(loc, "The location should not be null");
+        Preconditions.checkArgument(loc != null, "The location should not be null");
 
         return endOperation(new BlockPosition(loc));
     }
@@ -204,7 +203,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} to begin with.
      */
     public boolean endOperation(@Nonnull Block b) {
-        Validate.notNull(b, "The Block should not be null");
+        Preconditions.checkArgument(b != null, "The Block should not be null");
 
         return endOperation(new BlockPosition(b));
     }
@@ -219,7 +218,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} to begin with.
      */
     public boolean endOperation(@Nonnull BlockPosition pos) {
-        Validate.notNull(pos, "The BlockPosition cannot be null");
+        Preconditions.checkArgument(pos != null, "The BlockPosition cannot be null");
 
         T operation = machines.remove(pos);
 
@@ -231,6 +230,8 @@ public class MachineProcessor<T extends MachineOperation> {
             if (operation.isFinished()) {
                 Event event = new AsyncMachineOperationFinishEvent(pos, this, operation);
                 Bukkit.getPluginManager().callEvent(event);
+            } else {
+                operation.cancel();
             }
 
             return true;
@@ -240,8 +241,8 @@ public class MachineProcessor<T extends MachineOperation> {
     }
 
     public void updateProgressBar(@Nonnull BlockMenu inv, int slot, @Nonnull T operation) {
-        Validate.notNull(inv, "The inventory must not be null.");
-        Validate.notNull(operation, "The MachineOperation must not be null.");
+        Preconditions.checkArgument(inv != null, "The inventory must not be null.");
+        Preconditions.checkArgument(operation != null, "The MachineOperation must not be null.");
 
         if (getProgressBar() == null) {
             // No progress bar, no need to update anything.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/MiningOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/MiningOperation.java
@@ -1,12 +1,18 @@
 package io.github.thebusybiscuit.slimefun4.implementation.operations;
 
+import java.util.OptionalInt;
+
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
+
+import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
+import io.github.thebusybiscuit.slimefun4.api.geo.ResourceManager;
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.geo.GEOMiner;
 
 /**
@@ -22,20 +28,24 @@ public class MiningOperation implements MachineOperation {
 
     private final ItemStack result;
 
+    private final GEOResource resource;
+    private final Block block;
     private final int totalTicks;
     private int currentTicks = 0;
 
-    public MiningOperation(@Nonnull ItemStack result, int totalTicks) {
-        Validate.notNull(result, "The result cannot be null");
-        Validate.isTrue(totalTicks >= 0, "The amount of total ticks must be a positive integer or zero, received: " + totalTicks);
+    public MiningOperation(@Nonnull GEOResource resource, Block block, int totalTicks) {
+        Preconditions.checkArgument(resource != null, "The resource cannot be null");
+        Preconditions.checkArgument(totalTicks >= 0, "The amount of total ticks must be a positive integer or zero, received: " + totalTicks);
 
-        this.result = result;
+        this.resource = resource;
+        this.result = resource.getItem().clone();
+        this.block = block;
         this.totalTicks = totalTicks;
     }
 
     @Override
     public void addProgress(int num) {
-        Validate.isTrue(num > 0, "Progress must be positive.");
+        Preconditions.checkArgument(num > 0, "Progress must be positive.");
         currentTicks += num;
     }
 
@@ -57,6 +67,13 @@ public class MiningOperation implements MachineOperation {
     @Override
     public int getTotalTicks() {
         return totalTicks;
+    }
+
+    @Override
+    public void cancel() {
+        ResourceManager resourceManager = Slimefun.getGPSNetwork().getResourceManager();
+        OptionalInt supplies = resourceManager.getSupplies(resource, block.getWorld(), block.getX() >> 4, block.getZ() >> 4);
+        supplies.ifPresent(s -> resourceManager.setSupplies(resource, block.getWorld(), block.getX() >> 4, block.getZ() >> 4, s + 1));
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When breaking a geo miner the resource it was currently mining would get voided.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Write logic for ``MachineOperation``s to allow for behavior to be implemented when a ``MachineOperation`` is interrupted without finishing. Use this to return the resource to the chunk when a ``MiningOperation`` is interrupted.
I also fixed annotations and Preconditions in the affected classes.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
