### PR TITLE
fix generating geo resources every scan

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
@@ -237,7 +237,7 @@ public class ResourceManager {
         for (int i = page * 28; i < resources.size() && i < (page + 1) * 28; i++) {
             GEOResource resource = resources.get(i);
             OptionalInt optional = getSupplies(resource, block.getWorld(), x, z);
-            int supplies = optional.orElse(generate(resource, block.getWorld(), x, block.getY(), z));
+            int supplies = optional.orElseGet(() -> generate(resource, block.getWorld(), x, block.getY(), z));
             String suffix = Slimefun.getLocalization().getResourceString(p, ChatUtils.checkPlurality("tooltips.unit", supplies));
 
             ItemStack item = new CustomItemStack(resource.getItem(), "&f" + resource.getName(p), "&8\u21E8 &e" + supplies + ' ' + suffix);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
``OptionalInt.orElse`` evaluates the result even when the optional is present.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
replace ``orElse`` with ``orElseGet`` (which doesn't evaluate if the optional is present).

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3974

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
