### PR TITLE
feat: silent give command

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/AbstractGiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/AbstractGiveCommand.java
@@ -1,0 +1,109 @@
+package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.bakedlibs.dough.common.CommonPatterns;
+import io.github.bakedlibs.dough.common.PlayerList;
+import io.github.bakedlibs.dough.items.CustomItemStack;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
+import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
+import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+/**
+ * This is an abstract command that is used to cheat items to players.
+ * Extending class decides whether the receiver is notified or not.
+ *
+ * @author TheBusyBiscuit
+ * @author ybw0014
+ */
+abstract class AbstractGiveCommand extends SubCommand {
+
+    private static final String PLACEHOLDER_PLAYER = "%player%";
+    private static final String PLACEHOLDER_ITEM = "%item%";
+    private static final String PLACEHOLDER_AMOUNT = "%amount%";
+
+    private final boolean silent;
+
+    @ParametersAreNonnullByDefault
+    AbstractGiveCommand(Slimefun plugin, SlimefunCommand cmd, String name, boolean silent) {
+        super(plugin, cmd, name, false);
+
+        this.silent = silent;
+    }
+
+    @Override
+    public void onExecute(CommandSender sender, String[] args) {
+        if (sender.hasPermission("slimefun.cheat.items") || !(sender instanceof Player)) {
+            if (args.length > 2) {
+                Optional<Player> player = PlayerList.findByName(args[1]);
+
+                if (player.isPresent()) {
+                    Player p = player.get();
+
+                    SlimefunItem sfItem = SlimefunItem.getById(args[2].toUpperCase(Locale.ROOT));
+
+                    if (sfItem != null) {
+                        giveItem(sender, p, sfItem, args);
+                    } else {
+                        Slimefun.getLocalization().sendMessage(sender, "messages.invalid-item", true, msg -> msg.replace(PLACEHOLDER_ITEM, args[2]));
+                    }
+                } else {
+                    Slimefun.getLocalization().sendMessage(sender, "messages.not-online", true, msg -> msg.replace(PLACEHOLDER_PLAYER, args[1]));
+                }
+            } else {
+                Slimefun.getLocalization().sendMessage(sender, "messages.usage", true, msg -> msg.replace("%usage%", "/sf " + getName() + " <Player> <Slimefun Item> [Amount]"));
+            }
+        } else {
+            Slimefun.getLocalization().sendMessage(sender, "messages.no-permission", true);
+        }
+    }
+
+    private void giveItem(CommandSender sender, Player p, SlimefunItem sfItem, String[] args) {
+        if (sfItem instanceof MultiBlockMachine) {
+            Slimefun.getLocalization().sendMessage(sender, "guide.cheat.no-multiblocks");
+        } else {
+            int amount = parseAmount(args);
+
+            if (amount > 0) {
+                if (!silent) {
+                    Slimefun.getLocalization().sendMessage(p, "messages.given-item", true, msg -> msg.replace(PLACEHOLDER_ITEM, sfItem.getItemName()).replace(PLACEHOLDER_AMOUNT, String.valueOf(amount)));
+                }
+                Map<Integer, ItemStack> excess = p.getInventory().addItem(new CustomItemStack(sfItem.getItem(), amount));
+                if (Slimefun.getCfg().getBoolean("options.drop-excess-sf-give-items") && !excess.isEmpty()) {
+                    for (ItemStack is : excess.values()) {
+                        p.getWorld().dropItem(p.getLocation(), is);
+                    }
+                }
+
+                Slimefun.getLocalization().sendMessage(sender, "messages.give-item", true, msg -> msg.replace(PLACEHOLDER_PLAYER, args[1]).replace(PLACEHOLDER_ITEM, sfItem.getItemName()).replace(PLACEHOLDER_AMOUNT, String.valueOf(amount)));
+            } else {
+                Slimefun.getLocalization().sendMessage(sender, "messages.invalid-amount", true, msg -> msg.replace(PLACEHOLDER_AMOUNT, args[3]));
+            }
+        }
+    }
+
+    private int parseAmount(String[] args) {
+        int amount = 1;
+
+        if (args.length == 4) {
+            if (CommonPatterns.NUMERIC.matcher(args[3]).matches()) {
+                amount = Integer.parseInt(args[3]);
+            } else {
+                return 0;
+            }
+        }
+
+        return amount;
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
@@ -1,15 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
 
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-
 import io.github.bakedlibs.dough.common.CommonPatterns;
 import io.github.bakedlibs.dough.common.PlayerList;
 import io.github.bakedlibs.dough.items.CustomItemStack;
@@ -18,79 +8,24 @@ import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
 import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
-class GiveCommand extends SubCommand {
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 
-    private static final String PLACEHOLDER_PLAYER = "%player%";
-    private static final String PLACEHOLDER_ITEM = "%item%";
-    private static final String PLACEHOLDER_AMOUNT = "%amount%";
-
+/**
+ * The give command cheat items for player.
+ *
+ * @author TheBusyBiscuit
+ * @author ybw0014
+ */
+class GiveCommand extends AbstractGiveCommand {
     @ParametersAreNonnullByDefault
     GiveCommand(Slimefun plugin, SlimefunCommand cmd) {
         super(plugin, cmd, "give", false);
     }
-
-    @Override
-    public void onExecute(CommandSender sender, String[] args) {
-        if (sender.hasPermission("slimefun.cheat.items") || !(sender instanceof Player)) {
-            if (args.length > 2) {
-                Optional<Player> player = PlayerList.findByName(args[1]);
-
-                if (player.isPresent()) {
-                    Player p = player.get();
-
-                    SlimefunItem sfItem = SlimefunItem.getById(args[2].toUpperCase(Locale.ROOT));
-
-                    if (sfItem != null) {
-                        giveItem(sender, p, sfItem, args);
-                    } else {
-                        Slimefun.getLocalization().sendMessage(sender, "messages.invalid-item", true, msg -> msg.replace(PLACEHOLDER_ITEM, args[2]));
-                    }
-                } else {
-                    Slimefun.getLocalization().sendMessage(sender, "messages.not-online", true, msg -> msg.replace(PLACEHOLDER_PLAYER, args[1]));
-                }
-            } else {
-                Slimefun.getLocalization().sendMessage(sender, "messages.usage", true, msg -> msg.replace("%usage%", "/sf give <Player> <Slimefun Item> [Amount]"));
-            }
-        } else {
-            Slimefun.getLocalization().sendMessage(sender, "messages.no-permission", true);
-        }
-    }
-
-    private void giveItem(CommandSender sender, Player p, SlimefunItem sfItem, String[] args) {
-        if (sfItem instanceof MultiBlockMachine) {
-            Slimefun.getLocalization().sendMessage(sender, "guide.cheat.no-multiblocks");
-        } else {
-            int amount = parseAmount(args);
-
-            if (amount > 0) {
-                Slimefun.getLocalization().sendMessage(p, "messages.given-item", true, msg -> msg.replace(PLACEHOLDER_ITEM, sfItem.getItemName()).replace(PLACEHOLDER_AMOUNT, String.valueOf(amount)));
-                Map<Integer, ItemStack> excess = p.getInventory().addItem(new CustomItemStack(sfItem.getItem(), amount));
-                if (Slimefun.getCfg().getBoolean("options.drop-excess-sf-give-items") && !excess.isEmpty()) {
-                    for (ItemStack is : excess.values()) {
-                        p.getWorld().dropItem(p.getLocation(), is);
-                    }
-                }
-
-                Slimefun.getLocalization().sendMessage(sender, "messages.give-item", true, msg -> msg.replace(PLACEHOLDER_PLAYER, args[1]).replace(PLACEHOLDER_ITEM, sfItem.getItemName()).replace(PLACEHOLDER_AMOUNT, String.valueOf(amount)));
-            } else {
-                Slimefun.getLocalization().sendMessage(sender, "messages.invalid-amount", true, msg -> msg.replace(PLACEHOLDER_AMOUNT, args[3]));
-            }
-        }
-    }
-
-    private int parseAmount(String[] args) {
-        int amount = 1;
-
-        if (args.length == 4) {
-            if (CommonPatterns.NUMERIC.matcher(args[3]).matches()) {
-                amount = Integer.parseInt(args[3]);
-            } else {
-                return 0;
-            }
-        }
-
-        return amount;
-    }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
@@ -1,21 +1,9 @@
 package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
 
-import io.github.bakedlibs.dough.common.CommonPatterns;
-import io.github.bakedlibs.dough.common.PlayerList;
-import io.github.bakedlibs.dough.items.CustomItemStack;
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
-import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
-import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * The give command cheat items for player.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SilentGiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SilentGiveCommand.java
@@ -1,0 +1,18 @@
+package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
+
+import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+/**
+ * The give command cheat items for player, but does not send a message to the receiver.
+ *
+ * @author ybw0014
+ */
+class SilentGiveCommand extends AbstractGiveCommand {
+    @ParametersAreNonnullByDefault
+    SilentGiveCommand(Slimefun plugin, SlimefunCommand cmd) {
+        super(plugin, cmd, "silent_give", true);
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
@@ -32,6 +32,7 @@ public final class SlimefunSubCommands {
         commands.add(new CheatCommand(plugin, cmd));
         commands.add(new GuideCommand(plugin, cmd));
         commands.add(new GiveCommand(plugin, cmd));
+        commands.add(new SilentGiveCommand(plugin, cmd));
         commands.add(new ResearchCommand(plugin, cmd));
         commands.add(new StatsCommand(plugin, cmd));
         commands.add(new TimingsCommand(plugin, cmd));

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -2,6 +2,7 @@ commands:
   help: Displays this help screen
   cheat: Allows you to cheat Items
   give: Give somebody some Slimefun Items
+  silent_give: Give somebody some Slimefun Items without notification messages
   guide: Gives yourself a Slimefun Guide
   teleporter: See other Player's Waypoints
   versions: Lists all installed Addons


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Adds a `silent_give` command to give items to players without notifying them.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Move the logics to `AbstractGiveCommand`, and pass arguments to determine whether the receiver should get a notification.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Discord suggestion [2579](https://discord.com/channels/565557184348422174/693130800853418055/1243284910769438741)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
