### PR TITLE
Multi tools won't reset their modes after server restart

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiTool.java
@@ -1,17 +1,19 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.gadgets;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.bakedlibs.dough.common.ChatColors;
+import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
 import org.bukkit.ChatColor;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -26,17 +28,19 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 /**
  * The {@link MultiTool} is an electric device which can mimic
  * the behaviour of any other {@link SlimefunItem}.
- * 
- * @author TheBusyBiscuit
  *
+ * @author TheBusyBiscuit
  */
 public class MultiTool extends SlimefunItem implements Rechargeable {
 
     private static final float COST = 0.3F;
 
-    private final Map<UUID, Integer> selectedMode = new HashMap<>();
     private final List<MultiToolMode> modes = new ArrayList<>();
     private final float capacity;
+
+    private static final NamespacedKey key = new NamespacedKey(Slimefun.instance(), "multitool_mode");
+    private static final String LORE_PREFIX = ChatColors.color("&8\u21E8 &7Mode: ");
+    private static final Pattern REGEX = Pattern.compile(ChatColors.color("(&c&o)?" + LORE_PREFIX) + "(.+)");
 
     @ParametersAreNonnullByDefault
     public MultiTool(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, float capacity, String... items) {
@@ -73,17 +77,15 @@ public class MultiTool extends SlimefunItem implements Rechargeable {
         return e -> {
             Player p = e.getPlayer();
             ItemStack item = e.getItem();
+            ItemMeta meta = item.getItemMeta();
             e.cancel();
 
-            int index = selectedMode.getOrDefault(p.getUniqueId(), 0);
+            int index = PersistentDataAPI.getInt(meta, key);
+            SlimefunItem sfItem = modes.get(index).getItem();
 
             if (!p.isSneaking()) {
-                if (removeItemCharge(item, COST)) {
-                    SlimefunItem sfItem = modes.get(index).getItem();
-
-                    if (sfItem != null) {
-                        sfItem.callItemHandler(ItemUseHandler.class, handler -> handler.onRightClick(e));
-                    }
+                if (sfItem != null && removeItemCharge(item, COST)) {
+                    sfItem.callItemHandler(ItemUseHandler.class, handler -> handler.onRightClick(e));
                 }
             } else {
                 index = nextIndex(index);
@@ -91,7 +93,28 @@ public class MultiTool extends SlimefunItem implements Rechargeable {
                 SlimefunItem selectedItem = modes.get(index).getItem();
                 String itemName = selectedItem != null ? selectedItem.getItemName() : "Unknown";
                 Slimefun.getLocalization().sendMessage(p, "messages.multi-tool.mode-change", true, msg -> msg.replace("%device%", "Multi Tool").replace("%mode%", ChatColor.stripColor(itemName)));
-                selectedMode.put(p.getUniqueId(), index);
+
+                PersistentDataAPI.setInt(meta, key, index);
+
+                List<String> lore = meta.hasLore() ? meta.getLore() : new ArrayList<>();
+
+                boolean regexMatchFound = false;
+                for (int i = 0; i < lore.size(); i++) {
+                    String line = lore.get(i);
+
+                    if (REGEX.matcher(line).matches()) {
+                        lore.set(i, LORE_PREFIX + ChatColor.stripColor(itemName));
+                        regexMatchFound = true;
+                        break;
+                    }
+                }
+
+                if (!regexMatchFound) {
+                    lore.add(2, LORE_PREFIX + ChatColor.stripColor(itemName));
+                }
+
+                meta.setLore(lore);
+                item.setItemMeta(meta);
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiToolMode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiToolMode.java
@@ -8,19 +8,40 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 
 class MultiToolMode {
 
+    private final int id;
+    private final String itemId;
     private final ItemSetting<String> item;
     private final ItemSetting<Boolean> enabled;
 
+    // TODO: Move "id" into some NamespacedKey
     MultiToolMode(@Nonnull MultiTool multiTool, int id, @Nonnull String itemId) {
+        this.id = id;
+        this.itemId = itemId;
         this.item = new ItemSetting<>(multiTool, "mode." + id + ".item", itemId);
         this.enabled = new ItemSetting<>(multiTool, "mode." + id + ".enabled", true);
 
         multiTool.addItemSetting(item, enabled);
     }
 
+    /**
+     * This method is deprecated and should not be used.
+     *
+     *
+     * @return The ID of this mode
+     */
+    @Deprecated(since = "RC-37", forRemoval = true)
+    public int getId() {
+        return id;
+    }
+
     @Nullable
     SlimefunItem getItem() {
         return SlimefunItem.getById(item.getValue());
+    }
+
+    @Nonnull
+    String getItemId() {
+        return itemId;
     }
 
     boolean isEnabled() {


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Multi tools reset their mode after server restart. I found it really annoying and so did my players, so I decided to fix that.
This pull request also adds a display of current multi tool mode in its lore.
Feel free to improve my code. I tried to achieve my goal without changing too much stuff, so it *shouldn't* break anything.

![Captura de pantalla 2023-12-28 231315](https://github.com/Slimefun/Slimefun4/assets/28115365/d7e32739-b908-454f-8a44-f19fb99292d0)

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Multi tools keep their current mode after server restart
- Current multi tool mode is displayed in its lore (works with already existing multi tools)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
