### PR TITLE
Add update warning to /sf versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-api</artifactId>
-            <version>fcdbd45aa0</version>
+            <version>1108163a49</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -65,11 +65,25 @@ class VersionsCommand extends SubCommand {
                 .append(serverSoftware)
                 .color(ChatColor.GREEN)
                 .append(" " + Bukkit.getVersion() + '\n')
-                .color(ChatColor.DARK_GREEN)
+                .color(ChatColor.DARK_GREEN);
+
+            builder
                 .append("Slimefun ")
                 .color(ChatColor.GREEN)
-                .append(Slimefun.getVersion() + '\n')
+                .append(Slimefun.getVersion())
                 .color(ChatColor.DARK_GREEN);
+            if (!Slimefun.getUpdater().isLatestVersion()) {
+                builder
+                    .append(" (").color(ChatColor.GRAY)
+                    .append("Update available").color(ChatColor.RED).event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
+                        "Your Slimefun version is out of date!\n" +
+                        "Please update to get the latest bug fixes and performance improvements.\n" +
+                        "Please do not report any bugs without updating first."
+                    )))
+                    .append(")").color(ChatColor.GRAY);
+            }
+
+            builder.append("\n");
             // @formatter:on
 
             if (Slimefun.getMetricsService().getVersion() != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -1,6 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.core.services;
 
 import java.io.File;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
@@ -108,6 +109,29 @@ public class UpdaterService {
         }
 
         return -1;
+    }
+
+    public int getLatestVersion() {
+        if (updater != null && updater.getLatestVersion().isDone()) {
+            PrefixedVersion version;
+            try {
+                version = updater.getLatestVersion().get();
+                return version.getVersionNumber();
+            } catch (InterruptedException | ExecutionException e) {
+                return -1;
+            }
+        }
+
+        return -1;
+    }
+
+    public boolean isLatestVersion() {
+        if (getBuildNumber() == -1 || getLatestVersion() == -1) {
+            // We don't know if we're latest so just report we are
+            return true;
+        }
+        
+        return getBuildNumber() == getLatestVersion();
     }
 
     /**


### PR DESCRIPTION
## Description
Adds a "Update available" to /sf versions if someone isn't on the latest Slimefun version. Hovering over will tell the user they should update and not to report bugs on this version.

Needs https://github.com/baked-libs/dough/pull/245 merged

## Proposed changes
Check if we're on the latest version in the versions command and if not, send a update available message.

![image](https://github.com/Slimefun/Slimefun4/assets/8492901/4cc9d8e7-9d6e-4e9d-8227-48772d63458e)
![image](https://github.com/Slimefun/Slimefun4/assets/8492901/6e301498-2f22-414f-9e92-56102fae47e7)

## Related Issues (if applicable)
N/A

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

## TODO

- [x] Update dough