### PR TITLE
Fixes #4123 - Coal Generator will no longer be locked after researching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,20 @@
                     <groupId>org.jetbrains</groupId>
                     <artifactId>annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.papermc.paper</groupId>
+                    <artifactId>paper-api</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Override MockBukkit's Paper to a pinned slightly older version -->
+        <!-- This is because MockBukkit currently fails after this PR: -->
+        <!-- https://github.com/PaperMC/Paper/pull/9629 -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.20.4-R0.1-20240205.114523-90</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Third party plugin integrations / soft dependencies -->

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/legacy/LegacyStorage.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/legacy/LegacyStorage.java
@@ -91,7 +91,17 @@ public class LegacyStorage implements Storage {
                 playerFile.setValue("researches." + research.getID(), true);
 
             // Remove the research if it's no longer researched
-            } else if (playerFile.contains("researches." + research.getID())) {
+            // ----
+            // We have a duplicate ID (173) used for both Coal Gen and Bio Reactor
+            // If you researched the Goal Gen we would remove it on save if you didn't also have the Bio Reactor
+            // Due to the fact we would set it as researched (true in the branch above) on Coal Gen
+            // but then go into this branch and remove it if you didn't have Bio Reactor
+            // Sooooo we're gonna hack this for now while we move away from the Legacy Storage
+            // Let's make sure the user doesn't have _any_ research with this ID and _then_ remove it
+            } else if (
+                playerFile.contains("researches." + research.getID())
+                && !data.getResearches().stream().anyMatch((r) -> r.getID() == research.getID())
+            ) {
                 playerFile.setValue("researches." + research.getID(), null);
             }
         }


### PR DESCRIPTION
## Description
Due to a logic bug in the Legacy storage backend if there was a duplicate ID it would mark it as researched for the first, then see it researched already and remove it on the second. This was happening for the Coal Generator and Bio Reactor here. Both shared he same research ID 173.

We're just doing this fix for now until we can move away from the legacy backend (work in progress).

## Proposed changes
If we already see the value as researched in the file just double-check that the player does not have it researched.

This change also needed us to pin Paper due to a Paper PR that caused MockBukkit to fail. Not a fan of this but it should only be temporary until MockBukkit updates.
I hate that we always use a "1.x" version which versions are pushed to... Everyone really should always pin to just specific versions to avoid these kinda problems. But that's another topic for another day.

## Related Issues (if applicable)
Fixes #4123 

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
