### PR TITLE
Fix errors in SlimefunUtils

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -38,7 +38,7 @@ import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
  *
  * @see StormStaff
  */
-public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> {
+public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> implements DistinctiveItem {
 
     private final NamespacedKey defaultUsageKey;
     private int maxUseCount = -1;
@@ -149,4 +149,13 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
         }
     }
 
+    @Override
+    public boolean canStack(ItemMeta itemMetaOne, ItemMeta itemMetaTwo) {
+        NamespacedKey key = getStorageKey();
+        PersistentDataContainer pdc1 = itemMetaOne.getPersistentDataContainer();
+        int usesLeft1 = pdc1.getOrDefault(key, PersistentDataType.INTEGER, getMaxUseCount());
+        PersistentDataContainer pdc2 = itemMetaTwo.getPersistentDataContainer();
+        int usesLeft2 = pdc2.getOrDefault(key, PersistentDataType.INTEGER, getMaxUseCount());
+        return usesLeft1 == usesLeft2;
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -160,6 +160,6 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
         NamespacedKey key = getStorageKey();
         int usesLeft1 = PersistentDataAPI.getInt(itemMetaOne, key);
         int usesLeft2 = PersistentDataAPI.getInt(itemMetaTwo, key);
-        return usesLeft1 != -1 && usesLeft1 == usesLeft2;
+        return usesLeft1 == usesLeft2;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -16,6 +16,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
 import io.github.bakedlibs.dough.common.ChatColors;
+import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -67,7 +68,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
      *
      * @param count
      *            The maximum number of times this item can be used.
-     * 
+     *
      * @return The {@link LimitedUseItem} for chaining of setters
      */
     public final @Nonnull LimitedUseItem setMaxUseCount(int count) {
@@ -152,14 +153,13 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
 
     @Override
     public boolean canStack(ItemMeta itemMetaOne, ItemMeta itemMetaTwo) {
-        if (Slimefun.getItemDataService().getItemData(itemMetaOne) != Slimefun.getItemDataService().getItemData(itemMetaTwo)) {
+        if (!Slimefun.getItemDataService().getItemData(itemMetaOne).equals(Slimefun.getItemDataService().getItemData(itemMetaTwo))) {
             return false;
         }
+
         NamespacedKey key = getStorageKey();
-        PersistentDataContainer pdc1 = itemMetaOne.getPersistentDataContainer();
-        int usesLeft1 = pdc1.getOrDefault(key, PersistentDataType.INTEGER, getMaxUseCount());
-        PersistentDataContainer pdc2 = itemMetaTwo.getPersistentDataContainer();
-        int usesLeft2 = pdc2.getOrDefault(key, PersistentDataType.INTEGER, getMaxUseCount());
-        return usesLeft1 == usesLeft2;
+        int usesLeft1 = PersistentDataAPI.getInt(itemMetaOne, key);
+        int usesLeft2 = PersistentDataAPI.getInt(itemMetaTwo, key);
+        return usesLeft1 != -1 && usesLeft1 == usesLeft2;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -152,6 +152,9 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
 
     @Override
     public boolean canStack(ItemMeta itemMetaOne, ItemMeta itemMetaTwo) {
+        if (Slimefun.getItemDataService().getItemData(itemMetaOne) != Slimefun.getItemDataService().getItemData(itemMetaTwo)) {
+            return false;
+        }
         NamespacedKey key = getStorageKey();
         PersistentDataContainer pdc1 = itemMetaOne.getPersistentDataContainer();
         int usesLeft1 = pdc1.getOrDefault(key, PersistentDataType.INTEGER, getMaxUseCount());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -20,6 +20,7 @@ import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.core.attributes.DistinctiveItem;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -388,14 +388,15 @@ public final class SlimefunUtils {
                  * Slimefun items may be ItemStackWrapper's in the context of cargo
                  * so let's try to do an ID comparison before meta comparison
                  */
-                Debug.log(TestCase.CARGO_INPUT_TESTING, "  sfitem is ItemStackWrapper - possible SF Item: {}", sfitem);
+                Debug.log(TestCase.CARGO_INPUT_TESTING, "  sfitem is ItemStackWrapper - possible SF Item: {}", item);
 
-                ItemMeta possibleSfItemMeta = sfitem.getItemMeta();
-                String id = Slimefun.getItemDataService().getItemData(itemMeta).orElse(null);
-                String possibleItemId = Slimefun.getItemDataService().getItemData(possibleSfItemMeta).orElse(null);
+                ItemMeta sfItemMeta = sfitem.getItemMeta();
+                String possibleItemId = Slimefun.getItemDataService().getItemData(itemMeta).orElse(null);
+                String sfItemId = Slimefun.getItemDataService()
+                        .getItemData(sfItemMeta).get();
                 // Prioritize SlimefunItem id comparison over ItemMeta comparison
-                if (id != null && id.equals(possibleItemId)) {
-                    Debug.log(TestCase.CARGO_INPUT_TESTING, "  Item IDs matched!");
+                if (possibleItemId != null && possibleItemId.equals(sfItemId)) {
+                    Debug.log(TestCase.CARGO_INPUT_TESTING, "  SlimefunItem IDs matched!");
 
                     /*
                      * PR #3417
@@ -403,15 +404,13 @@ public final class SlimefunUtils {
                      * Some items can't rely on just IDs matching and will implement {@link DistinctiveItem}
                      * in which case we want to use the method provided to compare
                      */
-                    Optional<DistinctiveItem> optionalDistinctive = getDistinctiveItem(id);
+                    Optional<DistinctiveItem> optionalDistinctive = getDistinctiveItem(possibleItemId);
                     if (optionalDistinctive.isPresent()) {
-                        return optionalDistinctive.get().canStack(possibleSfItemMeta, itemMeta);
+                        return optionalDistinctive.get().canStack(sfItemMeta, itemMeta);
                     }
                     return true;
-                } else {
-                    Debug.log(TestCase.CARGO_INPUT_TESTING, "  Item IDs don't match, checking meta {} == {} (lore: {})", itemMeta, possibleSfItemMeta, checkLore);
-                    return equalsItemMeta(itemMeta, possibleSfItemMeta, checkLore);
                 }
+                return false;
             } else if (sfitem.hasItemMeta()) {
                 ItemMeta sfItemMeta = sfitem.getItemMeta();
                 Debug.log(TestCase.CARGO_INPUT_TESTING, "  Comparing meta (vanilla items?) - {} == {} (lore: {})", itemMeta, sfItemMeta, checkLore);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -409,8 +409,9 @@ public final class SlimefunUtils {
                         return optionalDistinctive.get().canStack(sfItemMeta, itemMeta);
                     }
                     return true;
+                } else {
+                    return false;
                 }
-                return false;
             } else if (sfitem.hasItemMeta()) {
                 ItemMeta sfItemMeta = sfitem.getItemMeta();
                 Debug.log(TestCase.CARGO_INPUT_TESTING, "  Comparing meta (vanilla items?) - {} == {} (lore: {})", itemMeta, sfItemMeta, checkLore);


### PR DESCRIPTION
## Description
Fix #4212 

This issue explains why to change.

**or move `equalsItemMeta` check to `if (id != null && id.equals(possibleItemId)) { `?**

## Proposed changes
- remove `equalsItemMeta` check
- rename var

## Related Issues (if applicable)
#4212 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
