### PR TITLE
Add a SlimefunItem constructor that only needs `ItemGroup` and `SlimefunItemStack`

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -160,6 +160,21 @@ public class SlimefunItem implements Placeable {
         this.recipeOutput = recipeOutput;
     }
 
+    /**
+     * This creates a new {@link SlimefunItem} from the given arguments.
+     *
+     * @param itemGroup
+     *                  The {@link ItemGroup} this {@link SlimefunItem} belongs
+     *                  to
+     * @param item
+     *                  The {@link SlimefunItemStack} that describes the visual
+     *                  features of our {@link SlimefunItem}
+     */
+    @ParametersAreNonnullByDefault
+    public SlimefunItem(ItemGroup itemGroup, SlimefunItemStack item) {
+        this(itemGroup, item, RecipeType.NULL, new ItemStack[] {});
+    }
+
     // Previously deprecated constructor, now only for internal purposes
     @ParametersAreNonnullByDefault
     protected SlimefunItem(ItemGroup itemGroup, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I have a seperate system of managing recipes and would like a shorthand to not have to define them at item creation time. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add a `SlimefunItem` constructor that just passed RecipeType.NULL and empty recipe for its `recipe` and `input` fields.
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
