### PR TITLE
Update ButcherAndroidListener.java

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
@@ -88,5 +88,9 @@ public class ButcherAndroidListener implements Listener {
         if (entityType == EntityType.BLAZE) {
             drops.add(new ItemStack(Material.BLAZE_ROD, 1 + random.nextInt(1)));
         }
+
+        if (entityType == EntityType.VINDICATOR) {
+            drops.add(new Itemstack(Material.EMERALD, 1 + random.nextInt(2)));
+        }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
@@ -90,7 +90,7 @@ public class ButcherAndroidListener implements Listener {
         }
 
         if (entityType == EntityType.VINDICATOR) {
-            drops.add(new Itemstack(Material.EMERALD, 1 + random.nextInt(2)));
+            drops.add(new ItemStack(Material.EMERALD, 1 + random.nextInt(2)));
         }
     }
 }


### PR DESCRIPTION
Fixed bug with emerald drop from vindicators when killed by Butcher Android

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I'm making this pull request to fix the bug with vindicators don't drop emeralds when killed by Butcher Android

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I just added code to fix the bug

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3849 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
