### PR TITLE
Fixes #4087 and some cleanup

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -178,7 +178,7 @@ public class BlockListener implements Listener {
             dropItems(e, drops);
 
             // Checks for vanilla sensitive blocks everywhere
-            checkForSensitiveBlocks(e.getBlock(), 0, e.isDropItems());
+            // checkForSensitiveBlocks(e.getBlock(), 0, e.isDropItems());
         }
     }
 
@@ -306,8 +306,7 @@ public class BlockListener implements Listener {
     // Disabled for now due to #4069 - Servers crashing due to this check
     // There is additionally a second bug with `getMaxChainedNeighborUpdates` not existing in 1.17
     @ParametersAreNonnullByDefault
-    private void checkForSensitiveBlocks(Block block, Integer count, boolean isDropItems) {
-        /*
+    private void checkForSensitiveBlocks(Block block, int count, boolean isDropItems) {
         if (count >= Bukkit.getServer().getMaxChainedNeighborUpdates()) {
             return;
         }
@@ -329,7 +328,6 @@ public class BlockListener implements Listener {
         // Set the BlockData back: this makes it so containers and spawners drop correctly. This is a hacky fix.
         block.setBlockData(state.getBlockData(), false);
         state.update(true, false);
-        */
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -18,6 +18,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -220,6 +221,14 @@ public class BlockListener implements Listener {
             }
 
             drops.addAll(sfItem.getDrops());
+            // Partial fix for #4087 - We don't want the inventory to be usable post break, close it for anyone still inside
+            // The main fix is in SlimefunItemInteractListener preventing opening to begin with
+            // Close the inventory for all viewers of this block
+            // TODO(future): Remove this check when MockBukkit supports viewers
+            if (!Slimefun.instance().isUnitTest()) {
+                BlockStorage.getInventory(e.getBlock()).toInventory().getViewers().forEach(HumanEntity::closeInventory);
+            }
+            // Remove the block data
             BlockStorage.clearBlockInfo(e.getBlock());
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemInteractListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemInteractListener.java
@@ -57,6 +57,13 @@ public class SlimefunItemInteractListener implements Listener {
                 return;
             }
 
+            // Fixes #4087 - Prevents players from interacting with a block that is about to be deleted
+            // We especially don't want to open inventories as that can cause duplication
+            if (Slimefun.getTickerTask().isDeletedSoon(e.getClickedBlock().getLocation())) {
+                e.setCancelled(true);
+                return;
+            }
+
             // Fire our custom Event
             PlayerRightClickEvent event = new PlayerRightClickEvent(e);
             Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
@@ -140,16 +140,18 @@ public class BiomeMap<T> implements Keyed {
         return "BiomeMap " + dataMap.toString();
     }
 
+    @Nonnull
     @ParametersAreNonnullByDefault
-    public static <T> @Nonnull BiomeMap<T> fromJson(NamespacedKey key, String json, BiomeDataConverter<T> valueConverter) throws BiomeMapException {
+    public static <T> BiomeMap<T> fromJson(NamespacedKey key, String json, BiomeDataConverter<T> valueConverter) throws BiomeMapException {
         // All parameters are validated by the Parser.
         BiomeMapParser<T> parser = new BiomeMapParser<>(key, valueConverter);
         parser.read(json);
         return parser.buildBiomeMap();
     }
 
+    @Nonnull
     @ParametersAreNonnullByDefault
-    public static <T> @Nonnull BiomeMap<T> fromJson(NamespacedKey key, String json, BiomeDataConverter<T> valueConverter, boolean isLenient) throws BiomeMapException {
+    public static <T> BiomeMap<T> fromJson(NamespacedKey key, String json, BiomeDataConverter<T> valueConverter, boolean isLenient) throws BiomeMapException {
         // All parameters are validated by the Parser.
         BiomeMapParser<T> parser = new BiomeMapParser<>(key, valueConverter);
         parser.setLenient(isLenient);
@@ -157,8 +159,9 @@ public class BiomeMap<T> implements Keyed {
         return parser.buildBiomeMap();
     }
 
+    @Nonnull
     @ParametersAreNonnullByDefault
-    public static <T> @Nonnull BiomeMap<T> fromResource(NamespacedKey key, JavaPlugin plugin, String path, BiomeDataConverter<T> valueConverter) throws BiomeMapException {
+    public static <T> BiomeMap<T> fromResource(NamespacedKey key, JavaPlugin plugin, String path, BiomeDataConverter<T> valueConverter) throws BiomeMapException {
         Validate.notNull(key, "The key shall not be null.");
         Validate.notNull(plugin, "The plugin shall not be null.");
         Validate.notNull(path, "The path should not be null!");

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/interfaces/InventoryBlock.java
@@ -64,7 +64,11 @@ public interface InventoryBlock {
                 if (p.hasPermission("slimefun.inventory.bypass")) {
                     return true;
                 } else {
-                    return item.canUse(p, false) && Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK);
+                    return item.canUse(p, false) && (
+                        // Protection manager doesn't exist in unit tests
+                        Slimefun.instance().isUnitTest()
+                        || Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.INTERACT_BLOCK)
+                    );
                 }
             }
         };

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunItemInteractListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunItemInteractListener.java
@@ -1,0 +1,137 @@
+package io.github.thebusybiscuit.slimefun4.implementation.listeners;
+
+import io.github.thebusybiscuit.slimefun4.api.events.SlimefunBlockBreakEvent;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event.Result;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.ElectricFurnace;
+import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+
+class TestSlimefunItemInteractListener {
+
+    private static ServerMock server;
+    private static Slimefun plugin;
+    private static SlimefunItem slimefunItem;
+
+    @BeforeAll
+    public static void load() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.load(Slimefun.class);
+
+        // Register block listener (for place + break) and our interact listener for inventory handling
+        new BlockListener(plugin);
+        new SlimefunItemInteractListener(plugin);
+
+        // Enable tickers so the electric furnace can be registered
+        Slimefun.getCfg().setValue("URID.enable-tickers", true);
+
+        slimefunItem = new ElectricFurnace(
+            TestUtilities.getItemGroup(plugin, "test"), SlimefunItems.ELECTRIC_FURNACE, RecipeType.NULL, new ItemStack[]{}
+        )
+            .setCapacity(100)
+            .setEnergyConsumption(10)
+            .setProcessingSpeed(1);
+        slimefunItem.register(plugin);
+    }
+
+    @AfterAll
+    public static void unload() {
+        MockBukkit.unmock();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        server.getPluginManager().clearEvents();
+    }
+
+    // Test for dupe bug - issue #4087
+    @Test
+    void testCannotOpenInvOfBrokenBlock() {
+        // Place down an electric furnace
+        Player player = server.addPlayer();
+        ItemStack itemStack = slimefunItem.getItem();
+        player.getInventory().setItemInMainHand(itemStack);
+
+        // Create a world and place the block
+        World world = TestUtilities.createWorld(server);
+        Block block = TestUtilities.placeSlimefunBlock(server, itemStack, world, player);
+
+        // Right click on the block
+        PlayerInteractEvent playerInteractEvent = new PlayerInteractEvent(
+            player, Action.RIGHT_CLICK_BLOCK, itemStack, block, BlockFace.UP, EquipmentSlot.HAND
+        );
+
+        server.getPluginManager().callEvent(playerInteractEvent);
+        server.getPluginManager().assertEventFired(PlayerInteractEvent.class, e -> {
+            // We cancel the event on inventory open
+            Assertions.assertSame(e.useInteractedBlock(), Result.DENY);
+            return true;
+        });
+
+        // Assert our right click event fired and the block usage was not denied
+        server.getPluginManager().assertEventFired(PlayerRightClickEvent.class, e -> {
+            Assertions.assertNotSame(e.useBlock(), Result.DENY);
+            return true;
+        });
+
+        // Assert we do have an inventory which would be opened
+        // TODO: Create an event for open inventory so this isn't guess work
+        Assertions.assertTrue(BlockMenuPreset.isInventory(slimefunItem.getId()));
+        Assertions.assertTrue(BlockStorage.getStorage(block.getWorld()).hasInventory(block.getLocation()));
+        // TODO(future): Check viewers - MockBukkit does not implement this today
+
+        // Break the block
+        BlockBreakEvent blockBreakEvent = new BlockBreakEvent(block, player);
+        server.getPluginManager().callEvent(blockBreakEvent);
+        server.getPluginManager().assertEventFired(SlimefunBlockBreakEvent.class, e -> {
+            Assertions.assertEquals(slimefunItem.getId(), e.getSlimefunItem().getId());
+            return true;
+        });
+
+        // Assert the block is queued for removal
+        Assertions.assertTrue(Slimefun.getTickerTask().isDeletedSoon(block.getLocation()));
+
+        // Clear event queue since we'll be running duplicate events
+        server.getPluginManager().clearEvents();
+
+         // Right click on the block again now that it's broken
+        PlayerInteractEvent secondPlayerInteractEvent = new PlayerInteractEvent(
+            player, Action.RIGHT_CLICK_BLOCK, itemStack, block, BlockFace.UP, EquipmentSlot.HAND
+        );
+
+        server.getPluginManager().callEvent(secondPlayerInteractEvent);
+        server.getPluginManager().assertEventFired(PlayerInteractEvent.class, e -> {
+            // We cancelled the event due to the block being removed
+            Assertions.assertSame(e.useInteractedBlock(), Result.DENY);
+            return true;
+        });
+
+        // Assert our right click event was not fired due to the block being broken
+        Assertions.assertThrows(
+            AssertionError.class,
+            () -> server.getPluginManager().assertEventFired(PlayerRightClickEvent.class, e -> true)
+        );
+    }
+}


### PR DESCRIPTION
## Description
Per #4087 if you can get into the inventory of a broken block you can easily dupe items (take them out of the inv before cleanup - 500ms by default and from block drops).
We want to fix that and there's also just some general cleanup

## Proposed changes
There are 2 parts to this fix, the first is disabling opening the inventory if the block is broken. The second is closing the inventory on block create (rather than an SF tick later). Created a pretty long test to validate this behaviour and fully verified it through debugger.

I also did a bit of cleanup, and commented out `checkForSensitiveBlocks` rather than the code in the function so we don't have random unused code. Moved @Nonnull annotations in BiomeMap as vscode was freaking out over it being in the middle of generics.

## Related Issues (if applicable)
Fixes #4087 

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
