### PR TITLE
[ci skip] Add blob builds workflow

### DIFF
--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -1,0 +1,36 @@
+name: Publish build
+
+on:
+  push:
+    branches:
+      - master
+      - stable
+
+jobs:
+  publish:
+    name: Upload build
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, '[ci skip]') == false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3.13.0
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+          java-package: jdk
+          architecture: x64
+
+      - name: Build with Maven
+        run: mvn clean package
+
+      - name: Upload to Blob Builds
+        uses: WalshyDev/blob-builds/gh-action@f3da5ce
+        with:
+          project: Slimefun4
+          releaseChannel: ${{ github.ref == 'refs/heads/master' && 'Dev' || 'RC' }}
+          apiToken: ${{ secrets.BLOB_BUILDS_API_TOKEN }}
+          file: './target/Slimefun v4.9-UNOFFICIAL.jar'
+          releaseNotes: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
## Description
We've moved to blob builds, let's finally get the auto-publish working

## Proposed changes
Adds a new workflow for publishing on pushes to master/stable.

## Related Issues (if applicable)
N/A

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
