### PR TITLE
Fix sensitive blocks attached to sf blocks not dropping (1.19+)

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -235,12 +235,12 @@ public class BlockListener implements Listener {
      *
      * @param block
      *      The {@link Block} in question
-     * @param c
+     * @param count
      *      The amount of times this has been recursively called
      */
     @ParametersAreNonnullByDefault
-    private void checkForSensitiveBlocks(Block block, Integer c) {
-        if (c >= Bukkit.getServer().getMaxChainedNeighborUpdates()) {
+    private void checkForSensitiveBlocks(Block block, Integer count) {
+        if (count >= Bukkit.getServer().getMaxChainedNeighborUpdates()) {
             return;
         }
         for (BlockFace face : CARDINAL_BLOCKFACES) {
@@ -250,7 +250,7 @@ public class BlockListener implements Listener {
                 for (ItemStack drop : relative.getDrops()) {
                     block.getWorld().dropItemNaturally(relative.getLocation(), drop);
                 }
-                checkForSensitiveBlocks(relative, ++c);
+                checkForSensitiveBlocks(relative, ++count);
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -266,6 +266,7 @@ public class BlockListener implements Listener {
      * @return
      *      Whether the {@link BlockData} would be supported at the given {@link Block}
      */
+    @ParametersAreNonnullByDefault
     private boolean isSupported(BlockData blockData, Block block) {
         if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_19)) {
             return blockData.isSupported(block);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When you would break a Slimefun block any sensitive blocks attached to it would be destroyed, but not drop their item.
This fix only works for 1.19+, but that accounts for 4/5 of all Slimefun servers. Feel free to suggest a 1.16-1.18 version.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Recursively check all attached sensitive blocks and drop them if they should be, while respecting ``max-chained-neighbor-updates`` in ``server.properties``.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3182 
Resolves #3831 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
