### PR TITLE
chore: add rc warnings to `sf versions` command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <!-- Our default version will be UNOFFICIAL, this will prevent auto updates -->
     <!-- from overriding our local test file -->
-    <version>RC - 38</version>
+    <version>4.9-UNOFFICIAL</version>
     <inceptionYear>2013</inceptionYear>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <!-- Our default version will be UNOFFICIAL, this will prevent auto updates -->
     <!-- from overriding our local test file -->
-    <version>4.9-UNOFFICIAL</version>
+    <version>RC - 38</version>
     <inceptionYear>2013</inceptionYear>
     <packaging>jar</packaging>
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -84,7 +84,7 @@ class VersionsCommand extends SubCommand {
                     .append(")").color(ChatColor.GRAY);
             }
 
-            builder.append("\n");
+            builder.append("\n").event((HoverEvent) null);
             // @formatter:on
 
             if (Slimefun.getMetricsService().getVersion() != null) {
@@ -99,10 +99,14 @@ class VersionsCommand extends SubCommand {
             addJavaVersion(builder);
 
             if (Slimefun.getUpdater().getBranch() == SlimefunBranch.STABLE) {
-                builder.append("\nYou are using a RC (stable) version,")
+                builder.append("\nYou are using a RC (stable) version, " +
+                        "\nDO NOT report any bugs to Discord/GitHub.\n")
                     .color(ChatColor.RED)
-                    .append("\nDO NOT report any bugs to Discord/GitHub")
-                    .color(ChatColor.DARK_RED);
+                    .event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
+                        "We do not provide support for stable versions, use with caution!\n" +
+                            "Please do not report any bugs with this version.\n" +
+                            "Upgrade to Dev version first for support."
+                    )));
             }
 
             builder.append("\n").event((HoverEvent) null);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -99,11 +99,12 @@ class VersionsCommand extends SubCommand {
             addJavaVersion(builder);
 
             if (Slimefun.getUpdater().getBranch() == SlimefunBranch.STABLE) {
-                builder.append("\nYou are using a RC (stable) version, " +
+                builder.append("\nYou are using a stable version," +
+                        "\nWe do not provide support to stable versions." +
                         "\nDO NOT report any bugs to Discord/GitHub.\n")
                     .color(ChatColor.RED)
                     .event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(
-                        "We do not provide support for stable versions, use with caution!\n" +
+                        "We do not provide support for stable versions.\n" +
                             "Please do not report any bugs with this version.\n" +
                             "Upgrade to Dev version first for support."
                     )));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -5,13 +5,13 @@ import java.util.Collection;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.plugin.Plugin;
 
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
 import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
@@ -96,6 +97,13 @@ class VersionsCommand extends SubCommand {
             }
 
             addJavaVersion(builder);
+
+            if (Slimefun.getUpdater().getBranch() == SlimefunBranch.STABLE) {
+                builder.append("\nYou are using a RC (stable) version,")
+                    .color(ChatColor.RED)
+                    .append("\nDO NOT report any bugs to Discord/GitHub")
+                    .color(ChatColor.DARK_RED);
+            }
 
             builder.append("\n").event((HoverEvent) null);
             addPluginVersions(builder);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
People who use RC versions still report bugs to Discord/GitHub, adding warning messages may possibily stop them from reporting. (just possible, people without eyes will still report)
Also fixed a issue introduced in https://github.com/Slimefun/Slimefun4/pull/4096, where all the text after updater available have hover event.

This will only apply to future RC versions.

Test run (I changed the version manually to RC - 38, and this is only screenshot for first run):
![image](https://github.com/Slimefun/Slimefun4/assets/7105953/d4c66b24-2bb4-4305-974f-694fcc4d1e57)


## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add warning messages to `/sf versions`.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
