### PR TITLE
Update pom.xml to use latest dough commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-api</artifactId>
-            <version>39856a32c4</version>
+            <version>d3b0997226</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updates dough to version d3b0997226, this fixes HuskTowns breaking Slimefun4 functionality.

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
After discovering the hook for HuskTowns was out of date in dough causing Slimefun multiblocks to not function, @NCBPFluffyBear fixed that issue, thus this needs updated to support those changes.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Just a dough version bump.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves protection issues causing multiblocks and machines to not function. No issue report was opened.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
