### PR TITLE
Remove Unirest and replace with Java's native HttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,10 +205,6 @@
                             <shadedPattern>io.github.thebusybiscuit.slimefun4.libraries.paperlib</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>kong.unirest</pattern>
-                            <shadedPattern>io.github.thebusybiscuit.slimefun4.libraries.unirest</shadedPattern>
-                        </relocation>
-                        <relocation>
                             <pattern>org.apache.commons.lang</pattern>
                             <shadedPattern>io.github.thebusybiscuit.slimefun4.libraries.commons.lang</shadedPattern>
                         </relocation>
@@ -363,20 +359,6 @@
             <artifactId>paperlib</artifactId>
             <version>1.0.8</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.konghq</groupId>
-            <artifactId>unirest-java</artifactId>
-            <version>3.14.5</version>
-            <scope>compile</scope>
-
-            <exclusions>
-                <exclusion>
-                    <!-- No need to shade Gson, Spigot does that already -->
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Testing dependencies -->

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/ContributionsConnector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/ContributionsConnector.java
@@ -9,11 +9,11 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
-import kong.unirest.JsonNode;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 class ContributionsConnector extends GitHubConnector {
 
@@ -90,11 +90,11 @@ class ContributionsConnector extends GitHubConnector {
     }
 
     @Override
-    public void onSuccess(@Nonnull JsonNode response) {
+    public void onSuccess(@Nonnull JsonElement response) {
         finished = true;
 
-        if (response.isArray()) {
-            computeContributors(response.getArray());
+        if (response.isJsonArray()) {
+            computeContributors(response.getAsJsonArray());
         } else {
             Slimefun.logger().log(Level.WARNING, "Received an unusual answer from GitHub, possibly a timeout? ({0})", response);
         }
@@ -123,13 +123,13 @@ class ContributionsConnector extends GitHubConnector {
         return parameters;
     }
 
-    private void computeContributors(@Nonnull JSONArray array) {
-        for (int i = 0; i < array.length(); i++) {
-            JSONObject object = array.getJSONObject(i);
+    private void computeContributors(@Nonnull JsonArray array) {
+        for (JsonElement element : array) {
+            JsonObject object = element.getAsJsonObject();
 
-            String name = object.getString("login");
-            int commits = object.getInt("contributions");
-            String profile = object.getString("html_url");
+            String name = object.get("login").getAsString();
+            int commits = object.get("contributions").getAsInt();
+            String profile = object.get("html_url").getAsString();
 
             if (!ignoredAccounts.contains(name)) {
                 String username = aliases.getOrDefault(name, name);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubActivityConnector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubActivityConnector.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
-import kong.unirest.JsonNode;
-import kong.unirest.json.JSONObject;
+import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 
 class GitHubActivityConnector extends GitHubConnector {
 
@@ -23,11 +23,11 @@ class GitHubActivityConnector extends GitHubConnector {
     }
 
     @Override
-    public void onSuccess(@Nonnull JsonNode response) {
-        JSONObject object = response.getObject();
-        int forks = object.getInt("forks");
-        int stars = object.getInt("stargazers_count");
-        LocalDateTime lastPush = NumberUtils.parseGitHubDate(object.getString("pushed_at"));
+    public void onSuccess(@Nonnull JsonElement response) {
+        JsonObject object = response.getAsJsonObject();
+        int forks = object.get("forks").getAsInt();
+        int stars = object.get("stargazers_count").getAsInt();
+        LocalDateTime lastPush = NumberUtils.parseGitHubDate(object.get("pushed_at").getAsString());
 
         callback.accept(forks, stars, lastPush);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubIssuesConnector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubIssuesConnector.java
@@ -25,7 +25,7 @@ class GitHubIssuesConnector extends GitHubConnector {
 
     @Override
     public void onSuccess(@Nonnull JsonElement response) {
-        if (response.isJsonObject()) {
+        if (response.isJsonArray()) {
             JsonArray array = response.getAsJsonArray();
 
             int issues = 0;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubIssuesConnector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubIssuesConnector.java
@@ -7,11 +7,11 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
-import kong.unirest.JsonNode;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 class GitHubIssuesConnector extends GitHubConnector {
 
@@ -24,15 +24,15 @@ class GitHubIssuesConnector extends GitHubConnector {
     }
 
     @Override
-    public void onSuccess(@Nonnull JsonNode response) {
-        if (response.isArray()) {
-            JSONArray array = response.getArray();
+    public void onSuccess(@Nonnull JsonElement response) {
+        if (response.isJsonObject()) {
+            JsonArray array = response.getAsJsonArray();
 
             int issues = 0;
             int pullRequests = 0;
 
-            for (int i = 0; i < array.length(); i++) {
-                JSONObject obj = array.getJSONObject(i);
+            for (JsonElement element : array) {
+                JsonObject obj = element.getAsJsonObject();
 
                 if (obj.has("pull_request")) {
                     pullRequests++;


### PR DESCRIPTION
## Description
When we first implemented Unirest, the goal was always to remove it once we moved to Java 11 minimum. It's been a while since this happened so let's do this.

This reduces the jar size from 4.7 MB (4782834 bytes) to 2.4 MB (2480486 bytes) so we remove ~2.3 MB.

## Proposed changes
Removes Unirest with Java's native HttpClient (introduced in Java 11)

## Related Issues (if applicable)
N/A

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
