### PR TITLE
Fix backpack IDs not incrementing

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -91,7 +91,10 @@ public class PlayerProfile {
      * Only intended for internal usage.
      * 
      * @return The {@link Config} associated with this {@link PlayerProfile}
+     *
+     * @deprecated Look at {@link PlayerProfile#getPlayerData()} instead for reading data.
      */
+    @Deprecated
     public @Nonnull Config getConfig() {
         return configFile;
     }
@@ -245,10 +248,9 @@ public class PlayerProfile {
     }
 
     public @Nonnull PlayerBackpack createBackpack(int size) {
-        IntStream stream = IntStream.iterate(0, i -> i + 1).filter(i -> !configFile.contains("backpacks." + i + ".size"));
-        int id = stream.findFirst().getAsInt();
+        int nextId = this.data.getBackpacks().size(); // Size is not 0 indexed so next ID can just be the current size
 
-        PlayerBackpack backpack = PlayerBackpack.newBackpack(this.ownerId, id, size);
+        PlayerBackpack backpack = PlayerBackpack.newBackpack(this.ownerId, nextId, size);
         this.data.addBackpack(backpack);
 
         markDirty();

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestPlayerBackpacks.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestPlayerBackpacks.java
@@ -48,6 +48,21 @@ class TestPlayerBackpacks {
     }
 
     @Test
+    @DisplayName("Test creating a new backpack will increment the id")
+    void testCreateBackpackIncrementsId() throws InterruptedException {
+        Player player = server.addPlayer();
+        PlayerProfile profile = TestUtilities.awaitProfile(player);
+
+        PlayerBackpack backpackOne = profile.createBackpack(18);
+        PlayerBackpack backpackTwo = profile.createBackpack(18);
+        PlayerBackpack backpackThree = profile.createBackpack(18);
+
+        Assertions.assertEquals(0, backpackOne.getId());
+        Assertions.assertEquals(1, backpackTwo.getId());
+        Assertions.assertEquals(2, backpackThree.getId());
+    }
+
+    @Test
     @DisplayName("Test upgrading the backpack size")
     void testChangeSize() throws InterruptedException {
         Player player = server.addPlayer();


### PR DESCRIPTION
## Description
Fixes backpack IDs not incrementing unless the server is closed.

## Proposed changes
The ID increment code was still reading the config file, updated this to rely on PlayerData. Made the next ID now be the backpack size. Created a new test to validate behaviour.

## Related Issues (if applicable)
Fixes #4080 

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
