### PR TITLE
Writtenbook soulbound fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/CraftingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/CraftingTableListener.java
@@ -2,6 +2,9 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.implementation.items.magical.SoulboundItem;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
@@ -12,6 +15,9 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import org.bukkit.inventory.meta.BookMeta;
+
+import java.awt.print.Book;
 
 /**
  * This {@link Listener} prevents any {@link SlimefunItem} from being used in a
@@ -49,6 +55,12 @@ public class CraftingTableListener implements SlimefunCraftingListener {
                     e.getInventory().setResult(null);
                     break;
                 }
+            }
+
+            if (e.getInventory().getResult() == null) return;
+            ItemStack result = e.getInventory().getResult();
+            if (result.getType() == Material.WRITTEN_BOOK) {
+                SlimefunUtils.setSoulbound(result, false);
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/CraftingTableListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/crafting/CraftingTableListener.java
@@ -2,7 +2,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting;
 
 import javax.annotation.Nonnull;
 
-import io.github.thebusybiscuit.slimefun4.implementation.items.magical.SoulboundItem;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -15,9 +14,6 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import org.bukkit.inventory.meta.BookMeta;
-
-import java.awt.print.Book;
 
 /**
  * This {@link Listener} prevents any {@link SlimefunItem} from being used in a


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
When cloning an Written Book in the crafting slot with a Writable Book, it keeps all the item data, like the SoulBound Status. With should not be intended since it "dupes it".

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Simply setting the soul bound status false when a book is cloned

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
