### PR TITLE
ElectricJuicer

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -586,6 +586,7 @@ public final class SlimefunItems {
     public static final SlimefunItemStack ORE_WASHER = new SlimefunItemStack("ORE_WASHER", Material.CAULDRON, "&6Ore Washer", "", "&aWashes Sifted Ore to filter Ores", "&aand gives you small Stone Chunks");
     public static final SlimefunItemStack TABLE_SAW = new SlimefunItemStack("TABLE_SAW", Material.STONECUTTER, "&6Table Saw", "", "&aAllows you to get 8 planks from 1 Log", "&a(Works with all log types)");
     public static final SlimefunItemStack JUICER = new SlimefunItemStack("JUICER", Material.GLASS_BOTTLE, "&aJuicer", "", "&aAllows you to create delicious Juice");
+    public static final SlimefunItemStack ELECTRIC_JUICER = new SlimefunItemStack("ELECTRIC_JUICER", Material.TINTED_GLASS, "&aElectric Juicer", "", "&aAllows you to create delicious Juice", "", LoreBuilder.machine(MachineTier.BASIC, MachineType.MACHINE), LoreBuilder.powerBuffer(128), LoreBuilder.powerPerSecond(10));
     public static final SlimefunItemStack AUTOMATED_PANNING_MACHINE = new SlimefunItemStack("AUTOMATED_PANNING_MACHINE", Material.BOWL, "&eAutomated Panning Machine", "", "&fA MultiBlock Version of the Gold Pan", "&fand Nether Gold Pan combined in one machine.");
 
     public static final SlimefunItemStack INDUSTRIAL_MINER = new SlimefunItemStack("INDUSTRIAL_MINER", Material.GOLDEN_PICKAXE, "&bIndustrial Miner", "", "&fThis Multiblock will mine any Ores", "&fin a 7x7 area underneath it.", "&fPlace coal or similar in its chest", "&fto fuel this machine.");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricJuicer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricJuicer.java
@@ -1,0 +1,28 @@
+package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+
+public class ElectricJuicer extends AContainer implements RecipeDisplayItem {
+    public ElectricJuicer(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+    }
+
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.DIAMOND_SHOVEL);
+    }
+
+    @Nonnull
+    @Override
+    public String getMachineIdentifier() {
+        return "ELECTRIC_JUICER";
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/PostSetup.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks.Juicer;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -82,6 +83,7 @@ public final class PostSetup {
         
         loadOreGrinderRecipes();
         loadSmelteryRecipes();
+        loadJuicer();
 
         CommandSender sender = Bukkit.getConsoleSender();
 
@@ -204,6 +206,34 @@ public final class PostSetup {
                 }
             }
         }
+    }
+
+    private static void loadJuicer() {
+        List<ItemStack[]> juicerRecipes = new ArrayList<>();
+
+        Juicer juicer = (Juicer) SlimefunItems.JUICER.getItem();
+        if (juicer == null) {
+            return;
+        }
+
+        ItemStack[] input = null;
+
+        for (ItemStack[] recipe : juicer.getRecipes()) {
+
+            if (input == null) {
+                input = recipe;
+                continue;
+            }
+
+            if (input[0] != null && recipe[0] != null) {
+                juicerRecipes.add(new ItemStack[] { input[0], recipe[0] });
+            }
+
+            input = null;
+        }
+
+        Stream<ItemStack[]> stream = juicerRecipes.stream();
+        stream.forEach(recipe -> registerMachineRecipe("ELECTRIC_JUICER", 2, new ItemStack[] { recipe[0] }, new ItemStack[] { recipe[1] }));
     }
 
     private static void addSmelteryRecipe(ItemStack[] input, ItemStack[] output, MakeshiftSmeltery makeshiftSmeltery) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.ElectricJuicer;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -2319,6 +2320,13 @@ public final class SlimefunItemSetup {
         new ElevatorPlate(itemGroups.gps, SlimefunItems.ELEVATOR_PLATE, RecipeType.ENHANCED_CRAFTING_TABLE,
         new ItemStack[] {null, new ItemStack(Material.STONE_PRESSURE_PLATE), null, new ItemStack(Material.PISTON), SlimefunItems.ELECTRIC_MOTOR, new ItemStack(Material.PISTON), SlimefunItems.ALUMINUM_BRONZE_INGOT, SlimefunItems.ALUMINUM_BRONZE_INGOT, SlimefunItems.ALUMINUM_BRONZE_INGOT},
         new SlimefunItemStack(SlimefunItems.ELEVATOR_PLATE, 2))
+        .register(plugin);
+
+        new ElectricJuicer(itemGroups.electricity, SlimefunItems.ELECTRIC_JUICER, RecipeType.ENHANCED_CRAFTING_TABLE,
+        new ItemStack[]{ null, new ItemStack(Material.GLASS), null, SlimefunItems.ELECTRIC_MOTOR, new ItemStack(Material.NETHER_BRICK_FENCE), SlimefunItems.ELECTRIC_MOTOR, new ItemStack(Material.NETHER_BRICKS), SlimefunItems.SMALL_CAPACITOR, new ItemStack(Material.NETHER_BRICKS)})
+        .setCapacity(128)
+        .setEnergyConsumption(5)
+        .setProcessingSpeed(1)
         .register(plugin);
 
         new FoodFabricator(itemGroups.electricity, SlimefunItems.FOOD_FABRICATOR, RecipeType.ENHANCED_CRAFTING_TABLE,


### PR DESCRIPTION
Suggestion #2560 discord

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Adding an ElectricJuicer so people aren't force to use the manual MultiBlock to get juiced

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added on PostSetup a juicer recipe loader to a new machine called ElectricJuicer
The new recipe is similar to the original multiblock, but requiring some electric motors, a battery and some other basic blocks.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
