### PR TITLE
fix breaking sf block with not unlocked item duping contents

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -141,15 +141,15 @@ public class BlockListener implements Listener {
             }
         }
 
+        int fortune = getBonusDropsWithFortune(item, e.getBlock());
+        List<ItemStack> drops = new ArrayList<>();
+
+        if (!item.getType().isAir()) {
+            callToolHandler(e, item, fortune, drops);
+        }
+
         if (!e.isCancelled()) {
             checkForSensitiveBlockAbove(e.getPlayer(), e.getBlock(), item);
-
-            int fortune = getBonusDropsWithFortune(item, e.getBlock());
-            List<ItemStack> drops = new ArrayList<>();
-
-            if (!item.getType().isAir()) {
-                callToolHandler(e, item, fortune, drops);
-            }
 
             callBlockHandler(e, item, drops, sfItem);
             dropItems(e, drops);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -141,10 +141,10 @@ public class BlockListener implements Listener {
             }
         }
 
-        int fortune = getBonusDropsWithFortune(item, e.getBlock());
         List<ItemStack> drops = new ArrayList<>();
 
         if (!item.getType().isAir()) {
+            int fortune = getBonusDropsWithFortune(item, e.getBlock());
             callToolHandler(e, item, fortune, drops);
         }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I you broke a Slimefun block with a not unlocked item the contents of the inventory of the block would still drop. This is because the block handler would still get called no matter the results of the tool handler.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Move the tool handler code outside of the ``if (!e.isCancelled())`` block. That way if the tool handler cancels the event, the block handler won't get called. This should have no side effects since ``ignoreCancelled`` is true and there is nothing that cancels the event above the changed code.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
https://discord.com/channels/565557184348422174/565569196218384385/1153792378327535738

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
