### PR TITLE
Update dough to fix item stacking issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-api</artifactId>
-            <version>a2364de77c</version>
+            <version>fcdbd45aa0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description
Items currently won't stack due to random UUIDs being used on each load. This will fix that

## Proposed changes
Update dough to include pr https://github.com/baked-libs/dough/pull/246

## Related Issues (if applicable)
Fixes #4097

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
