### PR TITLE
Added McMMO anvil fix

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/McMMOIntegration.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/McMMOIntegration.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.integrations;
 
 import javax.annotation.Nonnull;
 
+import com.gmail.nossr50.events.skills.repair.McMMOPlayerRepairCheckEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -19,7 +20,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 
 /**
  * This handles all integrations with {@link mcMMO}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -55,6 +56,18 @@ class McMMOIntegration implements Listener {
     }
 
     @EventHandler(ignoreCancelled = true)
+    public void onItemRepair(McMMOPlayerRepairCheckEvent e) {
+        ItemStack repaired = e.getRepairedObject();
+        ItemStack material = e.getRepairMaterial();
+
+        if (isSalvageable(repaired) && isSalvageable(material))
+            return;
+
+        e.setCancelled(true);
+        Slimefun.getLocalization().sendMessage(e.getPlayer(), "anvil.mcmmo-repair");
+    }
+
+    @EventHandler(ignoreCancelled = true)
     public void onAutoDisenchant(AutoDisenchantEvent e) {
         try {
             SkillUtils.removeAbilityBuff(e.getItem());
@@ -67,10 +80,10 @@ class McMMOIntegration implements Listener {
      * This method checks if an {@link ItemStack} can be salvaged or not.
      * We basically don't want players to salvage any {@link SlimefunItem} unless
      * it is a {@link VanillaItem}.
-     * 
+     *
      * @param item
      *            The {@link ItemStack} to check
-     * 
+     *
      * @return Whether this item can be safely salvaged
      */
     private boolean isSalvageable(@Nonnull ItemStack item) {


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Fixing a bug where having mcmmo would allow you to repair for instance a gold chestplate with 4k gold, and then dismantling it for normal gold, or using lead to repair an iron sword. You can use slimefun items to repair vanilla items and use items to repair Slimefun items

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added and event listener for the repair event.
Add a translation key for the error mcmmo.anvil-repair

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #4181

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [X] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [X] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
