### PR TITLE
Allow sword of beheading drop piglin heads

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
@@ -5,8 +5,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import org.bukkit.Material;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Monster;
@@ -19,12 +17,14 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.settings.IntRangeSetting;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.EntityKillHandler;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 
 /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
@@ -5,6 +5,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import org.bukkit.Material;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Monster;
@@ -80,7 +82,8 @@ public class SwordOfBeheading extends SimpleSlimefunItem<EntityKillHandler> {
                     }
                 }
                 case PIGLIN -> {
-                    if (random.nextInt(100) < chancePiglin.getValue()) {
+                    if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_20) &&
+                        random.nextInt(100) < chancePiglin.getValue()) {
                         e.getDrops().add(new ItemStack(Material.PIGLIN_HEAD));
                     }
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
@@ -8,6 +8,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.Material;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Monster;
+import org.bukkit.entity.Piglin;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Skeleton;
 import org.bukkit.entity.WitherSkeleton;
@@ -26,7 +27,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 
 /**
  * The {@link SwordOfBeheading} is a special kind of sword which allows you to obtain
- * {@link Zombie}, {@link Skeleton} and {@link Creeper} skulls when killing the respective {@link Monster}.
+ * {@link Zombie}, {@link Skeleton}, {@link Creeper} and {@link Piglin} skulls when killing the respective
+ * {@link Monster}.
  * Additionally, you can also obtain the head of a {@link Player} by killing them too.
  * This sword also allows you to have a higher chance of getting the skull of a {@link WitherSkeleton} too.
  * 
@@ -41,13 +43,14 @@ public class SwordOfBeheading extends SimpleSlimefunItem<EntityKillHandler> {
     private final ItemSetting<Integer> chanceSkeleton = new IntRangeSetting(this, "chance.SKELETON", 0, 40, 100);
     private final ItemSetting<Integer> chanceWitherSkeleton = new IntRangeSetting(this, "chance.WITHER_SKELETON", 0, 25, 100);
     private final ItemSetting<Integer> chanceCreeper = new IntRangeSetting(this, "chance.CREEPER", 0, 40, 100);
+    private final ItemSetting<Integer> chancePiglin = new IntRangeSetting(this, "chance.PIGLIN", 0, 40, 100);
     private final ItemSetting<Integer> chancePlayer = new IntRangeSetting(this, "chance.PLAYER", 0, 70, 100);
 
     @ParametersAreNonnullByDefault
     public SwordOfBeheading(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
-        addItemSetting(chanceZombie, chanceSkeleton, chanceWitherSkeleton, chanceCreeper, chancePlayer);
+        addItemSetting(chanceZombie, chanceSkeleton, chanceWitherSkeleton, chanceCreeper, chancePiglin, chancePlayer);
     }
 
     @Override
@@ -56,27 +59,32 @@ public class SwordOfBeheading extends SimpleSlimefunItem<EntityKillHandler> {
             Random random = ThreadLocalRandom.current();
 
             switch (e.getEntityType()) {
-                case ZOMBIE:
+                case ZOMBIE -> {
                     if (random.nextInt(100) < chanceZombie.getValue()) {
                         e.getDrops().add(new ItemStack(Material.ZOMBIE_HEAD));
                     }
-                    break;
-                case SKELETON:
+                }
+                case SKELETON -> {
                     if (random.nextInt(100) < chanceSkeleton.getValue()) {
                         e.getDrops().add(new ItemStack(Material.SKELETON_SKULL));
                     }
-                    break;
-                case CREEPER:
+                }
+                case CREEPER -> {
                     if (random.nextInt(100) < chanceCreeper.getValue()) {
                         e.getDrops().add(new ItemStack(Material.CREEPER_HEAD));
                     }
-                    break;
-                case WITHER_SKELETON:
+                }
+                case WITHER_SKELETON -> {
                     if (random.nextInt(100) < chanceWitherSkeleton.getValue()) {
                         e.getDrops().add(new ItemStack(Material.WITHER_SKELETON_SKULL));
                     }
-                    break;
-                case PLAYER:
+                }
+                case PIGLIN -> {
+                    if (random.nextInt(100) < chancePiglin.getValue()) {
+                        e.getDrops().add(new ItemStack(Material.PIGLIN_HEAD));
+                    }
+                }
+                case PLAYER -> {
                     if (random.nextInt(100) < chancePlayer.getValue()) {
                         ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
 
@@ -86,9 +94,9 @@ public class SwordOfBeheading extends SimpleSlimefunItem<EntityKillHandler> {
 
                         e.getDrops().add(skull);
                     }
-                    break;
-                default:
-                    break;
+                }
+                default -> {
+                }
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/weapons/SwordOfBeheading.java
@@ -95,8 +95,7 @@ public class SwordOfBeheading extends SimpleSlimefunItem<EntityKillHandler> {
                         e.getDrops().add(skull);
                     }
                 }
-                default -> {
-                }
+                default -> {}
             }
         };
     }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
According to Minecraft wiki [Head](https://minecraft.fandom.com/wiki/Head) page, piglin head is available but there is no way to get it through Sword of Beheading. I think it should drop a piglin head when killing a piglin.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Use enhanced switch.
- Add piglin head as drop when killing piglins.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
