### PR TITLE
chore: localization for options menu

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.core.guide.options;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.bukkit.Material;
@@ -31,7 +32,13 @@ class FireworksOption implements SlimefunGuideOption<Boolean> {
 
         if (registry.isResearchingEnabled() && registry.isResearchFireworkEnabled()) {
             boolean enabled = getSelectedOption(p, guide).orElse(true);
-            ItemStack item = new CustomItemStack(Material.FIREWORK_ROCKET, "&bFireworks: &" + (enabled ? "aYes" : "4No"), "", "&7You can now toggle whether you", "&7will be presented with a big firework", "&7upon researching an item.", "", "&7\u21E8 &eClick to " + (enabled ? "disable" : "enable") + " your fireworks");
+
+            String optionState = enabled ? "enabled" : "disabled";
+            List<String> lore = Slimefun.getLocalization().getMessages(p, "guide.options.fireworks." + optionState + ".text");
+            lore.add("");
+            lore.add("&7\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.options.fireworks." + optionState + ".click"));
+
+            ItemStack item = new CustomItemStack(Material.FIREWORK_ROCKET, lore);
             return Optional.of(item);
         } else {
             return Optional.empty();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/GuideModeOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/GuideModeOption.java
@@ -56,14 +56,15 @@ class GuideModeOption implements SlimefunGuideOption<SlimefunGuideMode> {
             }
 
             ItemMeta meta = item.getItemMeta();
-            meta.setDisplayName(ChatColor.GRAY + "Slimefun Guide Type: " + ChatColor.YELLOW + ChatUtils.humanize(selectedMode.name()));
+            meta.setDisplayName(ChatColor.GRAY + Slimefun.getLocalization().getMessage(p, "guide.modes.selected") +
+                    ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "guide.modes." + selectedMode.name()));
             List<String> lore = new ArrayList<>();
             lore.add("");
-            lore.add((selectedMode == SlimefunGuideMode.SURVIVAL_MODE ? ChatColor.GREEN : ChatColor.GRAY) + "Survival Mode");
-            lore.add((selectedMode == SlimefunGuideMode.CHEAT_MODE ? ChatColor.GREEN : ChatColor.GRAY) + "Cheat Sheet");
+            lore.add((selectedMode == SlimefunGuideMode.SURVIVAL_MODE ? ChatColor.GREEN : ChatColor.GRAY) + Slimefun.getLocalization().getMessage(p, "guide.modes.SURVIVAL_MODE"));
+            lore.add((selectedMode == SlimefunGuideMode.CHEAT_MODE ? ChatColor.GREEN : ChatColor.GRAY) + Slimefun.getLocalization().getMessage(p, "guide.modes.CHEAT_MODE"));
 
             lore.add("");
-            lore.add(ChatColor.GRAY + "\u21E8 " + ChatColor.YELLOW + "Click to change the type");
+            lore.add(ChatColor.GRAY + "\u21E8 " + ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "guide.modes.change"));
             meta.setLore(lore);
             item.setItemMeta(meta);
 

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -98,6 +98,12 @@ guide:
       name: '&aIs something missing?'
       lore: 'Click to add your own translation'
 
+  modes:
+    selected: 'Slimefun Guide Type: '
+    change: 'Click to change the type'
+    SURVIVAL_MODE: 'Survival Mode'
+    CHEAT_MODE: 'Cheat Sheet'
+
   options:
     fireworks:
       enabled:

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -99,6 +99,21 @@ guide:
       lore: 'Click to add your own translation'
 
   options:
+    fireworks:
+      enabled:
+        text:
+        - '&bFireworks: &aYes'
+        - ''
+        - '&7You can now toggle whether you'
+        - '&7will see fireworks upon researching an item.'
+        click: '&eClick to disable your fireworks'
+      disabled:
+        text:
+        - '&bFireworks: &4No'
+        - ''
+        - '&7You can now toggle whether you'
+        - '&7will see fireworks upon researching an item.'
+        click: '&eClick to enable your fireworks'
     learning-animation:
       enabled:
         text:


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
These buttons in settings can be translated.

I modified the messages.yml to add an **a** at the end of fireworks option. The messages are read properly.
![image](https://github.com/Slimefun/Slimefun4/assets/7105953/9500b767-08b0-4a64-a7b2-600892e0fadb)

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add localization for guide mode and fireworks option in the settings menu.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
