### PR TITLE
replace builds page with blob builds

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -9,7 +9,6 @@ import io.github.bakedlibs.dough.updater.BlobBuildUpdater;
 import org.bukkit.plugin.Plugin;
 
 import io.github.bakedlibs.dough.config.Config;
-import io.github.bakedlibs.dough.updater.GitHubBuildsUpdater;
 import io.github.bakedlibs.dough.updater.PluginUpdater;
 import io.github.bakedlibs.dough.versions.PrefixedVersion;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 
+import io.github.bakedlibs.dough.updater.BlobBuildUpdater;
 import org.bukkit.plugin.Plugin;
 
 import io.github.bakedlibs.dough.config.Config;
@@ -53,7 +54,7 @@ public class UpdaterService {
      */
     public UpdaterService(@Nonnull Slimefun plugin, @Nonnull String version, @Nonnull File file) {
         this.plugin = plugin;
-        GitHubBuildsUpdater autoUpdater = null;
+        BlobBuildUpdater autoUpdater = null;
 
         if (version.contains("UNOFFICIAL")) {
             // This Server is using a modified build that is not a public release.
@@ -61,7 +62,7 @@ public class UpdaterService {
         } else if (version.startsWith("DEV - ")) {
             // If we are using a development build, we want to switch to our custom
             try {
-                autoUpdater = new GitHubBuildsUpdater(plugin, file, "TheBusyBiscuit/Slimefun4/master");
+                autoUpdater = new BlobBuildUpdater(plugin, file, "Slimefun4", "Dev");
             } catch (Exception x) {
                 plugin.getLogger().log(Level.SEVERE, "Failed to create AutoUpdater", x);
             }
@@ -70,7 +71,7 @@ public class UpdaterService {
         } else if (version.startsWith("RC - ")) {
             // If we are using a "stable" build, we want to switch to our custom
             try {
-                autoUpdater = new GitHubBuildsUpdater(plugin, file, "TheBusyBiscuit/Slimefun4/stable", "RC - ");
+                autoUpdater = new BlobBuildUpdater(plugin, file, "Slimefun4", "RC");
             } catch (Exception x) {
                 plugin.getLogger().log(Level.SEVERE, "Failed to create AutoUpdater", x);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -16,7 +16,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 /**
  * This Class represents our {@link PluginUpdater} Service.
- * If enabled, it will automatically connect to https://thebusybiscuit.github.io/builds/
+ * If enabled, it will automatically connect to https://blob.build/
  * to check for updates and to download them automatically.
  *
  * @author TheBusyBiscuit

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -58,7 +58,7 @@ public class UpdaterService {
         if (version.contains("UNOFFICIAL")) {
             // This Server is using a modified build that is not a public release.
             branch = SlimefunBranch.UNOFFICIAL;
-        } else if (version.startsWith("DEV - ")) {
+        } else if (version.startsWith("Dev - ")) {
             // If we are using a development build, we want to switch to our custom
             try {
                 autoUpdater = new BlobBuildUpdater(plugin, file, "Slimefun4", "Dev");

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
@@ -33,7 +33,7 @@ class TestUpdaterService {
     @Test
     @DisplayName("Test if the development branch is recognized correctly")
     void testDevelopmentBuilds() {
-        UpdaterService service = new UpdaterService(plugin, "DEV - 131 (git 123456)", file);
+        UpdaterService service = new UpdaterService(plugin, "Dev - 131 (git 123456)", file);
         Assertions.assertEquals(SlimefunBranch.DEVELOPMENT, service.getBranch());
         Assertions.assertTrue(service.getBranch().isOfficial());
         // Cannot currently be tested... yay


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This PR replaces the broken builds page with https://blob.build
This is a new builds page build by @WalshyDev https://github.com/WalshyDev/blob-builds
In @WalshyDev fork there is a auto updater which automatically pulls the current changes and pushes it to the build page since it requires an api key.
We cant add an API key here only Cookie can

This PR is blocked till https://github.com/Slimefun/Slimefun4/pull/4027 is merged
## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Change from Cookies build page to Walshys build page

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves builds not being build

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
