### PR TITLE
Fixed vanilla sensitive blocks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -10,10 +10,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -170,6 +173,8 @@ public class BlockListener implements Listener {
             callBlockHandler(e, item, drops, sfItem);
 
             dropItems(e, drops);
+
+            checkForSensitiveBlocks(e.getBlock(), 0, e.isDropItems());
         }
     }
 
@@ -280,6 +285,59 @@ public class BlockListener implements Listener {
                 // Fixes #2944 - Don't forget to clear the Block Data
                 BlockStorage.clearBlockInfo(blockAbove);
             }
+        }
+    }
+
+    /**
+     * This method checks recursively for any sensitive blocks
+     * that are no longer supported due to this block breaking
+     *
+     * @param block
+     *      The {@link Block} in question
+     * @param count
+     *      The amount of times this has been recursively called
+     */
+    @ParametersAreNonnullByDefault
+    private void checkForSensitiveBlocks(Block block, Integer count, boolean isDropItems) {
+        if (count >= Bukkit.getServer().getMaxChainedNeighborUpdates()) {
+            return;
+        }
+
+        BlockState state = block.getState();
+        block.setType(Material.AIR, false);
+        for (BlockFace face : CARDINAL_BLOCKFACES) {
+            if (!isSupported(block.getRelative(face).getBlockData(), block.getRelative(face))) {
+                Block relative = block.getRelative(face);
+                if (!isDropItems) {
+                    for (ItemStack drop : relative.getDrops()) {
+                        block.getWorld().dropItemNaturally(relative.getLocation(), drop);
+                    }
+                }
+                checkForSensitiveBlocks(relative, ++count, isDropItems);
+            }
+        }
+        block.setBlockData(state.getBlockData(), false);
+        state.update(true, false);
+    }
+
+    /**
+     * This method checks if the {@link BlockData} would be
+     * supported at the given {@link Block}.
+     *
+     * @param blockData
+     *      The {@link BlockData} to check
+     * @param block
+     *      The {@link Block} the {@link BlockData} would be at
+     * @return
+     *      Whether the {@link BlockData} would be supported at the given {@link Block}
+     */
+    @ParametersAreNonnullByDefault
+    private boolean isSupported(BlockData blockData, Block block) {
+        if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_19)) {
+            return blockData.isSupported(block);
+        } else {
+            // TODO: Make 1.16-1.18 version. BlockData::isSupported is 1.19+.
+            return true;
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -307,6 +307,7 @@ public class BlockListener implements Listener {
         }
 
         BlockState state = block.getState();
+        // We set the block to air to make use of BlockData#isSupported.
         block.setType(Material.AIR, false);
         for (BlockFace face : CARDINAL_BLOCKFACES) {
             if (!isSupported(block.getRelative(face).getBlockData(), block.getRelative(face))) {
@@ -319,6 +320,7 @@ public class BlockListener implements Listener {
                 checkForSensitiveBlocks(relative, ++count, isDropItems);
             }
         }
+        // Set the BlockData back: this makes it so containers and spawners drop correctly. This is a hacky fix.
         block.setBlockData(state.getBlockData(), false);
         state.update(true, false);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -10,7 +10,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -32,6 +31,7 @@ import io.github.thebusybiscuit.slimefun4.api.events.ExplosiveToolBreakBlocksEve
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunBlockBreakEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunBlockPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
@@ -168,12 +168,15 @@ public class BlockListener implements Listener {
         }
 
         if (!e.isCancelled()) {
+            // Checks for Slimefun sensitive blocks above, using Slimefun Tags
+            // TODO: merge this with the vanilla sensitive block check (when 1.18- is dropped)
             checkForSensitiveBlockAbove(e.getPlayer(), e.getBlock(), item);
 
             callBlockHandler(e, item, drops, sfItem);
 
             dropItems(e, drops);
 
+            // Checks for vanilla sensitive blocks everywhere
             checkForSensitiveBlocks(e.getBlock(), 0, e.isDropItems());
         }
     }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Sensitive blocks were an issue, they were "fixed" a couple of times (#3966, #4048) and then we reverted the changes as it was a mess (#4049).
This now solves the issue for good in terms of vanilla sensitive blocks.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Only drop items when BlockBreakEvent.isDropItems() is false, as otherwise we get double vanilla drops
Check around the block for sensitive blocks up until the max chained amount

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3182
Resolves #3831

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
