### PR TITLE
Add Yaw to GPS Waypoint Location

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSMarkerTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/GPSMarkerTool.java
@@ -36,7 +36,11 @@ public class GPSMarkerTool extends SimpleSlimefunItem<ItemUseHandler> implements
 
             if (e.getClickedBlock().isPresent()) {
                 Block b = e.getClickedBlock().get().getRelative(e.getClickedFace());
-                Slimefun.getGPSNetwork().createWaypoint(e.getPlayer(), b.getLocation());
+                Location l = b.getLocation();
+                Location locationWithYaw = new Location(
+                    l.getWorld(), l.getX(), l.getY(), l.getZ(), e.getPlayer().getLocation().getYaw(), 0.0f
+                );
+                Slimefun.getGPSNetwork().createWaypoint(e.getPlayer(), locationWithYaw);
             }
         };
     }


### PR DESCRIPTION
## Description
Currently GPS Waypoints use the Block's Location (and thus Yaw). This means the player always is south facing when spawning as the default is 0.

## Proposed changes
Preserve the Yaw of the player when creating GPS Marker Waypoints.

## Related Issues (if applicable)
N?A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
