### PR TITLE
Fixes Javadocs build & adds workflow to ensure no more breakages

### DIFF
--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -1,0 +1,37 @@
+name: Javadocs
+
+on:
+  push:
+    paths:
+    - 'src/**'
+    - 'pom.xml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Maven build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: 'adopt'
+        java-version: '17'
+        java-package: jdk
+        architecture: x64
+
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
+    - name: Build Javadocs
+      run: mvn javadoc:javadoc

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.idea/
 /.vscode/
 /data-storage/
+/javadocs/
 
 dependency-reduced-pom.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
 
                 <configuration>
                     <reportOutputDirectory>${project.basedir}</reportOutputDirectory>
-                    <destDir>docs</destDir>
+                    <destDir>javadocs</destDir>
 
                     <doctitle>Slimefun4 - Javadocs</doctitle>
                     <windowtitle>Slimefun4 - Javadocs</windowtitle>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/ThreadService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/ThreadService.java
@@ -39,7 +39,7 @@ public final class ThreadService {
      * This is a much better alternative to using
      * {@link BukkitScheduler#runTaskAsynchronously(org.bukkit.plugin.Plugin, Runnable)}
      * as this will show not only the plugin but a useful name.
-     * By default, Bukkit will use "Craft Scheduler Thread - <x> - <plugin>" which is nice to show the plugin but
+     * By default, Bukkit will use "Craft Scheduler Thread - {@literal <x>} - {@literal <plugin>}" which is nice to show the plugin but
      * it's impossible to track exactly what thread that is.
      *
      * @param plugin The {@link JavaPlugin} that is creating this thread
@@ -60,7 +60,7 @@ public final class ThreadService {
      * This is a much better alternative to using
      * {@link BukkitScheduler#runTaskTimerAsynchronously(org.bukkit.plugin.Plugin, Runnable, long, long)}
      * as this will show not only the plugin but a useful name.
-     * By default, Bukkit will use "Craft Scheduler Thread - <x> - <plugin>" which is nice to show the plugin but
+     * By default, Bukkit will use "Craft Scheduler Thread - {@literal <x>} - {@literal <plugin>}" which is nice to show the plugin but
      * it's impossible to track exactly what thread that is.
      *
      * @param plugin The {@link JavaPlugin} that is creating this thread


### PR DESCRIPTION
## Description
The javadocs have again been broken for a while, I said I wanted to do this last time and forgot. So now, we're gonna both fix the docs and add validation to this repo.

## Proposed changes
* Adds a new workflow "Javadocs" to validate that we can build the javadocs and there are no errors
* Fixes the javadoc errors in ThreadService
* Changes the destination dir of the javadocs since we now have a real "docs" dir 
  * Accompanying javadocs PR - https://github.com/Slimefun/javadocs/pull/14 

## Related Issues (if applicable)
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
