### PR TITLE
temporarily diable senstive blocks check

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -303,8 +303,10 @@ public class BlockListener implements Listener {
      * @param count
      *      The amount of times this has been recursively called
      */
+    //disabled for now due to #4069
     @ParametersAreNonnullByDefault
     private void checkForSensitiveBlocks(Block block, Integer count, boolean isDropItems) {
+        /*
         if (count >= Bukkit.getServer().getMaxChainedNeighborUpdates()) {
             return;
         }
@@ -326,6 +328,7 @@ public class BlockListener implements Listener {
         // Set the BlockData back: this makes it so containers and spawners drop correctly. This is a hacky fix.
         block.setBlockData(state.getBlockData(), false);
         state.update(true, false);
+        */
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -303,7 +303,8 @@ public class BlockListener implements Listener {
      * @param count
      *      The amount of times this has been recursively called
      */
-    //disabled for now due to #4069
+    // Disabled for now due to #4069 - Servers crashing due to this check
+    // There is additionally a second bug with `getMaxChainedNeighborUpdates` not existing in 1.17
     @ParametersAreNonnullByDefault
     private void checkForSensitiveBlocks(Block block, Integer count, boolean isDropItems) {
         /*


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->

This PR temporarily disables the senstive blocks check added in #4050.
This will now rebreak these issues https://github.com/Slimefun/Slimefun4/issues/3831 https://github.com/Slimefun/Slimefun4/issues/3182

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
commented out the code added in #4050 

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
