### PR TITLE
Undeprecate the CS-Core stuff for now

### DIFF
--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/Configuration/Config.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/Configuration/Config.java
@@ -13,10 +13,8 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
  * An old remnant of CS-CoreLib.
  * This will be removed once we updated everything.
  * Don't look at the code, it will be gone soon, don't worry.
- *
- * @deprecated Only used by the legacy {@link BlockStorage} system.
+ * Only used by the legacy {@link BlockStorage} system.
  */
-@Deprecated
 public class Config {
 
     private final File file;

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ChestMenu.java
@@ -16,9 +16,7 @@ import org.bukkit.inventory.ItemStack;
  * An old remnant of CS-CoreLib.
  * This will be removed once we updated everything.
  * Don't look at the code, it will be gone soon, don't worry.
- *
  */
-@Deprecated
 public class ChestMenu {
 
     private boolean clickable;
@@ -207,7 +205,6 @@ public class ChestMenu {
      *
      * @return The ChestMenu Instance
      */
-    @Deprecated
     public ChestMenu build() {
         return this;
     }

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ClickAction.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/ClickAction.java
@@ -4,9 +4,7 @@ package me.mrCookieSlime.CSCoreLibPlugin.general.Inventory;
  * An old remnant of CS-CoreLib.
  * This will be removed once we updated everything.
  * Don't look at the code, it will be gone soon, don't worry.
- *
  */
-@Deprecated
 public class ClickAction {
 
     private boolean right;

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/general/Inventory/MenuListener.java
@@ -17,12 +17,9 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu.MenuClickHan
 
 /**
  * An old {@link Listener} for CS-CoreLib
- * 
- * @deprecated This is an old remnant of CS-CoreLib, the last bits of the past. They will be removed once everything is
+ * This is an old remnant of CS-CoreLib, the last bits of the past. They will be removed once everything is
  *             updated.
- *
  */
-@Deprecated
 public class MenuListener implements Listener {
 
     static final Map<UUID, ChestMenu> menus = new HashMap<>();

--- a/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/package-info.java
+++ b/src/main/java/me/mrCookieSlime/CSCoreLibPlugin/package-info.java
@@ -1,5 +1,4 @@
 /**
  * Old CS-CoreLib 1.X code.
  */
-@java.lang.Deprecated
 package me.mrCookieSlime.CSCoreLibPlugin;

--- a/src/main/java/me/mrCookieSlime/package-info.java
+++ b/src/main/java/me/mrCookieSlime/package-info.java
@@ -3,5 +3,4 @@
  * Don't look too close at the code that lays here. It's horrible, believe me.
  * Once we updated everything, all of these classes will be removed.
  */
-@java.lang.Deprecated
 package me.mrCookieSlime;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Undepreated the old stuff in `me.mrCookieSlime`. This was done because we have no replacement yet, and the IDE warnings are getting annoying in addons. Deprecate these *after* having a replacement.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I added sufficient Unit Tests to cover my code.
