### PR TITLE
:sparkles: feat(api): Introduce SlimefunItemRegistryFinalizedEvent

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemRegistryFinalizedEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemRegistryFinalizedEvent.java
@@ -11,7 +11,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 /**
  * This {@link Event} is fired after {@link Slimefun} finishes loading the
- * {@link SlimefunItem} registry. 
+ * {@link SlimefunItem} registry. We recommend listening to this event if you
+ * want to register recipes using items from other addons.
  *
  * @author ProfElements
  */
@@ -31,5 +32,4 @@ public class SlimefunItemRegistryFinalizedEvent extends Event {
     public HandlerList getHandlers() {
         return getHandlerList(); 
     }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemRegistryFinalizedEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemRegistryFinalizedEvent.java
@@ -11,15 +11,15 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 /**
  * This {@link Event} is fired after {@link Slimefun} finishes loading the
- * {@link SlimefunItem} registry before auto loading
+ * {@link SlimefunItem} registry. 
  *
  * @author ProfElements
  */
-public class SlimefunRegistryFinalizedEvent extends Event {
+public class SlimefunItemRegistryFinalizedEvent extends Event {
     
     private static final HandlerList handlers = new HandlerList();
 
-    public SlimefunRegistryFinalizedEvent() {}
+    public SlimefunItemRegistryFinalizedEvent() {}
 
     @Nonnull
     public static HandlerList getHandlerList() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunRegistryFinalizedEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunRegistryFinalizedEvent.java
@@ -1,0 +1,35 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import javax.annotation.Nonnull;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+
+/**
+ * This {@link Event} is fired after {@link Slimefun} finishes loading the
+ * {@link SlimefunItem} registry before auto loading
+ *
+ * @author ProfElements
+ */
+public class SlimefunRegistryFinalizedEvent extends Event {
+    
+    private static final HandlerList handlers = new HandlerList();
+
+    public SlimefunRegistryFinalizedEvent() {}
+
+    @Nonnull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Nonnull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList(); 
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.ItemStack;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import io.github.thebusybiscuit.slimefun4.api.events.SlimefunItemRegistryFinalizedEvent;
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunRegistryFinalizedEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -78,6 +79,8 @@ public final class PostSetup {
             }
         }
 
+        Bukkit.getPluginManager().callEvent(new SlimefunItemRegistryFinalizedEvent());
+        
         loadOreGrinderRecipes();
         loadSmelteryRecipes();
 
@@ -110,7 +113,7 @@ public final class PostSetup {
 
         Slimefun.getItemCfg().save();
         Slimefun.getResearchCfg().save();
-        Bukkit.getPluginManager().callEvent(new SlimefunRegistryFinalizedEvent());
+
         Slimefun.getRegistry().setAutoLoadingMode(true);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -112,7 +112,6 @@ public final class PostSetup {
 
         Slimefun.getItemCfg().save();
         Slimefun.getResearchCfg().save();
-
         Slimefun.getRegistry().setAutoLoadingMode(true);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunItemRegistryFinalizedEvent;
-import io.github.thebusybiscuit.slimefun4.api.events.SlimefunRegistryFinalizedEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -24,6 +24,7 @@ import org.bukkit.inventory.ItemStack;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import io.github.thebusybiscuit.slimefun4.api.events.SlimefunRegistryFinalizedEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
@@ -109,6 +110,7 @@ public final class PostSetup {
 
         Slimefun.getItemCfg().save();
         Slimefun.getResearchCfg().save();
+        Bukkit.getPluginManager().callEvent(new SlimefunRegistryFinalizedEvent());
         Slimefun.getRegistry().setAutoLoadingMode(true);
     }
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.Assertions;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,13 +28,11 @@ class TestSlimefunRegistryFinalizedEvent {
         MockBukkit.unmock();
     }
 
-
     @Test
     @DisplayName("Test that SlimefunRegistryFinalizedEvent is fired")
     void testEventIsFired() {
-        
         //Make sure post setup does not throw
-        assertDoesNotThrow(() -> PostSetup.loadItems());
+        Assertions.assertDoesNotThrow(() -> PostSetup.loadItems());
         
         //Make sure post setup sent the event
         server.getPluginManager().assertEventFired(SlimefunItemRegistryFinalizedEvent.class, ignored -> true);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
@@ -27,7 +27,6 @@ class TestSlimefunRegistryFinalizedEvent {
     public static void unload() {
         MockBukkit.unmock();
     }
-
     @Test
     @DisplayName("Test that SlimefunRegistryFinalizedEvent is fired")
     void testEventIsFired() {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
@@ -31,13 +31,12 @@ class TestSlimefunRegistryFinalizedEvent {
     @Test
     @DisplayName("Test that SlimefunRegistryFinalizedEvent is fired")
     void testEventIsFired() {
-        //Make sure post setup does not throw
+        // Make sure post setup does not throw
         Assertions.assertDoesNotThrow(() -> PostSetup.loadItems());
         
-        //Make sure post setup sent the event
+        // Make sure post setup sent the event
         server.getPluginManager().assertEventFired(SlimefunItemRegistryFinalizedEvent.class, ignored -> true);
  
         server.getPluginManager().clearEvents();
     }
-
 } 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
@@ -37,7 +37,7 @@ class TestSlimefunRegistryFinalizedEvent {
         assertDoesNotThrow(() -> PostSetup.loadItems());
         
         //Make sure post setup sent the event
-        server.getPluginManager().assertEventFired(SlimefunRegistryFinalizedEvent.class, ignored -> true);
+        server.getPluginManager().assertEventFired(SlimefunItemRegistryFinalizedEvent.class, ignored -> true);
  
         server.getPluginManager().clearEvents();
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
@@ -27,6 +27,7 @@ class TestSlimefunRegistryFinalizedEvent {
     public static void unload() {
         MockBukkit.unmock();
     }
+
     @Test
     @DisplayName("Test that SlimefunRegistryFinalizedEvent is fired")
     void testEventIsFired() {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
@@ -1,0 +1,45 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.setup.PostSetup;
+
+class TestSlimefunRegistryFinalizedEvent {
+
+    private static ServerMock server;
+    private static Slimefun plugin;
+
+    @BeforeAll
+    public static void load() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.load(Slimefun.class);
+    }
+
+    @AfterAll
+    public static void unload() {
+        MockBukkit.unmock();
+    }
+
+
+    @Test
+    @DisplayName("Test that SlimefunRegistryFinalizedEvent is fired")
+    void testEventIsFired() {
+        
+        //Make sure post setup does not throw
+        assertDoesNotThrow(() -> PostSetup.loadItems());
+        
+        //Make sure post setup sent the event
+        server.getPluginManager().assertEventFired(SlimefunRegistryFinalizedEvent.class, ignored -> true);
+ 
+        server.getPluginManager().clearEvents();
+    }
+
+} 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This Event is provided so that plugins that have integrations with each other aren't stuck in a state in which some SlimefunItems may not be available to one plugin or the other.

I will use this event to provide a cleaner integration between Dynatech and other plugins. Currently InfinityXpansion, ExoticGarden, and Gastronomicon.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Make an event to be able to listen to Slimefun's Registry finalizing all static items. 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
