### PR TITLE
feat: add item group key to item group items

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -216,11 +216,7 @@ public class ItemGroup implements Keyed {
      */
     public @Nonnull ItemStack getItem(@Nonnull Player p) {
         return new CustomItemStack(item, meta -> {
-            String name = Slimefun.getLocalization().getItemGroupName(p, getKey());
-
-            if (name == null) {
-                name = meta.getDisplayName();
-            }
+            String name = getDisplayName(p);
 
             if (this instanceof SeasonalItemGroup) {
                 meta.setDisplayName(ChatColor.GOLD + name);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.LockedItemGroup;
@@ -37,6 +38,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
  * 
  */
 public class ItemGroup implements Keyed {
+    private static final NamespacedKey ITEM_GROUP_KEY = new NamespacedKey(Slimefun.instance(), "item_group");
 
     private SlimefunAddon addon;
 
@@ -217,7 +219,7 @@ public class ItemGroup implements Keyed {
             String name = Slimefun.getLocalization().getItemGroupName(p, getKey());
 
             if (name == null) {
-                name = item.getItemMeta().getDisplayName();
+                name = meta.getDisplayName();
             }
 
             if (this instanceof SeasonalItemGroup) {
@@ -227,6 +229,8 @@ public class ItemGroup implements Keyed {
             }
 
             meta.setLore(Arrays.asList("", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
+
+            PersistentDataAPI.setString(meta, ITEM_GROUP_KEY, getKey().toString());
         });
     }
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
ItemGroup items can be arbitrary. A Slimefun item, a simple renamed vanilla item, or a complex item can be an ItemGroup item.
It would be good if they could have their `NamespacedKey` in their PDC so other plugins can read this as an ItemGroup item.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
ItemGroup items now have `slimefun:item_group` in their PDC.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
