### PR TITLE
Hotfix for the Sensistive Block Check

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -257,8 +257,9 @@ public class BlockListener implements Listener {
         if (count >= Bukkit.getServer().getMaxChainedNeighborUpdates()) {
             return;
         }
+        BlockData blockData = block.getBlockData();
+        block.setType(Material.AIR, false);
         for (BlockFace face : CARDINAL_BLOCKFACES) {
-            block.setType(Material.AIR, false);
             if (!isSupported(block.getRelative(face).getBlockData(), block.getRelative(face))) {
                 Block relative = block.getRelative(face);
                 for (ItemStack drop : relative.getDrops()) {
@@ -267,6 +268,7 @@ public class BlockListener implements Listener {
                 checkForSensitiveBlocks(relative, ++count);
             }
         }
+        block.setBlockData(blockData, false);
     }
 
     /**


### PR DESCRIPTION
## Description
A bug slipped through the craps on the sensitive blocks PR

## Proposed changes
gets and then re sets the block data of the block for sensitive blocks

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
