### PR TITLE
Fixes exhaustion when loading large profiles

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/Threads.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/Threads.java
@@ -1,0 +1,23 @@
+package io.github.thebusybiscuit.slimefun4;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Threads {
+
+    @ParametersAreNonnullByDefault
+    public static void newThread(JavaPlugin plugin, String name, Runnable runnable) {
+        // TODO: Change to thread pool
+        new Thread(runnable, plugin.getName() + " - " + name).start();
+    }
+
+    public static String getCaller() {
+        // First item will be getting the call stack
+        // Second item will be this call
+        // Third item will be the func we care about being called
+        // And finally will be the caller
+        StackTraceElement element = Thread.currentThread().getStackTrace()[3];
+        return element.getClassName() + "." + element.getMethodName() + ":" + element.getLineNumber();
+    }
+}


### PR DESCRIPTION
## Description
Fixes exhaustion when loading large PlayerProfiles due to multiple load calls being made.
If we're already loading the profile, we don't want to spin up a whole new thread and load the profile again/more. This can very easily cause CPU, memory and thread exhaustion if the profile is large

We saw AbstractArmorTask constantly try to get the PlayerProfile (every 10 mc ticks) even though the profile was still being loaded (due to it's very large size). This compounded the issue and ended up killing servers off entirely.

## Proposed changes
Add tracking for when we're loading the PlayerProfile from file into memory. If the profile is loading, we will simply return and not try to load it again. This does mean that callbacks for PlayerProfile#get are currently tossed away, this isn't ideal but IMO is acceptable here. It will just mean if someone interacts with a block/item quickly and they have a large profile, instead of the interaction happening after load it will just not happen and they will need to re-interact. This is only for first load so not a big deal but worth calling out.

## Related Issues (if applicable)
Fixes #4011
Fixes #4116

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
