### PR TITLE
added custom texture support for everything but heads

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
@@ -87,6 +87,10 @@ public class SlimefunItemStack extends ItemStack {
                 meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
             }
 
+            //add custom model
+            SlimefunItem itemItem = SlimefunItem.getById(id);
+            if (itemItem != null && itemItem.customModelData != 0) meta.setCustomModelData(itemItem.customModelData);
+
             consumer.accept(meta);
         });
     }
@@ -96,6 +100,10 @@ public class SlimefunItemStack extends ItemStack {
             if (name != null) {
                 im.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
             }
+
+            //add custom model
+            SlimefunItem itemItem = SlimefunItem.getById(id);
+            if (itemItem != null && itemItem.customModelData != 0) im.setCustomModelData(itemItem.customModelData);
 
             if (lore.length > 0) {
                 List<String> lines = new ArrayList<>();
@@ -153,6 +161,10 @@ public class SlimefunItemStack extends ItemStack {
 
                 im.setLore(lines);
             }
+
+            //add custom model
+            SlimefunItem itemItem = SlimefunItem.getById(id);
+            if (itemItem != null && itemItem.customModelData != 0) im.setCustomModelData(itemItem.customModelData);
 
             if (im instanceof PotionMeta potionMeta) {
                 potionMeta.setColor(color);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomTextureService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomTextureService.java
@@ -167,7 +167,10 @@ public class CustomTextureService {
         Validate.notNull(id, "Cannot store null on an ItemMeta!");
 
         int data = getModelData(id);
-        im.setCustomModelData(data == 0 ? null : data);
+        //im.setCustomModelData(data == 0 ? null : data);
+        //keep custom model data for texturePacks
+        if (data != 0) im.setCustomModelData(data);
+
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Minecraft supports custom Textures for items since 1.14 and I thought it would be a great addition to allow TexturePack creators to add custom textures to ingots, items and so on.
## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
I added added customModelData to each items Metadata during registration,
excluding heads since that'd break their textures.
I also added a setter for the counter so add-ons can claim their own range for compatibility.
Furthermore, and here I am a little uncertain, I had to change a line in customTextureService to not reset the customModelData.
The provided Tests all passed and I am currently testing the changes on a private server.
The variable customModelData could be used to get item-ids in guide.
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
(For the ones I tested the customModelData increased as expected, the Items seem to behave as expected)
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
(CustomModelData seems to have been added in 1.14)
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
