### PR TITLE
Optional player for SlimefunItemSpawnEvent

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemSpawnEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemSpawnEvent.java
@@ -1,10 +1,14 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
+import java.util.Optional;
+
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -29,6 +33,7 @@ public class SlimefunItemSpawnEvent extends Event implements Cancellable {
     private ItemStack itemStack;
     private boolean cancelled;
     private final ItemSpawnReason itemSpawnReason;
+    private final Player player;
 
     @ParametersAreNonnullByDefault
     public SlimefunItemSpawnEvent(Location location, ItemStack itemStack, ItemSpawnReason itemSpawnReason) {
@@ -36,6 +41,25 @@ public class SlimefunItemSpawnEvent extends Event implements Cancellable {
         this.itemStack = itemStack;
         this.itemSpawnReason = itemSpawnReason;
         this.cancelled = false;
+        this.player = null;
+    }
+
+    @ParametersAreNonnullByDefault
+    public SlimefunItemSpawnEvent(@Nullable Player player, Location location, ItemStack itemStack, ItemSpawnReason itemSpawnReason) {
+        this.location = location;
+        this.itemStack = itemStack;
+        this.itemSpawnReason = itemSpawnReason;
+        this.cancelled = false;
+        this.player = player;
+    }
+
+    /**
+     * Optionally returns the {@link Player} responsible for this spawn reason.
+     *
+     * @return The player responsible if applicable.
+     */
+    public Optional<Player> getPlayer() {
+        return Optional.ofNullable(player);
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -167,7 +167,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
             ItemUtils.consumeItem(hand, false);
         }
 
-        Item entity = SlimefunUtils.spawnItem(b.getLocation().add(0.5, 1.2, 0.5), displayItem, ItemSpawnReason.ANCIENT_PEDESTAL_PLACE_ITEM);
+        Item entity = SlimefunUtils.spawnItem(p, b.getLocation().add(0.5, 1.2, 0.5), displayItem, ItemSpawnReason.ANCIENT_PEDESTAL_PLACE_ITEM, false);
 
         if (entity != null) {
             ArmorStand armorStand = getArmorStand(b, true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/ChristmasPresent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/ChristmasPresent.java
@@ -55,7 +55,7 @@ public class ChristmasPresent extends SimpleSlimefunItem<ItemUseHandler> impleme
 
                 Block b = block.getRelative(e.getClickedFace());
                 ItemStack gift = gifts[ThreadLocalRandom.current().nextInt(gifts.length)].clone();
-                SlimefunUtils.spawnItem(b.getLocation(), gift, ItemSpawnReason.CHRISTMAS_PRESENT_OPENED, true);
+                SlimefunUtils.spawnItem(e.getPlayer(), b.getLocation(), gift, ItemSpawnReason.CHRISTMAS_PRESENT_OPENED, true);
             });
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -154,7 +154,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
 
                     // Make sure that the randomly selected item is not air
                     if (output.getType() != Material.AIR) {
-                        SlimefunUtils.spawnItem(b.getLocation(), output.clone(), ItemSpawnReason.GOLD_PAN_USE, true);
+                        SlimefunUtils.spawnItem(e.getPlayer(), b.getLocation(), output.clone(), ItemSpawnReason.GOLD_PAN_USE, true);
                     }
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
@@ -50,7 +50,7 @@ public class PickaxeOfContainment extends SimpleSlimefunItem<ToolUseHandler> {
 
             if (b.getType() == Material.SPAWNER) {
                 ItemStack spawner = breakSpawner(b);
-                SlimefunUtils.spawnItem(b.getLocation(), spawner, ItemSpawnReason.BROKEN_SPAWNER_DROP, true);
+                SlimefunUtils.spawnItem(e.getPlayer(), b.getLocation(), spawner, ItemSpawnReason.BROKEN_SPAWNER_DROP, true);
 
                 e.setExpToDrop(0);
                 e.setDropItems(false);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -610,6 +610,23 @@ public final class SlimefunUtils {
         }
     }
 
+    public static @Nullable Item spawnItem(Player player, Location loc, ItemStack item, ItemSpawnReason reason, boolean addRandomOffset) {
+        SlimefunItemSpawnEvent event = new SlimefunItemSpawnEvent(player, loc, item, reason);
+        Slimefun.instance().getServer().getPluginManager().callEvent(event);
+
+        if (!event.isCancelled()) {
+            World world = event.getLocation().getWorld();
+
+            if (addRandomOffset) {
+                return world.dropItemNaturally(event.getLocation(), event.getItemStack());
+            } else {
+                return world.dropItem(event.getLocation(), event.getItemStack());
+            }
+        } else {
+            return null;
+        }
+    }
+
     /**
      * Helper method to spawn an {@link ItemStack}.
      * This method automatically calls a {@link SlimefunItemSpawnEvent} to allow


### PR DESCRIPTION
## Description
This adds Optional player field for SlimefunItemSpawnEvent.
Some of the spawn reasons are tied to a player and there is not way to get it currently.

## Proposed changes
This adds a new constructor to the class that accepts a player field. This field is null by default.

## Related Issues (if applicable)
n/a

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
