### PR TITLE
Use a thread-safe Set impl for the TickerTask's tickingLocations

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -44,6 +44,7 @@ public class TickerTask implements Runnable {
 
     /**
      * This Map holds all currently actively ticking locations.
+     * The value of this map (Set entries) MUST be thread-safe and mutable.
      */
     private final Map<ChunkPosition, Set<Location>> tickingLocations = new ConcurrentHashMap<>();
 
@@ -329,7 +330,7 @@ public class TickerTask implements Runnable {
     public Set<Location> getLocations(@Nonnull Chunk chunk) {
         Validate.notNull(chunk, "The Chunk cannot be null!");
 
-        Set<Location> locations = tickingLocations.getOrDefault(new ChunkPosition(chunk), new HashSet<>());
+        Set<Location> locations = tickingLocations.getOrDefault(new ChunkPosition(chunk), Collections.emptySet());
         return Collections.unmodifiableSet(locations);
     }
 
@@ -343,7 +344,14 @@ public class TickerTask implements Runnable {
         Validate.notNull(l, "Location cannot be null!");
 
         ChunkPosition chunk = new ChunkPosition(l.getWorld(), l.getBlockX() >> 4, l.getBlockZ() >> 4);
-        Set<Location> newValue = new HashSet<>();
+
+        /*
+          Note that all the values in #tickingLocations must be thread-safe.
+          Thus, the choice is between the CHM KeySet or a synchronized set.
+          The CHM KeySet was chosen since it at least permits multiple concurrent
+          reads without blocking.
+        */
+        Set<Location> newValue = ConcurrentHashMap.newKeySet();
         Set<Location> oldValue = tickingLocations.putIfAbsent(chunk, newValue);
 
         /**


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Bugfix

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
* Replace the use of a `HashSet` with `ConcurrentHashMap#newKeySet` in the ticker task to prevent `CME`s from ocurring when we are ticking
* Updated relevant javadocs
* Replace getOrDefault creations of `HashSet` with `Collections#emptySet`
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Fixes #3696 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
