### PR TITLE
Fixes NPE when interacting with air

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemInteractListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemInteractListener.java
@@ -59,7 +59,7 @@ public class SlimefunItemInteractListener implements Listener {
 
             // Fixes #4087 - Prevents players from interacting with a block that is about to be deleted
             // We especially don't want to open inventories as that can cause duplication
-            if (Slimefun.getTickerTask().isDeletedSoon(e.getClickedBlock().getLocation())) {
+            if (e.getClickedBlock() != null && Slimefun.getTickerTask().isDeletedSoon(e.getClickedBlock().getLocation())) {
                 e.setCancelled(true);
                 return;
             }


### PR DESCRIPTION
## Description
Small bug in the latest change causes an NPE if interacting with air.

## Proposed changes
Add a null check before we check for pending deletion.

## Related Issues (if applicable)
<https://paste.walshy.dev/IwsWtVpt568o>

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
