### PR TITLE
Research unlock with vault economy provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- TODO: Remove this dependency -->
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
@@ -249,7 +249,9 @@ public class Research implements Keyed {
         }
 
         boolean creativeResearch = p.getGameMode() == GameMode.CREATIVE && Slimefun.getRegistry().isFreeCreativeResearchingEnabled();
-        return creativeResearch || p.getLevel() >= cost;
+        boolean economyResearch = Slimefun.getIntegrations().isVaultInstalled() && Slimefun.getIntegrations().getVaultIntegration().hasBalanceForResearch(p, cost);
+        boolean expResearch = !Slimefun.getRegistry().isVaultEconomyEnabled() && p.getLevel() >= cost;
+        return creativeResearch || economyResearch || expResearch;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -70,6 +70,8 @@ public final class SlimefunRegistry {
     private boolean freeCreativeResearches;
     private boolean researchFireworks;
     private boolean disableLearningAnimation;
+    private boolean enableVaultEconomy;
+    private double economyPriceMultiplier;
     private boolean logDuplicateBlockEntries;
     private boolean talismanActionBarMessages;
 
@@ -111,6 +113,8 @@ public final class SlimefunRegistry {
         freeCreativeResearches = cfg.getBoolean("researches.free-in-creative-mode");
         researchFireworks = cfg.getBoolean("researches.enable-fireworks");
         disableLearningAnimation = cfg.getBoolean("researches.disable-learning-animation");
+        enableVaultEconomy = cfg.getBoolean("researches.enable-vault-economy");
+        economyPriceMultiplier = cfg.getDouble("researches.economy-price-multiplier");
         logDuplicateBlockEntries = cfg.getBoolean("options.log-duplicate-block-entries");
         talismanActionBarMessages = cfg.getBoolean("talismans.use-actionbar");
     }
@@ -222,6 +226,24 @@ public final class SlimefunRegistry {
      */
     public boolean isLearningAnimationDisabled() {
         return disableLearningAnimation;
+    }
+
+    /**
+     * Returns whether Vault Economy is enabled for researching
+     *
+     * @return Whether Vault Economy is enabled for researching
+     */
+    public boolean isVaultEconomyEnabled() {
+        return enableVaultEconomy;
+    }
+
+    /**
+     * Returns the multiplier for prices if Vault Economy is enabled
+     *
+     * @return the multiplier to apply to the cost in levels of each research
+     */
+    public double getEconomyPriceMultiplier() {
+        return economyPriceMultiplier;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/SlimefunGuideImplementation.java
@@ -70,7 +70,11 @@ public interface SlimefunGuideImplementation {
         if (p.getGameMode() == GameMode.CREATIVE && Slimefun.getRegistry().isFreeCreativeResearchingEnabled()) {
             research.unlock(p, true, callback);
         } else {
-            p.setLevel(p.getLevel() - research.getCost());
+            if (Slimefun.getIntegrations().isVaultInstalled() && Slimefun.getRegistry().isVaultEconomyEnabled()) {
+                Slimefun.getIntegrations().getVaultIntegration().withdrawForResearch(p, research.getCost());
+            } else {
+                p.setLevel(p.getLevel() - research.getCost());
+            }
 
             boolean skipLearningAnimation = Slimefun.getRegistry().isLearningAnimationDisabled() || !SlimefunGuideSettings.hasLearningAnimationEnabled(p);
             research.unlock(p, skipLearningAnimation, callback);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -289,7 +289,8 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
             menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNoPermissionItem(), sfitem.getItemName(), message.toArray(new String[0])));
             menu.addMenuClickHandler(index, ChestMenuUtils.getEmptyClickHandler());
         } else if (isSurvivalMode() && research != null && !profile.hasUnlocked(research)) {
-            menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNotResearchedItem(), ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", "&a> Click to unlock", "", "&7Cost: &b" + research.getCost() + " Level(s)"));
+            String cost = Slimefun.getIntegrations().isVaultInstalled() && Slimefun.getRegistry().isVaultEconomyEnabled() ? Slimefun.getIntegrations().getVaultIntegration().getResearchPrice(research.getCost()) : research.getCost() + " Level(s)" ;
+            menu.addItem(index, new CustomItemStack(ChestMenuUtils.getNotResearchedItem(), ChatColor.WHITE + ItemUtils.getItemName(sfitem.getItem()), "&4&l" + Slimefun.getLocalization().getMessage(p, "guide.locked"), "", "&a> Click to unlock", "", "&7Cost: &b" + cost));
             menu.addMenuClickHandler(index, (pl, slot, item, action) -> {
                 research.unlockFromGuide(this, p, profile, sfitem, itemGroup, page);
                 return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/IntegrationsManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/IntegrationsManager.java
@@ -60,6 +60,9 @@ public class IntegrationsManager {
     private boolean isClearLagInstalled = false;
     private boolean isItemsAdderInstalled = false;
     private boolean isOrebfuscatorInstalled = false;
+    private boolean isVaultInstalled = false;
+
+    VaultIntegration vaultIntegration;
 
     /**
      * This initializes the {@link IntegrationsManager}
@@ -130,6 +133,12 @@ public class IntegrationsManager {
 
         // ItemsAdder Integration (custom blocks)
         load("ItemsAdder", integration -> isItemsAdderInstalled = true);
+
+        // Vault integration (research with server currency)
+        load("Vault", integration -> {
+            vaultIntegration = new VaultIntegration();
+            isVaultInstalled = true;
+        });
     }
 
     /**
@@ -208,6 +217,10 @@ public class IntegrationsManager {
      */
     public @Nonnull ProtectionManager getProtectionManager() {
         return protectionManager;
+    }
+
+    public @Nonnull VaultIntegration getVaultIntegration() {
+        return vaultIntegration;
     }
 
     /**
@@ -309,5 +322,9 @@ public class IntegrationsManager {
 
     public boolean isOrebfuscatorInstalled() {
         return isOrebfuscatorInstalled;
+    }
+
+    public boolean isVaultInstalled() {
+        return isVaultInstalled;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/VaultIntegration.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/VaultIntegration.java
@@ -1,0 +1,67 @@
+package io.github.thebusybiscuit.slimefun4.integrations;
+
+import javax.annotation.Nonnull;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import net.milkbowl.vault.economy.Economy;
+
+/**
+ * This handles all integrations with Vault's economy.
+ * Used to unlock research.
+ *
+ * @author Mis
+ *
+ */
+public class VaultIntegration {
+    private RegisteredServiceProvider<Economy> economy;
+
+    public VaultIntegration() {
+        this.economy = Bukkit.getServer().getServicesManager().getRegistration(Economy.class);
+    }
+
+    public double getBalance(@Nonnull Player player) {
+        return this.economy.getProvider().getBalance(player);
+    }
+
+    public boolean hasBalance(@Nonnull Player player, double amount) {
+        return this.getBalance(player) >= amount;
+    }
+
+    public void deposit(@Nonnull Player player, double amount) {
+        this.economy.getProvider().depositPlayer(player, amount);
+    }
+
+    public void withdraw(@Nonnull Player player, double amount) {
+        this.economy.getProvider().withdrawPlayer(player, amount);
+    }
+
+    /**
+     * Checks if the player has enough money to buy this research,
+     * depending on the xp levels required and the price multiplier.
+     *
+     * @return whether the player can afford the research or not.
+     */
+    public boolean hasBalanceForResearch(@Nonnull Player player, int xpCost) {
+        return this.hasBalance(player, xpCost * Slimefun.getRegistry().getEconomyPriceMultiplier());
+    }
+
+    /**
+     * Withdraws money from the player by the given amount times the price multiplier.
+     */
+    public void withdrawForResearch(@Nonnull Player player, int xpCost) {
+        this.withdraw(player, xpCost * Slimefun.getRegistry().getEconomyPriceMultiplier());
+    }
+
+    /**
+     * Returns the formatted price, according to the xp level cost and price multiplier.
+     *
+     * @return the formatted price.
+     */
+    public String getResearchPrice(int xpCost) {
+        return this.economy.getProvider().format(xpCost * Slimefun.getRegistry().getEconomyPriceMultiplier());
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,8 @@ researches:
   free-in-creative-mode: true
   enable-fireworks: true
   disable-learning-animation: false
+  enable-vault-economy: false
+  economy-price-multiplier: 1000.0
 
 URID:
   info-delay: 3000

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,6 +19,7 @@ softdepend:
 - mcMMO
 - ItemsAdder
 - Orebfuscator
+- Vault
 
 # Our commands
 commands:


### PR DESCRIPTION
## Description
Adds the option to use money instead of experience to unlock research, without major changes in the codebase or config files.

## Proposed changes
I added two new keys to config.yml inside researches. `enable-vault-economy` and `economy-price-multiplier`. If `enable-vault-economy` is true, money will be used instead of experience, and to avoid having to define the prices again for each investigation, the price is calculated by doing xp levels cost times `economy-price-multiplier`, that way the ratio between prices is the same as the previous exp cost system.
I created a VaultIntegration class with a few methods, in case anyone wants to mess with the economy in the future.
The lore that shows the cost of unlocking a research shows the price formatted correctly as a currency.

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.