### PR TITLE
Fixes guide search when using colored chat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,11 +345,10 @@
         </dependency>
 
         <!-- Shaded packages -->
-        <!-- TODO: Revert changes back to maven when dough 1.3 released -->
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-api</artifactId>
-            <version>1108163a49</version>
+            <version>0130f8d9ce</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description
Fixes guide search when using colored chat

## Proposed changes
With https://github.com/baked-libs/dough/pull/250 handle the ChatInput as colored text rather than user friendly (&) text.

Also pinned Spigot to resolve build issues.

## Related Issues (if applicable)
N/A

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

## TODO
- [x] merge dough PR and update pom