### PR TITLE
Feature/energy regulator gui

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
@@ -3,7 +3,16 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.core.attributes.MachineProcessHolder;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockUseHandler;
+import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
+import io.github.thebusybiscuit.slimefun4.core.machines.MachineProcessor;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -20,6 +29,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.handlers.SimpleBlockBre
 
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.*;
 
 /**
  * The {@link EnergyRegulator} is a special type of {@link SlimefunItem} which serves as the heart of every
@@ -32,6 +44,13 @@ import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
  *
  */
 public class EnergyRegulator extends SlimefunItem implements HologramOwner {
+
+    private static final int[] BORDER = { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+    private static final int[] END_BORDER = {45, 46, 48, 49, 50, 52, 53};
+    private static final int PREV = 47;
+    private static final int NEXT = 51;
+
+    private static int AMOUNT = 36;
 
     @ParametersAreNonnullByDefault
     public EnergyRegulator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -56,7 +75,7 @@ public class EnergyRegulator extends SlimefunItem implements HologramOwner {
         return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlayerPlace(BlockPlaceEvent e) {
+            public void onPlayerPlace(@Nonnull BlockPlaceEvent e) {
                 updateHologram(e.getBlock(), "&7Connecting...");
             }
 
@@ -66,6 +85,28 @@ public class EnergyRegulator extends SlimefunItem implements HologramOwner {
     @Override
     public void preRegister() {
         addItemHandler(onPlace());
+
+        BlockUseHandler handler = blockUserHandler -> {
+            Location location;
+            Player player = blockUserHandler.getPlayer();
+
+            try {
+                location = blockUserHandler.getClickedBlock().orElseThrow().getLocation();
+            } catch (NoSuchElementException e) {
+                blockUserHandler.cancel();
+                return;
+            }
+
+            EnergyNet network = getEnergyNetwork(location);
+
+            if (network == null)
+                return;
+
+
+            getGUI(player, 0, network).open(player);
+        };
+
+        addItemHandler(handler);
 
         addItemHandler(new BlockTicker() {
 
@@ -84,6 +125,126 @@ public class EnergyRegulator extends SlimefunItem implements HologramOwner {
     private void tick(@Nonnull Block b) {
         EnergyNet network = EnergyNet.getNetworkFromLocationOrCreate(b.getLocation());
         network.tick(b);
+    }
+
+    private EnergyNet getEnergyNetwork(Location location) {
+        EnergyNet network;
+
+        try {
+            network = Slimefun.getNetworkManager().getNetworkFromLocation(location, EnergyNet.class).orElseThrow();
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+
+        return network;
+    }
+
+
+    private List<ItemStack> getDisplayMachines(EnergyNet network) {
+
+        Map<Location, EnergyNetComponent> consumers = network.getConsumers();
+
+        List<ItemStack> print = new ArrayList<>();
+
+        for (var entry : consumers.entrySet()) {
+            EnergyNetComponent cmp = entry.getValue();
+            Location location = entry.getKey();
+
+            if (!(cmp instanceof SlimefunItem sf)) {
+                continue;
+            }
+
+            ItemStack element = sf.getItem().clone();
+            ItemMeta meta = element.getItemMeta();
+
+            if (meta == null) {
+                continue;
+            }
+
+            List<String> lore = element.getItemMeta().getLore();
+
+            if (lore == null) {
+                continue;
+            }
+
+            if (sf instanceof MachineProcessHolder<?> holder) {
+                //This isn't very reliable as end-game machines which are faster will show as offline if clicked when a recipe just completed
+                MachineProcessor<MachineOperation> processor = (MachineProcessor<MachineOperation>) holder.getMachineProcessor();
+                MachineOperation op = processor.getOperation(location);
+
+                String msg = op == null ? "§4§lOffline" : "§a§lOnline";
+                lore.add("");
+                lore.add("§bStored Energy:§3 " + cmp.getCharge(location) +" J");
+                lore.add(msg);
+                meta.setLore(lore);
+                element.setItemMeta(meta);
+            }
+
+            print.add(element);
+        }
+
+        print.sort(Comparator.comparing(ItemStack::getType));
+
+        return print;
+    }
+
+    private ChestMenu getGUI(Player p, int page, EnergyNet network) {
+        ChestMenu chestMenu = new ChestMenu(getItemName());
+
+        ChestMenu.MenuClickHandler blank = ChestMenuUtils.getEmptyClickHandler();
+        ItemStack background = ChestMenuUtils.getBackground();
+
+        for (int i : BORDER) {
+            chestMenu.addItem(i, background, blank);
+        }
+
+        List<ItemStack> displayMachines = getDisplayMachines(network);
+        int length = displayMachines.size();
+        int pages = length / AMOUNT;
+
+        int start = page * AMOUNT;
+        int end = start + AMOUNT;
+
+        for (int i = start; i < end; i++) {
+            int slot = i % AMOUNT + 9;
+
+            ItemStack item;
+            try {
+                item = displayMachines.get(i);
+            } catch (IndexOutOfBoundsException e) {
+                break;
+            }
+
+            if (item == null) {
+                break;
+            }
+
+            chestMenu.addItem(slot, displayMachines.get(i), blank);
+        }
+
+        chestMenu.addItem(PREV, ChestMenuUtils.getPreviousButton(p, page, pages), (p1, slot, item, action) -> {
+            int prev = page - 1;
+            if (prev == -1)
+                return false;
+
+            getGUI(p1, prev, network).open(p1);
+            return true;
+        });
+
+        chestMenu.addItem(NEXT, ChestMenuUtils.getNextButton(p, page, pages), (p1, slot, item, action) -> {
+            int next = page + 1;
+            if (next > pages)
+                return false;
+
+            getGUI(p1, next, network).open(p1);
+            return true;
+        });
+
+        for (int i : END_BORDER) {
+            chestMenu.addItem(i, background, blank);
+        }
+
+        return chestMenu;
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
@@ -31,7 +31,11 @@ import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Comparator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * The {@link EnergyRegulator} is a special type of {@link SlimefunItem} which serves as the heart of every


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
On right click of an energy regulator display the consumers and info about their state.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Saw on the #approved suggestions of the discord the suggestion number #2255 and I decided to implement it.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
