### PR TITLE
Make the CropGrowthAccelerator take speed into account (grow multiple…

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/CropGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/CropGrowthAccelerator.java
@@ -41,12 +41,20 @@ public abstract class CropGrowthAccelerator extends AbstractGrowthAccelerator {
         BlockMenu inv = BlockStorage.getInventory(b);
 
         if (getCharge(b.getLocation()) >= getEnergyConsumption()) {
+            int cropsGrown = 0;
+
             for (int x = -getRadius(); x <= getRadius(); x++) {
                 for (int z = -getRadius(); z <= getRadius(); z++) {
                     Block block = b.getRelative(x, 0, z);
 
-                    if (SlimefunTag.CROP_GROWTH_ACCELERATOR_BLOCKS.isTagged(block.getType()) && grow(b, inv, block)) {
-                        return;
+                    if (SlimefunTag.CROP_GROWTH_ACCELERATOR_BLOCKS.isTagged(block.getType())) {
+                        if (grow(b, inv, block)) {
+                            cropsGrown++;
+
+                            if (cropsGrown >= getSpeed()) {
+                                return;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
… blocks at once)

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This fixes the crop growth accelerator and makes it work as is advertised. 
Before it's only accelerating the growth of one block at at time instead of based on the Speed parameter of the accelerator.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Just take into account the speed of the accelerator block

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
