### PR TITLE
fix dupe glitch with backpacks

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -400,8 +400,8 @@ public class PlayerProfile {
 
             Slimefun.getRegistry().getPlayerProfiles().put(uuid, event.getProfile());
 
-            // Make sure we call this after we actually put the PlayerProfile into the map.
-            // Otherwise we end up with a race condition where the profile is not in the map just _yet_
+            // Make sure we call this after we put the PlayerProfile into the registry.
+            // Otherwise, we end up with a race condition where the profile is not in the map just _yet_
             // but the loading flag is gone and we can end up loading it a second time (and thus can dupe items)
             // Fixes https://github.com/Slimefun/Slimefun4/issues/4130
             loading.remove(uuid);
@@ -444,8 +444,8 @@ public class PlayerProfile {
                 PlayerProfile pp = new PlayerProfile(p, data);
                 Slimefun.getRegistry().getPlayerProfiles().put(uuid, pp);
 
-                // Make sure we call this after we actually put the PlayerProfile into the map.
-                // Otherwise we end up with a race condition where the profile is not in the map just _yet_
+                // Make sure we call this after we put the PlayerProfile into the registry.
+                // Otherwise, we end up with a race condition where the profile is not in the map just _yet_
                 // but the loading flag is gone and we can end up loading it a second time (and thus can dupe items)
                 // Fixes https://github.com/Slimefun/Slimefun4/issues/4130
                 loading.remove(uuid);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -394,12 +394,18 @@ public class PlayerProfile {
         loading.put(uuid, true);
         Slimefun.getThreadService().newThread(Slimefun.instance(), "PlayerProfile#get(" + uuid + ")", () -> {
             PlayerData data = Slimefun.getPlayerStorage().loadPlayerData(p.getUniqueId());
-            loading.remove(uuid);
 
             AsyncProfileLoadEvent event = new AsyncProfileLoadEvent(new PlayerProfile(p, data));
             Bukkit.getPluginManager().callEvent(event);
 
             Slimefun.getRegistry().getPlayerProfiles().put(uuid, event.getProfile());
+
+            // Make sure we call this after we actually put the PlayerProfile into the map.
+            // Otherwise we end up with a race condition where the profile is not in the map just _yet_
+            // but the loading flag is gone and we can end up loading it a second time (and thus can dupe items)
+            // Fixes https://github.com/Slimefun/Slimefun4/issues/4130
+            loading.remove(uuid);
+
             callback.accept(event.getProfile());
         });
 
@@ -434,10 +440,15 @@ public class PlayerProfile {
             // Should probably prevent multiple requests for the same profile in the future
             Slimefun.getThreadService().newThread(Slimefun.instance(), "PlayerProfile#request(" + uuid + ")", () -> {
                 PlayerData data = Slimefun.getPlayerStorage().loadPlayerData(uuid);
-                loading.remove(uuid);
 
                 PlayerProfile pp = new PlayerProfile(p, data);
                 Slimefun.getRegistry().getPlayerProfiles().put(uuid, pp);
+
+                // Make sure we call this after we actually put the PlayerProfile into the map.
+                // Otherwise we end up with a race condition where the profile is not in the map just _yet_
+                // but the loading flag is gone and we can end up loading it a second time (and thus can dupe items)
+                // Fixes https://github.com/Slimefun/Slimefun4/issues/4130
+                loading.remove(uuid);
             });
 
             return false;


### PR DESCRIPTION
## Description
This PR fixes a dupe glitch with backpacks. There was a race condition in PlayerProfile where the UUID got removed from the loading map before it was finished loading and inserted into the Registry. This meant that the PlayerProfile could load twice if someone did something like spam open a backpack after joining.
We now finish loading and adding to the registry before marking it as no longer loading.

## Proposed changes
Move where we finish loading (remove from the loading map) to ensure we're always after the registry.

## Related Issues (if applicable)
Fixes #4130 
possibly fix for #4131 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
