### PR TITLE
Fix #4216

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -106,7 +106,8 @@ public class TickerTask implements Runnable {
 
             // Run our ticker code
             if (!halted) {
-                for (Map.Entry<ChunkPosition, Set<Location>> entry : tickingLocations.entrySet()) {
+                Set<Map.Entry<ChunkPosition, Set<Location>>> loc = new HashSet<>(tickingLocations.entrySet());
+                for (Map.Entry<ChunkPosition, Set<Location>> entry : loc) {
                     tickChunk(entry.getKey(), tickers, entry.getValue());
                 }
             }
@@ -343,7 +344,7 @@ public class TickerTask implements Runnable {
         Validate.notNull(l, "Location cannot be null!");
 
         ChunkPosition chunk = new ChunkPosition(l.getWorld(), l.getBlockX() >> 4, l.getBlockZ() >> 4);
-        Set<Location> newValue = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        Set<Location> newValue = new HashSet<>();
         Set<Location> oldValue = tickingLocations.putIfAbsent(chunk, newValue);
 
         /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -343,7 +343,7 @@ public class TickerTask implements Runnable {
         Validate.notNull(l, "Location cannot be null!");
 
         ChunkPosition chunk = new ChunkPosition(l.getWorld(), l.getBlockX() >> 4, l.getBlockZ() >> 4);
-        Set<Location> newValue = new HashSet<>();
+        Set<Location> newValue = Collections.newSetFromMap(new ConcurrentHashMap<>());
         Set<Location> oldValue = tickingLocations.putIfAbsent(chunk, newValue);
 
         /**


### PR DESCRIPTION
## Description
Fix #4216
## Proposed changes
~~Make the value of `tickingLocations` thread-safe~~

~~new HashSet() -> Collections.newSetFromMap(new ConcurrentHashMap<>())~~

Initialize a new HashSet on read time to avoid exceptions

## Related Issues (if applicable)
#4216 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
