### PR TITLE
fix slimefun block turning into a vanilla block if there are viewers

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -226,9 +226,10 @@ public class BlockListener implements Listener {
             // The main fix is in SlimefunItemInteractListener preventing opening to begin with
             // Close the inventory for all viewers of this block
             BlockMenu inventory = BlockStorage.getInventory(e.getBlock());
-            // TODO(future): Remove this check when MockBukkit supports viewers
-            if (inventory != null && !Slimefun.instance().isUnitTest()) {
-                inventory.toInventory().getViewers().forEach(HumanEntity::closeInventory);
+            if (inventory != null) {
+                for (HumanEntity human : new ArrayList<>(inventory.toInventory().getViewers())) {
+                    human.closeInventory();
+                }
             }
             // Remove the block data
             BlockStorage.clearBlockInfo(e.getBlock());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunItemInteractListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunItemInteractListener.java
@@ -116,7 +116,9 @@ class TestSlimefunItemInteractListener {
         // TODO: Create an event for open inventory so this isn't guess work
         Assertions.assertTrue(BlockMenuPreset.isInventory(electricFurnace.getId()));
         Assertions.assertTrue(BlockStorage.getStorage(block.getWorld()).hasInventory(block.getLocation()));
-        // TODO(future): Check viewers - MockBukkit does not implement this today
+
+        // Assert player has the inventory open
+        Assertions.assertEquals(1, BlockStorage.getInventory(block).toInventory().getViewers().size());
 
         // Break the block
         BlockBreakEvent blockBreakEvent = new BlockBreakEvent(block, player);
@@ -128,6 +130,9 @@ class TestSlimefunItemInteractListener {
 
         // Assert the block is queued for removal
         Assertions.assertTrue(Slimefun.getTickerTask().isDeletedSoon(block.getLocation()));
+
+        // Assert that the inventory was closed
+        Assertions.assertEquals(0, BlockStorage.getInventory(block).toInventory().getViewers().size());
 
         // Clear event queue since we'll be running duplicate events
         server.getPluginManager().clearEvents();


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
when a slimefun block with an inventory has a viewer and gets broken it turns into a vanilla item.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Changed the for loop.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
https://paste.walshy.dev/pS31PJ6GnlJy

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
