### PR TITLE
Add Horizontal Offset support to Holograms

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -153,11 +153,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
             double offsetY = getYOffset(projector);
             double offsetZ = getZOffset(projector);
 
-            if (offsetX < -MAX_HORIZONTAL_OFFSET) {
-                offsetX = -MAX_HORIZONTAL_OFFSET;
-            } else if (offsetX > MAX_HORIZONTAL_OFFSET) {
-                offsetX = MAX_HORIZONTAL_OFFSET;
-            }
+            offsetX = Math.min(Math.max(offsetX, -MAX_HORIZONTAL_OFFSET), MAX_HORIZONTAL_OFFSET);
             
             ArmorStand hologram = getArmorStand(projector, true);
             Location l = new Location(projector.getWorld(), projector.getX() + offsetX, projector.getY() + offsetY, projector.getZ() + offsetZ);
@@ -189,11 +185,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
             double offsetY = getYOffset(projector);
             double offsetZ = NumberUtils.reparseDouble(getZOffset(projector) + (action.isRightClicked() ? -0.1F : 0.1F));
 
-            if (offsetZ < -MAX_HORIZONTAL_OFFSET) {
-                offsetZ = -MAX_HORIZONTAL_OFFSET;
-            } else if (offsetZ > MAX_HORIZONTAL_OFFSET) {
-                offsetZ = MAX_HORIZONTAL_OFFSET;
-            }
+            offsetZ = Math.min(Math.max(offsetZ, -MAX_HORIZONTAL_OFFSET), MAX_HORIZONTAL_OFFSET);
 
             ArmorStand hologram = getArmorStand(projector, true);
             Location l = new Location(projector.getWorld(), projector.getX() + offsetX, projector.getY() + offsetY, projector.getZ() + offsetZ);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -51,9 +51,9 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
     private static final String OFFSET_PARAMETER_X = "offset-x";
     private static final String OFFSET_PARAMETER_Z = "offset-z";
     private static final double MAX_HORIZONTAL_OFFSET = 32.0D; // Up to 2 chunks away in any direction horizontally
-    private static final double DEFAULT_OFFSET_X = 0D;
+    private static final double DEFAULT_OFFSET_X = 0.5D;
     private static final double DEFAULT_OFFSET_Y = 0.5D;
-    private static final double DEFAULT_OFFSET_Z = 0D;
+    private static final double DEFAULT_OFFSET_Z = 0.5D;
 
 
     @ParametersAreNonnullByDefault


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Hologram projectors are really nice things to use, but they lack horizontal offset support meaning any design without a central block annoyingly has an offset hologram. This PR adds support for them to be up to 32 blocks away horizontally. This offers more options to hide the projector in the wall or ceiling, while also allowing them to be centered nicely along any axis.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Add X offset to hologram projectors
- Add Z offset to hologram projectors
- Clean up code a little with the new additions

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
