### PR TITLE
Filter unlocked researches of player

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -1,6 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.api.player;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -36,7 +37,6 @@ import io.github.bakedlibs.dough.config.Config;
 import io.github.thebusybiscuit.slimefun4.api.events.AsyncProfileLoadEvent;
 import io.github.thebusybiscuit.slimefun4.api.gps.Waypoint;
 import io.github.thebusybiscuit.slimefun4.api.items.HashedArmorpiece;
-import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.core.attributes.ProtectionType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.ProtectiveArmor;
@@ -325,35 +325,52 @@ public class PlayerProfile {
         return Optional.empty();
     }
 
-    // returns the amount of researches with at least 1 enabled item
-    private int nonEmptyResearches() {
-        return (int) Slimefun.getRegistry().getResearches()
-                .stream()
-                .filter(research -> research.getAffectedItems().stream().anyMatch(item -> item.getState() == ItemState.ENABLED))
-                .count();
+    private int countNonEmptyResearches(@Nonnull Collection<Research> researches) {
+        int count = 0;
+        for (Research research : researches) {
+            if (research.hasEnabledItems()) {
+                count++;
+            }
+        }
+        return count;
     }
 
+    /**
+     * This method gets the research title, as defined in {@code config.yml},
+     * of this {@link PlayerProfile} based on the fraction
+     * of unlocked {@link Research}es of this player.
+     *
+     * @return The research title of this {@link PlayerProfile}
+     */
     public @Nonnull String getTitle() {
         List<String> titles = Slimefun.getRegistry().getResearchRanks();
 
-        float fraction = (float) researches.size() / nonEmptyResearches();
+        int allResearches = countNonEmptyResearches(Slimefun.getRegistry().getResearches());
+        float fraction = (float) countNonEmptyResearches(researches) / allResearches;
         int index = (int) (fraction * (titles.size() - 1));
 
         return titles.get(index);
     }
 
+    /**
+     * This sends the statistics for the specified {@link CommandSender}
+     * to the {@link CommandSender}. This includes research title, research progress
+     * and total xp spent.
+     *
+     * @param sender The {@link CommandSender} for which to get the statistics and send them to.
+     */
     public void sendStats(@Nonnull CommandSender sender) {
-        Set<Research> unlockedResearches = getResearches();
-        int levels = unlockedResearches.stream().mapToInt(Research::getCost).sum();
-        int allResearches = nonEmptyResearches();
+        int unlockedResearches = countNonEmptyResearches(getResearches());
+        int levels = getResearches().stream().mapToInt(Research::getCost).sum();
+        int allResearches = countNonEmptyResearches(Slimefun.getRegistry().getResearches());
 
-        float progress = Math.round(((unlockedResearches.size() * 100.0F) / allResearches) * 100.0F) / 100.0F;
+        float progress = Math.round(((unlockedResearches * 100.0F) / allResearches) * 100.0F) / 100.0F;
 
         sender.sendMessage("");
         sender.sendMessage(ChatColors.color("&7Statistics for Player: &b" + name));
         sender.sendMessage("");
         sender.sendMessage(ChatColors.color("&7Title: " + ChatColor.AQUA + getTitle()));
-        sender.sendMessage(ChatColors.color("&7Research Progress: " + NumberUtils.getColorFromPercentage(progress) + progress + " &r% " + ChatColor.YELLOW + '(' + unlockedResearches.size() + " / " + allResearches + ')'));
+        sender.sendMessage(ChatColors.color("&7Research Progress: " + NumberUtils.getColorFromPercentage(progress) + progress + " &r% " + ChatColor.YELLOW + '(' + unlockedResearches + " / " + allResearches + ')'));
         sender.sendMessage(ChatColors.color("&7Total XP Levels spent: " + ChatColor.AQUA + levels));
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
@@ -22,6 +22,7 @@ import org.bukkit.inventory.ItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerPreResearchEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.ResearchUnlockEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation;
@@ -195,6 +196,22 @@ public class Research implements Keyed {
     @Nonnull
     public List<SlimefunItem> getAffectedItems() {
         return items;
+    }
+
+    /**
+     * This method checks whether there is at least one enabled {@link SlimefunItem}
+     * included in this {@link Research}.
+     *
+     * @return whether there is at least one enabled {@link SlimefunItem}
+     * included in this {@link Research}.
+     */
+    public boolean hasEnabledItems() {
+        for (SlimefunItem item : items) {
+            if (item.getState() == ItemState.ENABLED) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When you first researched an item then disabled it you would still have the research. Sf stats however doesn't count researches without any enabled items for the total amount of researches. This means you could have more researches unlocked then the 'total'. This resulted in a fraction >1, thus an index >= titels.size, thus throwing an ``IndexOutOfBounds`` exception.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Also filter the unlocked researches of the player to only include researches with at least 1 enabled item.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolved #3995

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
