### PR TITLE
General Fix for Head Textures

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
@@ -11,6 +11,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
@@ -283,12 +284,10 @@ public class SlimefunItemStack extends ItemStack {
     }
 
     private static @Nonnull ItemStack getSkull(@Nonnull String id, @Nonnull String texture) {
-        if (Slimefun.getMinecraftVersion() == MinecraftVersion.UNIT_TEST) {
-            return new ItemStack(Material.PLAYER_HEAD);
-        }
+        Validate.notNull(id, "The id cannot be null");
+        Validate.notNull(texture, "The texture cannot be null");
 
-        PlayerSkin skin = PlayerSkin.fromBase64(getTexture(id, texture));
-        return PlayerHead.getItemStack(skin);
+        return SlimefunUtils.getCustomHead(texture);
     }
 
     private static @Nonnull String getTexture(@Nonnull String id, @Nonnull String texture) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -2,15 +2,23 @@ package io.github.thebusybiscuit.slimefun4.utils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import org.apache.commons.lang.Validate;
-import org.bukkit.*;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -22,10 +30,7 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
-import io.github.bakedlibs.dough.common.CommonPatterns;
 import io.github.bakedlibs.dough.items.ItemMetaSnapshot;
-import io.github.bakedlibs.dough.skins.PlayerHead;
-import io.github.bakedlibs.dough.skins.PlayerSkin;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunItemSpawnEvent;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.PrematureCodeException;
@@ -44,6 +49,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.tasks.CapacitorTextureU
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 import org.bukkit.profile.PlayerProfile;
 import org.bukkit.profile.PlayerTextures;
+
+import static org.bukkit.Bukkit.createPlayerProfile;
 
 /**
  * This utility class holds method that are directly linked to Slimefun.
@@ -222,13 +229,13 @@ public final class SlimefunUtils {
     private static PlayerProfile getProfile(@Nonnull String url) {
         Validate.notNull(url, "The provided url is null");
 
-        PlayerProfile profile = Bukkit.createPlayerProfile(RANDOM_UUID); // Create a new player profile
+        PlayerProfile profile = createPlayerProfile(RANDOM_UUID); // Create a new player profile
         PlayerTextures textures = profile.getTextures();
         URL urlObject;
         try {
             urlObject = new URL(url); // The URL to the skin
         } catch (MalformedURLException exception) {
-            throw new RuntimeException("Invalid URL", exception);
+            return null;
         }
         textures.setSkin(urlObject); // Set the skin of the player profile to the URL
         profile.setTextures(textures); // Set the textures back to the profile
@@ -259,6 +266,10 @@ public final class SlimefunUtils {
         }
 
         PlayerProfile profile = getProfile("https://textures.minecraft.net/texture/" + texture);
+        if (profile == null) {
+            return new ItemStack(Material.PLAYER_HEAD);
+        }
+
         ItemStack head = new ItemStack(Material.PLAYER_HEAD);
         SkullMeta meta = (SkullMeta) head.getItemMeta();
         meta.setOwnerProfile(profile); // Set the owning player of the head to the player profile

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -219,7 +219,9 @@ public final class SlimefunUtils {
      * @param url The URL to the texture
      * @return A {@link PlayerProfile} with the given texture
      */
-    private static PlayerProfile getProfile(String url) {
+    private static PlayerProfile getProfile(@Nonnull String url) {
+        Validate.notNull(url, "The provided url is null");
+
         PlayerProfile profile = Bukkit.createPlayerProfile(RANDOM_UUID); // Create a new player profile
         PlayerTextures textures = profile.getTextures();
         URL urlObject;


### PR DESCRIPTION
Note: I do not believe the fix is completely comprehensive.

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I am making this pull request to fix the "Alex/Steve" heads issue that Slimefun currently has on spigot builds > 246. Heads are not being turned into their custom textures.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I have changed the code to mainly stop using dough-api and instead to use plain Bukkit code to request the textures. I am aware that this probably not a comprehensive fix (meaning I did not remove every instance of DoughAPI's method calls. I just replaced the main SlimefunUtils function and the SlimefunItem function for custom textures), however, I hope this can serve as a base.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #4024 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
