### PR TITLE
Optimize SlimefunUtils#isItemSimilar / Optimize SlimefunUtils#equalsItemMeta

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -408,6 +408,11 @@ public final class SlimefunUtils {
                         return optionalDistinctive.get().canStack(possibleSfItemMeta, itemMeta);
                     }
                     return true;
+                } else if (id != null && possibleItemId != null) {
+                    /*
+                     * We have two IDs that DO NOT match, we can skip ItemMeta check.
+                     */
+                    return false;
                 } else {
                     Debug.log(TestCase.CARGO_INPUT_TESTING, "  Item IDs don't match, checking meta {} == {} (lore: {})", itemMeta, possibleSfItemMeta, checkLore);
                     return equalsItemMeta(itemMeta, possibleSfItemMeta, checkLore);
@@ -459,6 +464,10 @@ public final class SlimefunUtils {
     }
 
     private static boolean equalsItemMeta(@Nonnull ItemMeta itemMeta, @Nonnull ItemMeta sfitemMeta, boolean checkLore) {
+
+        if(!Slimefun.getItemDataService().getItemData(itemMeta).equals(Slimefun.getItemDataService().getItemData(sfitemMeta)))
+            return false;
+
         if (itemMeta.hasDisplayName() != sfitemMeta.hasDisplayName()) {
             return false;
         } else if (itemMeta.hasDisplayName() && sfitemMeta.hasDisplayName() && !itemMeta.getDisplayName().equals(sfitemMeta.getDisplayName())) {


### PR DESCRIPTION
Optimize SlimefunUtils#isItemSimilar
Optimize SlimefunUtils#equalsItemMeta

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
We can skip some of slow ItemMeta checks that relay on getDisplayName() and getLore() which both deserialize string from JSON internally in Spigot

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
We check SF Item IDs first if those are available and then fallback to ItemMeta check.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
