### PR TITLE
fix items not being able to be placed on ancient altar

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -2,6 +2,8 @@ package io.github.thebusybiscuit.slimefun4.utils;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 
@@ -47,6 +49,19 @@ public class ArmorStandUtils {
      * @return The spawned {@link ArmorStand}
      */
     public static @Nonnull ArmorStand spawnArmorStand(@Nonnull Location location) {
+        // This causes an error on 1.19 and below
+        if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_20)) {
+            return location.getWorld().spawn(location, ArmorStand.class, armorStand -> {
+                armorStand.setVisible(false);
+                armorStand.setSilent(true);
+                armorStand.setMarker(true);
+                armorStand.setGravity(false);
+                armorStand.setBasePlate(false);
+                armorStand.setRemoveWhenFarAway(false);
+            });
+        }
+
+        // Remove this when we drop support for 1.19
         ArmorStand armorStand = location.getWorld().spawn(location, ArmorStand.class);
         armorStand.setVisible(false);
         armorStand.setSilent(true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -47,13 +47,13 @@ public class ArmorStandUtils {
      * @return The spawned {@link ArmorStand}
      */
     public static @Nonnull ArmorStand spawnArmorStand(@Nonnull Location location) {
-        return location.getWorld().spawn(location, ArmorStand.class, armorStand -> {
-            armorStand.setVisible(false);
-            armorStand.setSilent(true);
-            armorStand.setMarker(true);
-            armorStand.setGravity(false);
-            armorStand.setBasePlate(false);
-            armorStand.setRemoveWhenFarAway(false);
-        });
+        ArmorStand armorStand = location.getWorld().spawn(location, ArmorStand.class);
+        armorStand.setVisible(false);
+        armorStand.setSilent(true);
+        armorStand.setMarker(true);
+        armorStand.setGravity(false);
+        armorStand.setBasePlate(false);
+        armorStand.setRemoveWhenFarAway(false);
+        return armorStand;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ArmorStandUtils.java
@@ -49,26 +49,22 @@ public class ArmorStandUtils {
      * @return The spawned {@link ArmorStand}
      */
     public static @Nonnull ArmorStand spawnArmorStand(@Nonnull Location location) {
-        // This causes an error on 1.19 and below
-        if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_20)) {
-            return location.getWorld().spawn(location, ArmorStand.class, armorStand -> {
-                armorStand.setVisible(false);
-                armorStand.setSilent(true);
-                armorStand.setMarker(true);
-                armorStand.setGravity(false);
-                armorStand.setBasePlate(false);
-                armorStand.setRemoveWhenFarAway(false);
-            });
+        // 1.19 and below don't have the consumer method so flicker exists on these versions.
+        if (Slimefun.getMinecraftVersion().isBefore(MinecraftVersion.MINECRAFT_1_20)) {
+            ArmorStand armorStand = location.getWorld().spawn(location, ArmorStand.class);
+            setupArmorStand(armorStand);
+            return armorStand;
         }
 
-        // Remove this when we drop support for 1.19
-        ArmorStand armorStand = location.getWorld().spawn(location, ArmorStand.class);
+        return location.getWorld().spawn(location, ArmorStand.class, armorStand -> setupArmorStand(armorStand));
+    }
+
+    private static void setupArmorStand(ArmorStand armorStand) {
         armorStand.setVisible(false);
         armorStand.setSilent(true);
         armorStand.setMarker(true);
         armorStand.setGravity(false);
         armorStand.setBasePlate(false);
         armorStand.setRemoveWhenFarAway(false);
-        return armorStand;
     }
 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This bug apparenttly has existed for 7 months.
On 1.19.4 you are not able to place items on an ancient altar you get the following error
https://pastebin.com/87UpB46w

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
revert https://github.com/Slimefun/Slimefun4/commit/060b59dd0f09886b72d0b4e63ab9f3d7ce5db952

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
issue reported on discord
https://canary.discord.com/channels/565557184348422174/565569196218384385/1196756895948619797

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
