### PR TITLE
Fix contributor head being pullable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-api</artifactId>
-            <version>4b28bd408e</version>
+            <version>da42c2f268</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -512,6 +512,12 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>1.5.25</version>
+            <scope>provided</scope>
         </dependency>
         <!-- TODO: Remove this dependency -->
         <dependency>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubTask.java
@@ -142,7 +142,7 @@ class GitHubTask implements Runnable {
 
         if (uuid.isPresent()) {
             CompletableFuture<PlayerSkin> future = PlayerSkin.fromPlayerUUID(Slimefun.instance(), uuid.get());
-            Optional<String> skin = Optional.of(future.get().toString());
+            Optional<String> skin = Optional.of(future.get().getProfile().getBase64Texture());
             skins.put(contributor.getMinecraftName(), skin.orElse(""));
             return skin.orElse(null);
         } else {


### PR DESCRIPTION
## Description
In `GitHubTask` we're doing `Optional<String> skin = Optional.of(future.get().toString());` where `future.get()` returns `PlayerSkin`. However, `PlayerSkin` does not have a `toString()` function and therefore this was resulting in the normal Object#toString meaning `skin` was like `io.github.thebusybiscuit.slimefun4.libraries.dough.skins.PlayerSkin@abcdef123` instead of the base64 texture.

## Proposed changes
This PR updates dough and a small change in our contributor code to fix #4071 

Unfortunately, this change cannot be easily unit-tested as the whole `GitHubTask` is private and changing that wouldn't make sense. We could run the Runnable but we shouldn't, it'll do a bunch of network requests and generally just be bad practice to test a single function.

Dough PR for this change: https://github.com/baked-libs/dough/pull/240

## Related Issues (if applicable)
Fixes #4071 

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

## Merge checklist

- [x] Dough PR merged
- [x] Dough version updated