### PR TITLE
[WIP] Binary storage for player data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,9 +347,9 @@
         <!-- Shaded packages -->
         <!-- TODO: Revert changes back to maven when dough 1.3 released -->
         <dependency>
-            <groupId>com.github.baked-libs.dough</groupId>
+            <groupId>io.github.baked-libs</groupId>
             <artifactId>dough-api</artifactId>
-            <version>1108163a49</version>
+            <version>1.3.0_local_nbt_v7</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -528,10 +528,12 @@
             <version>2.6</version>
             <scope>compile</scope>
         </dependency>
+        <!-- Also pinning Spigot since they did a breaking change  -->
+        <!-- in this PR: https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/pull-requests/829/overview -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>${spigot.version}-R0.1-SNAPSHOT</version>
+            <version>${spigot.version}-R0.1-20240209.081002-77</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.github.thebusybiscuit.slimefun4.storage.Storage;
+import io.github.thebusybiscuit.slimefun4.storage.backend.binary.BinaryStorage;
 import io.github.thebusybiscuit.slimefun4.storage.backend.legacy.LegacyStorage;
 
 import org.apache.commons.lang.Validate;
@@ -306,8 +307,21 @@ public class Slimefun extends JavaPlugin implements SlimefunAddon {
         networkManager = new NetworkManager(networkSize, config.getBoolean("networks.enable-visualizer"), config.getBoolean("networks.delete-excess-items"));
 
         // Data storage
-        playerStorage = new LegacyStorage();
-        logger.log(Level.INFO, "Using legacy storage for player data");
+        String storageBackend = config.getString("storage.player-data");
+
+        if (storageBackend.equals("legacy")) {
+            playerStorage = new LegacyStorage();
+            logger.info("Using legacy storage for player data");
+        } else if (storageBackend.equals("binary")) {
+            playerStorage = new BinaryStorage();
+            StartupWarnings.experimentalStorage(logger, storageBackend);
+
+            // TODO(future): Run migration if needed
+        } else {
+            playerStorage = new LegacyStorage();
+            logger.warning("Unknown storage backend for player data: " + storageBackend);
+            logger.warning("Defaulting to legacy storage instead");
+        }
 
         // Setting up bStats
         new Thread(metricsService::start, "Slimefun Metrics").start();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/StartupWarnings.java
@@ -73,4 +73,18 @@ final class StartupWarnings {
         logger.log(Level.WARNING, BORDER);
     }
 
+    static void experimentalStorage(Logger logger, String backend) {
+        logger.log(Level.WARNING, BORDER);
+        logger.log(Level.WARNING, PREFIX + "You have enabled an experimental storage backend!");
+        logger.log(Level.WARNING, PREFIX);
+        logger.log(Level.WARNING, PREFIX + "\"{0}\" storage is still in development.", backend);
+        logger.log(Level.WARNING, PREFIX + "It might not work as expected and it might");
+        logger.log(Level.WARNING, PREFIX + "break your Slimefun data. Use at your own risk!");
+        logger.log(Level.WARNING, PREFIX);
+        logger.log(Level.WARNING, PREFIX + "You can revert at any time but be aware you will");
+        logger.log(Level.WARNING, PREFIX + "lose progress that happened during the time you switched.");
+        logger.log(Level.WARNING, PREFIX);
+        logger.log(Level.WARNING, PREFIX + "If you encounter any issues, please report them to us!");
+        logger.log(Level.WARNING, BORDER);
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/BinaryStorage.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/BinaryStorage.java
@@ -1,0 +1,151 @@
+package io.github.thebusybiscuit.slimefun4.storage.backend.binary;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import io.github.thebusybiscuit.slimefun4.core.debug.Debug;
+import io.github.thebusybiscuit.slimefun4.core.debug.TestCase;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+
+import io.github.bakedlibs.dough.nbt.TagType;
+import io.github.bakedlibs.dough.nbt.streams.CompressionType;
+import io.github.bakedlibs.dough.nbt.streams.TagInputStream;
+import io.github.bakedlibs.dough.nbt.streams.TagOutputStream;
+import io.github.bakedlibs.dough.nbt.tags.CompoundTag;
+import io.github.bakedlibs.dough.nbt.tags.ListTag;
+import io.github.bakedlibs.dough.nbt.tags.StringTag;
+import io.github.bakedlibs.dough.nbt.tags.Tag;
+import io.github.thebusybiscuit.slimefun4.api.gps.Waypoint;
+import io.github.thebusybiscuit.slimefun4.api.player.PlayerBackpack;
+import io.github.thebusybiscuit.slimefun4.api.researches.Research;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.storage.Storage;
+import io.github.thebusybiscuit.slimefun4.storage.backend.binary.serializers.LocationSerializer;
+import io.github.thebusybiscuit.slimefun4.storage.data.PlayerData;
+
+public class BinaryStorage implements Storage {
+
+    private static final NamespacedKey PLAYER_DATA = new NamespacedKey(Slimefun.instance(), "player_data");
+    private static final NamespacedKey RESEARCHES_KEY = new NamespacedKey(Slimefun.instance(), "researches");
+    private static final NamespacedKey BACKPACKS_KEY = new NamespacedKey(Slimefun.instance(), "backpacks");
+    private static final NamespacedKey WAYPOINTS_KEY = new NamespacedKey(Slimefun.instance(), "waypoints");
+
+    // TODO: Move to lz4 or zstd
+    private static final CompressionType compression = CompressionType.GZIP;
+
+    /*
+     * Structure as JSON:
+     * {
+     *   "slimefun:researches": ["slimefun:some_research", "slimefun:some_other_research"],
+     *   "slimefun:backpacks": [
+     *     {
+     *       "id": x,
+     *       "item": y
+     *     }
+     *   ],
+     *   "slimefun:waypoints": {
+     *     "<ID>": {
+     *       "name": "",
+     *       "location": {}
+     *     }
+     *   }
+     * }
+     */
+
+    @Override
+    public PlayerData loadPlayerData(UUID uuid) {
+        Debug.log(TestCase.PLAYER_PROFILE_DATA, "Loading player data from binary storage for {}", uuid);
+        File file = new File("data-storage/Slimefun/Players/" + uuid + ".dat");
+
+        if (!file.exists()) {
+            return new PlayerData(Set.of(), Map.of(), Set.of());
+        }
+
+        CompoundTag root;
+        try {
+            try (TagInputStream stream = new TagInputStream(new FileInputStream(file), compression)) {
+                root = (CompoundTag) stream.readTag();
+            }
+        } catch(IOException e) {
+            throw new IllegalStateException("Failed to read Player data for " + uuid, e);
+        }
+
+        // Load researches
+        ListTag<StringTag> list = root.getList(RESEARCHES_KEY, TagType.STRING);
+
+        Set<Research> researches = new HashSet<>();
+        for (Research research : Slimefun.getRegistry().getResearches()) {
+            for (StringTag tag : list) {
+                if (tag.getValue().equals(research.getKey().toString())) {
+                    researches.add(research);
+                }
+            }
+        }
+
+        // Load backpacks
+        Map<Integer, PlayerBackpack> backpacks = Map.of();
+        CompoundTag backpackMap = root.getCompound(BACKPACKS_KEY);
+        // TODO: Item serialization
+
+        // Load waypoints
+        Set<Waypoint> waypoints = new HashSet<>();
+        CompoundTag waypointMap = root.getCompound(WAYPOINTS_KEY);
+        for (Map.Entry<NamespacedKey, Tag<?>> key : waypointMap) {
+            CompoundTag waypoint = (CompoundTag) key.getValue();
+
+            String name = waypoint.getString(CommonKeys.NAME);
+            Location location = LocationSerializer.INSTANCE.deserialize(waypoint.getCompound(CommonKeys.LOCATION));
+
+            waypoints.add(new Waypoint(uuid, key.getKey().getKey(), location, name));
+        }
+
+        return new PlayerData(researches, backpacks, waypoints);
+    }
+
+    @Override
+    public void savePlayerData(UUID uuid, PlayerData data) {
+        Debug.log(TestCase.PLAYER_PROFILE_DATA, "Saving player data from binary storage for {}", uuid);
+        File file = new File("data-storage/Slimefun/Players/" + uuid + ".dat");
+
+        CompoundTag root = new CompoundTag(PLAYER_DATA);
+
+        // Save researches
+        ListTag<StringTag> list = new ListTag<>();
+        for (Research research : data.getResearches()) {
+            list.add(new StringTag(research.getKey().toString()));
+        }
+
+        root.putList(RESEARCHES_KEY, list);
+
+        // Save backpacks
+        CompoundTag backpackMap = new CompoundTag();
+
+        // Save waypoints
+        CompoundTag waypointMap = new CompoundTag();
+        for (Waypoint waypoint : data.getWaypoints()) {
+            CompoundTag waypointTag = new CompoundTag();
+
+            waypointTag.putString(CommonKeys.ID, waypoint.getId());
+            waypointTag.putString(CommonKeys.NAME, waypoint.getName());
+            waypointTag.putCompound(CommonKeys.LOCATION, LocationSerializer.INSTANCE.serialize(waypoint.getLocation()));
+
+            waypointMap.putCompound(new NamespacedKey(Slimefun.instance(), waypoint.getId()), waypointTag);
+        }
+        root.putCompound(WAYPOINTS_KEY, waypointMap);
+
+        try {
+            try (TagOutputStream stream = new TagOutputStream(new FileOutputStream(file), compression)) {
+                stream.writeTag(root);
+            }
+        } catch(IOException e) {
+            throw new IllegalStateException("Failed to read Player data for " + uuid, e);
+        }
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/CommonKeys.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/CommonKeys.java
@@ -1,0 +1,17 @@
+package io.github.thebusybiscuit.slimefun4.storage.backend.binary;
+
+import org.bukkit.NamespacedKey;
+
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+public class CommonKeys {
+
+    public static final NamespacedKey ID = new NamespacedKey(Slimefun.instance(), "id");
+    public static final NamespacedKey NAME = new NamespacedKey(Slimefun.instance(), "name");
+    // Location stuff
+    public static final NamespacedKey LOCATION = new NamespacedKey(Slimefun.instance(), "location");
+    public static final NamespacedKey WORLD = new NamespacedKey(Slimefun.instance(), "world");
+    public static final NamespacedKey POSITION = new NamespacedKey(Slimefun.instance(), "position");
+    public static final NamespacedKey PITCH = new NamespacedKey(Slimefun.instance(), "pitch");
+    public static final NamespacedKey YAW = new NamespacedKey(Slimefun.instance(), "yaw");
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/serializers/BinarySerialize.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/serializers/BinarySerialize.java
@@ -1,0 +1,10 @@
+package io.github.thebusybiscuit.slimefun4.storage.backend.binary.serializers;
+
+import io.github.bakedlibs.dough.nbt.tags.Tag;
+
+public interface BinarySerialize<O, T extends Tag<?>> {
+
+    public T serialize(O obj);
+
+    public O deserialize(T obj);
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/serializers/LocationSerializer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/serializers/LocationSerializer.java
@@ -1,0 +1,60 @@
+package io.github.thebusybiscuit.slimefun4.storage.backend.binary.serializers;
+
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+
+import io.github.bakedlibs.dough.blocks.BlockPosition;
+import io.github.bakedlibs.dough.nbt.tags.CompoundTag;
+import io.github.bakedlibs.dough.nbt.tags.IntArrayTag;
+import io.github.thebusybiscuit.slimefun4.storage.backend.binary.CommonKeys;
+
+public class LocationSerializer implements BinarySerialize<Location, CompoundTag> {
+
+    public static final LocationSerializer INSTANCE = new LocationSerializer();
+
+    private LocationSerializer() {}
+
+    @Override
+    public CompoundTag serialize(Location location) {
+        CompoundTag tag = new CompoundTag();
+
+        if (location.getWorld() != null) {
+            tag.put(CommonKeys.WORLD, UUIDSerializer.INSTANCE.serialize(location.getWorld().getUID()));
+        }
+
+        tag.putDouble(CommonKeys.POSITION, BlockPosition.getAsLong(location));
+
+        if (location.getPitch() != 0.0F) {
+            tag.putFloat(CommonKeys.PITCH, location.getPitch());
+        }
+        if (location.getYaw() != 0.0F) {
+            tag.putFloat(CommonKeys.YAW, location.getYaw());
+        }
+
+        return tag;
+    }
+
+    @Override
+    public Location deserialize(CompoundTag location) {
+        UUID worldUuid = null;
+        IntArrayTag worldTag = (IntArrayTag) location.get(CommonKeys.WORLD);
+        if (worldTag != null) {
+            worldUuid = UUIDSerializer.INSTANCE.deserialize(worldTag);
+        }
+
+        BlockPosition position = new BlockPosition(null, location.getLong(CommonKeys.POSITION).getAsLong());
+
+        double x = position.getX();
+        double y = position.getY();
+        double z = position.getZ();
+        float pitch = location.getFloat(CommonKeys.PITCH).orElse(0.0f);
+        float yaw = location.getFloat(CommonKeys.YAW).orElse(0.0f);
+
+        return new Location(
+            worldUuid != null ? Bukkit.getWorld(worldUuid) : null,
+            x, y, z, yaw, pitch
+        );
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/serializers/UUIDSerializer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/storage/backend/binary/serializers/UUIDSerializer.java
@@ -1,0 +1,43 @@
+package io.github.thebusybiscuit.slimefun4.storage.backend.binary.serializers;
+
+import java.util.UUID;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang.Validate;
+
+import io.github.bakedlibs.dough.nbt.tags.IntArrayTag;
+
+public class UUIDSerializer implements BinarySerialize<UUID, IntArrayTag> {
+    
+    public static final UUIDSerializer INSTANCE = new UUIDSerializer();
+
+    private UUIDSerializer() {}
+
+    @Override
+    public IntArrayTag serialize(@Nonnull UUID uuid) {
+        Validate.notNull(uuid, "The provided UUID cannot be null");
+
+        long mostSig = uuid.getMostSignificantBits();
+        long leastSig = uuid.getLeastSignificantBits();
+        int[] ints = new int[] {
+            (int) (mostSig >> 32),
+            (int) mostSig,
+            (int) (leastSig >> 32),
+            (int) leastSig
+        };
+
+        return new IntArrayTag(ints);
+    }
+
+    @Override
+    public UUID deserialize(@Nonnull IntArrayTag uuid) {
+        Validate.notNull(uuid, "The provided UUID cannot be null");
+
+        int[] ints = uuid.getValue();
+        return new UUID(
+            (long) ints[0] << 32L | ints[1] & 0xFFFFFFFFL,
+            (long) ints[2] << 32L | ints[3] & 0xFFFFFFFFL
+        );
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,9 @@ options:
   backup-data: true
   drop-block-creative: true
 
+storage:
+  player-data: legacy
+
 guide:
   show-vanilla-recipes: true
   receive-on-first-join: true


### PR DESCRIPTION
## Description
Starting phase 2 of the new storage system

Once again there's a lot to unpack here but it's a much smaller change than phase 1!

### What changed
* There's a new config property - `storage.player-data`
  * This accepts two values, `legacy` and `binary`
  * `binary` is marked as experimental
* If `binary` (this PR) is selected in the config for player data we will show a large warning banner in the console:
![experimental warning](https://i.walshy.dev/fLzZbBNbIgb2VenGW5.png)
* Created a new BinaryStorage to handle writing the files as binary (more on this later)
* This BinaryStorage is changing the way researches are saved, they're now using their NamespacedKey's rather than incremental IDs. This has been a change we should have made forever ago and this is step 1 to removing these number IDs.

### Storage choice

Ok so, as you can see from the PR, the storage is done with NBT. The question I'm sure you're asking is why NBT over xyz?
Well, there's a few reasons;
1. Familiarity
  a. Lots of server owners and developers are familiar with NBT. This makes adoption internally and externally _much_ easier (especially with how much MC has leaned into it over the years)
3. Solid storage
  a. NBT is about as small as it can get. Some people think it's inflated, the format isn't. Usage however is. That isn't something any format can really prevent.
4. Existing tooling
  a. Lots of existing tooling exists for server owners to read these files (a bit more on this later as well)

> [!NOTE]
> This is a simple implementation which would have to have the whole file rewritten each time. I'll explore ways to avoid this but without limiting file size, there isn't a great way to do it.

### Usage example

Legacy file with all researches:

Legacy file with all researches, a backpack with numerous items and a waypoint:

Binary file with all researches (no compression):

Binary file with all researches (gzip compression):


### Tooling

- TODO

## Proposed changes
See above

## Related Issues (if applicable)
https://github.com/Slimefun/Slimefun4/issues/3170

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

## For the reviewers

- TODO

## Testing

- TODO

## TODO

- [ ] Sign off from reviewers we want to go this way
- [ ] Finish up NBT side on dough
  - [ ] Write any more methods that'd be helpful
  - [ ] Document all functions (snooze)
  - [ ] Add more tests covering more complex cases + compression
- [ ] TODO