### PR TITLE
Strip colors from search term

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -350,7 +350,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         }
 
         ChestMenu menu = new ChestMenu(Slimefun.getLocalization().getMessage(p, "guide.search.inventory").replace("%item%", ChatUtils.crop(ChatColor.WHITE, input)));
-        String searchTerm = input.toLowerCase(Locale.ROOT);
+        String searchTerm = ChatColor.strip(input.toLowerCase(Locale.ROOT));
 
         if (addToHistory) {
             profile.getGuideHistory().add(searchTerm);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -350,7 +350,7 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
         }
 
         ChestMenu menu = new ChestMenu(Slimefun.getLocalization().getMessage(p, "guide.search.inventory").replace("%item%", ChatUtils.crop(ChatColor.WHITE, input)));
-        String searchTerm = ChatColor.strip(input.toLowerCase(Locale.ROOT));
+        String searchTerm = ChatColor.stripColor(input.toLowerCase(Locale.ROOT));
 
         if (addToHistory) {
             profile.getGuideHistory().add(searchTerm);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
@@ -5,11 +5,14 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.guide.SurvivalSlimefunGuide;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -90,8 +93,28 @@ class TestGuideOpening {
     }
 
     @Test
-    @DisplayName("Test if the Slimefun Search can be opened from the History")
+    @DisplayName("Test if the Slimefun Search works with normal and colored querys")
     void testOpenSearch() throws InterruptedException {
+        String normalQuery = "iron";
+        String coloredQuery = ChatColor.DARK_PURPLE + "iron";
+
+        SlimefunItem testItem = TestUtilities.mockSlimefunItem(plugin, "IRON_ITEM", new CustomItemStack(Material.IRON_INGOT, "iron item"));
+        testItem.register(plugin);
+
+        Player player = server.addPlayer();
+        PlayerProfile profile = TestUtilities.awaitProfile(player);
+        SlimefunGuideImplementation guide = new SurvivalSlimefunGuide(false, false);
+
+        guide.openSearch(profile, normalQuery, false);
+        Assertions.assertTrue(player.getOpenInventory().getTopInventory().contains(testItem.getItem()), "Failed on normal query");
+
+        guide.openSearch(profile, coloredQuery, false);
+        Assertions.assertTrue(player.getOpenInventory().getTopInventory().contains(testItem.getItem()), "Failed on colored query");
+    }
+
+    @Test
+    @DisplayName("Test if the Slimefun Search can be opened from the History")
+    void testOpenSearchHistory() throws InterruptedException {
         String query = "electric";
 
         SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
@@ -93,10 +93,10 @@ class TestGuideOpening {
     }
 
     @Test
-    @DisplayName("Test if the Slimefun Search works with normal and colored querys")
-    void testOpenSearch() throws InterruptedException {
-        String normalQuery = "iron";
-        String coloredQuery = ChatColor.DARK_PURPLE + "iron";
+    @DisplayName("Test if the Slimefun Search works with normal and colored terms")
+    void testOpenSearch_withColoredSearchTerm() throws InterruptedException {
+        String normalTerm = "iron";
+        String coloredTerm = ChatColor.DARK_PURPLE + "iron";
 
         SlimefunItem testItem = TestUtilities.mockSlimefunItem(plugin, "IRON_ITEM", new CustomItemStack(Material.IRON_INGOT, "iron item"));
         testItem.register(plugin);
@@ -105,21 +105,23 @@ class TestGuideOpening {
         PlayerProfile profile = TestUtilities.awaitProfile(player);
         SlimefunGuideImplementation guide = new SurvivalSlimefunGuide(false, false);
 
-        guide.openSearch(profile, normalQuery, false);
+        guide.openSearch(profile, normalTerm, false);
+        // Assert we can open with a non-coloured search term
         Assertions.assertTrue(player.getOpenInventory().getTopInventory().contains(testItem.getItem()), "Failed on normal query");
 
-        guide.openSearch(profile, coloredQuery, false);
+        guide.openSearch(profile, coloredTerm, false);
+        // Assert we can open with a coloured search term
         Assertions.assertTrue(player.getOpenInventory().getTopInventory().contains(testItem.getItem()), "Failed on colored query");
     }
 
     @Test
     @DisplayName("Test if the Slimefun Search can be opened from the History")
     void testOpenSearchHistory() throws InterruptedException {
-        String query = "electric";
+        String term = "electric";
 
         SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);
-        PlayerProfile profile = prepare(guide, history -> history.add(query));
-        Mockito.verify(guide).openSearch(profile, query, false);
+        PlayerProfile profile = prepare(guide, history -> history.add(term));
+        Mockito.verify(guide).openSearch(profile, term, false);
     }
 
     @Test


### PR DESCRIPTION
## Description
To allow any servers that have colored chat to still use the slimefun search system

## Proposed changes
- In `SurvivalSlimefunGuide#openSearch` when `searchTerm` is defined I wrapped it with `ChatColor#stripColor`
- In `TestGuideOpening` I changed `testOpenSearch` to `testOpenSearchHistory` to better reflect the test
- In `TestGuideOpening` I created a new `testOpenSearch` method that tests with a normal, and then colored version of the same search. It opens the search for both and asserts that the item registered that should be found by the search is in the upper inventory (where the search would be displayed)

## Related Issues (if applicable)
Resolves #4043 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
