### PR TITLE
Fix: solve teleportation time overflow problem.

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -161,11 +161,15 @@ public final class TeleportationManager {
             return 100;
         }
 
-        int speed = 50_000 + complexity * complexity;
-        int unsafeTime = Math.min(4 * distanceSquared(source, destination) / speed, 40);
+        long speed = 50_000L + (long)complexity * complexity;
+        int distance = 4 * distanceSquared(source, destination), time = 1;
 
-        // Fixes #3573 - Using Math.max is a safer way to ensure values > 0 than relying on addition.
-        return Math.max(1, unsafeTime);
+        // If speed is greater than distance, ultimate time cost must be 1 tick.
+        // Otherwise, speed WON'T overflow the range of int.
+        if (speed <= distance)
+            time = Math.min(distance / (int)speed, 40);
+
+        return time;
     }
 
     @ParametersAreNonnullByDefault


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
In TP time calculation, $\rm complexity \times complexity$ may result in int overflow when complexity is higher than $4\times 10^{4}$, not difficult to achieve with several popular addons.

Compared with original solution based on `Math` function, it is better to avoid overflow directly.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Use `long` to storage temporary speed variable, which hardly overflow in TP time calculation.

If $\rm speed > distance$, time cost must be 1 tick, so we can skip calculation.

Otherwise, $\rm \dfrac {distance}{speed} \geq 1$, while speed must be in range of `int`.

Therefore we can simply convert speed to int variable to calculate ultimate time cost.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
