### PR TITLE
Implement resource cooldown for Oil Pump

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/OilPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/OilPump.java
@@ -2,7 +2,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.geo;
 
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.OptionalInt;
 
@@ -14,7 +13,6 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.config.Config;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;


### PR DESCRIPTION
## Description
Currently, Oil Pumps can block entire systems when automated with Buckets, if buckets are not a static quantity (such as autocrafting buckets to fill a barrel or network storage for addons). When there is no oil, this causes the output slots currently to fill with the bucket, which then gets pulled into the storage system again. However, once the bucket goes into the oil pump, there's room in the storage for another to be crafted and as such it's crafted and stored. This means there's now 1 too many buckets to be stored. The same happens again as an oil can fit in the output and eventually you get both output slots filled with buckets with no storage free for them at all. This then prevents the oil pump from working entirely until they're cleaned out.

## Proposed changes
I propose adding a cooldown to the oil pump when it finds no resource, such that it does not move the bucket but instead for  5 seconds will not even bother checking the recipes, resource supplies, or anything else. It simply returns fast (or fast enough). This means we no longer need to move the bucket to the output slot for lag prevention (even though this doesn't actually prevent lag really from what I can see, because there will always be more buckets in the input getting ticked).

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
None

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
