### PR TITLE
Use BlockPositions internally instead of Locations

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
@@ -17,6 +17,7 @@ import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.bakedlibs.dough.blocks.BlockPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
@@ -72,28 +73,33 @@ public class ErrorReport<T extends Throwable> {
         Slimefun.runSync(() -> print(printer));
     }
 
+    @ParametersAreNonnullByDefault
+    public ErrorReport(T throwable, Location l, SlimefunItem item) {
+        this(throwable, new BlockPosition(l), item);
+    }
+
     /**
      * This constructs a new {@link ErrorReport} for the given {@link Location} and
      * {@link SlimefunItem}.
      *
      * @param throwable
      *            The {@link Throwable} which caused this {@link ErrorReport}.
-     * @param l
+     * @param position
      *            The {@link Location} at which the error was thrown.
      * @param item
      *            The {@link SlimefunItem} responsible.
      */
     @ParametersAreNonnullByDefault
-    public ErrorReport(T throwable, Location l, SlimefunItem item) {
+    public ErrorReport(T throwable, BlockPosition position, SlimefunItem item) {
         this(throwable, item.getAddon(), stream -> {
             stream.println("Block Info:");
-            stream.println("  World: " + l.getWorld().getName());
-            stream.println("  X: " + l.getBlockX());
-            stream.println("  Y: " + l.getBlockY());
-            stream.println("  Z: " + l.getBlockZ());
-            stream.println("  Material: " + l.getBlock().getType());
-            stream.println("  Block Data: " + l.getBlock().getBlockData().getClass().getName());
-            stream.println("  State: " + l.getBlock().getState().getClass().getName());
+            stream.println("  World: " + position.getWorld().getName());
+            stream.println("  X: " + position.getX());
+            stream.println("  Y: " + position.getY());
+            stream.println("  Z: " + position.getZ());
+            stream.println("  Material: " + position.getBlock().getType());
+            stream.println("  Block Data: " + position.getBlock().getBlockData().getClass().getName());
+            stream.println("  State: " + position.getBlock().getState().getClass().getName());
             stream.println();
 
             if (item.getBlockTicker() != null) {
@@ -110,8 +116,8 @@ public class ErrorReport<T extends Throwable> {
 
             stream.println("Slimefun Data:");
             stream.println("  ID: " + item.getId());
-            stream.println("  Inventory: " + BlockStorage.getStorage(l.getWorld()).hasInventory(l));
-            stream.println("  Data: " + BlockStorage.getBlockInfoAsJson(l));
+            stream.println("  Inventory: " + BlockStorage.getStorage(position.getWorld()).hasInventory(position));
+            stream.println("  Data: " + BlockStorage.getBlockInfoAsJson(position));
             stream.println();
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
@@ -41,7 +41,6 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
  *            The type of {@link Throwable} which has spawned this {@link ErrorReport}
  *
  * @author TheBusyBiscuit
- *
  */
 public class ErrorReport<T extends Throwable> {
 
@@ -73,6 +72,11 @@ public class ErrorReport<T extends Throwable> {
         Slimefun.runSync(() -> print(printer));
     }
 
+    /**
+     * @deprecated
+     * @see ErrorReport#ErrorReport(Throwable, BlockPosition, SlimefunItem)
+     */
+    @Deprecated
     @ParametersAreNonnullByDefault
     public ErrorReport(T throwable, Location l, SlimefunItem item) {
         this(throwable, new BlockPosition(l), item);
@@ -116,7 +120,7 @@ public class ErrorReport<T extends Throwable> {
 
             stream.println("Slimefun Data:");
             stream.println("  ID: " + item.getId());
-            stream.println("  Inventory: " + BlockStorage.getStorage(position.getWorld()).hasInventory(position));
+            stream.println("  Inventory: " + BlockStorage.hasInventory(position.getBlock()));
             stream.println("  Data: " + BlockStorage.getBlockInfoAsJson(position));
             stream.println();
         });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/ProfiledBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/ProfiledBlock.java
@@ -17,7 +17,6 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
  * It is a modification of {@link BlockPosition} to be as memory-efficient as possible.
  * 
  * @author TheBusyBiscuit
- *
  */
 final class ProfiledBlock {
 
@@ -28,31 +27,36 @@ final class ProfiledBlock {
     private final World world;
 
     /**
-     * A {@link Long} representation of our {@link Location} (x, y, z).
+     * A {@link Long} representation of our {@link BlockPosition} (x, y, z).
      */
     private final long position;
 
     /**
-     * The {@link SlimefunItem} whihc is located at this {@link Location}.
+     * The {@link SlimefunItem} whihc is located at this {@link BlockPosition}.
      */
     private final SlimefunItem item;
 
     /**
-     * This creates a new {@link ProfiledBlock} for the given {@link Location} and
-     * the {@link SlimefunItem} found at this {@link Location}.
-     * 
-     * @param l
-     *            The {@link Location}
-     * @param item
-     *            The {@link SlimefunItem} found at that {@link Location}
+     * @deprecated
+     * @see ProfiledBlock#ProfiledBlock(BlockPosition, SlimefunItem)
      */
+    @Deprecated
     ProfiledBlock(@Nonnull Location l, @Nonnull SlimefunItem item) {
         this(new BlockPosition(l), item);
     }
 
+    /**
+     * This creates a new {@link ProfiledBlock} for the given {@link BlockPosition} and
+     * the {@link SlimefunItem} found at this {@link BlockPosition}.
+     *
+     * @param position
+     *            The {@link BlockPosition}
+     * @param item
+     *            The {@link SlimefunItem} found at that {@link BlockPosition}
+     */
     ProfiledBlock(@Nonnull BlockPosition position, @Nonnull SlimefunItem item) {
         this.world = position.getWorld();
-        this.position = getLocationAsLong(position.getX(), position.getY(), position.getZ());
+        this.position = getPositionAsLong(position.getX(), position.getY(), position.getZ());
         this.item = item;
     }
 
@@ -65,7 +69,7 @@ final class ProfiledBlock {
      */
     ProfiledBlock(@Nonnull Block b) {
         this.world = b.getWorld();
-        this.position = getLocationAsLong(b.getX(), b.getY(), b.getZ());
+        this.position = getPositionAsLong(b.getX(), b.getY(), b.getZ());
         this.item = null;
     }
 
@@ -81,7 +85,7 @@ final class ProfiledBlock {
      * 
      * @return A {@link Long} representation of this {@link Location}
      */
-    private static long getLocationAsLong(int x, int y, int z) {
+    private static long getPositionAsLong(int x, int y, int z) {
         return ((long) (x & 0x3FFFFFF) << 38) | ((long) (z & 0x3FFFFFF) << 12) | (long) (y & 0xFFF);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/ProfiledBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/ProfiledBlock.java
@@ -47,8 +47,12 @@ final class ProfiledBlock {
      *            The {@link SlimefunItem} found at that {@link Location}
      */
     ProfiledBlock(@Nonnull Location l, @Nonnull SlimefunItem item) {
-        this.world = l.getWorld();
-        this.position = getLocationAsLong((int) l.getX(), (int) l.getY(), (int) l.getZ());
+        this(new BlockPosition(l), item);
+    }
+
+    ProfiledBlock(@Nonnull BlockPosition position, @Nonnull SlimefunItem item) {
+        this.world = position.getWorld();
+        this.position = getLocationAsLong(position.getX(), position.getY(), position.getZ());
         this.item = item;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
@@ -15,6 +15,7 @@ import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 
+import io.github.bakedlibs.dough.blocks.BlockPosition;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -155,6 +156,11 @@ public class SlimefunProfiler {
      */
     public long closeEntry(@Nonnull Location l, @Nonnull SlimefunItem item, long timestamp) {
         Validate.notNull(l, "Location must not be null!");
+        return closeEntry(new BlockPosition(l), item, timestamp);
+    }
+
+    public long closeEntry(@Nonnull BlockPosition position, @Nonnull SlimefunItem item, long timestamp) {
+        Validate.notNull(position, "BlockPosition must not be null!");
         Validate.notNull(item, "You need to specify a SlimefunItem!");
 
         if (timestamp == 0) {
@@ -164,7 +170,7 @@ public class SlimefunProfiler {
         long elapsedTime = System.nanoTime() - timestamp;
 
         executor.execute(() -> {
-            ProfiledBlock block = new ProfiledBlock(l, item);
+            ProfiledBlock block = new ProfiledBlock(position, item);
 
             // Merge (if we have multiple samples for whatever reason)
             timings.merge(block, elapsedTime, Long::sum);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
@@ -41,7 +41,6 @@ import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
  * @author TheBusyBiscuit
  * 
  * @see TickerTask
- *
  */
 public class SlimefunProfiler {
 
@@ -142,23 +141,28 @@ public class SlimefunProfiler {
     }
 
     /**
-     * This method closes a previously started entry.
-     * Make sure to call {@link #newEntry()} to get the timestamp in advance.
-     * 
-     * @param l
-     *            The {@link Location} of our {@link Block}
-     * @param item
-     *            The {@link SlimefunItem} at this {@link Location}
-     * @param timestamp
-     *            The timestamp marking the start of this entry, you can retrieve it using {@link #newEntry()}
-     *
-     * @return The total timings of this entry
+     * @deprecated
+     * @see SlimefunProfiler#closeEntry(BlockPosition, SlimefunItem, long)
      */
+    @Deprecated
     public long closeEntry(@Nonnull Location l, @Nonnull SlimefunItem item, long timestamp) {
         Validate.notNull(l, "Location must not be null!");
         return closeEntry(new BlockPosition(l), item, timestamp);
     }
 
+    /**
+     * This method closes a previously started entry.
+     * Make sure to call {@link #newEntry()} to get the timestamp in advance.
+     *
+     * @param position
+     *            The {@link BlockPosition} of our {@link Block}
+     * @param item
+     *            The {@link SlimefunItem} at this {@link BlockPosition}
+     * @param timestamp
+     *            The timestamp marking the start of this entry, you can retrieve it using {@link #newEntry()}
+     *
+     * @return The total timings of this entry
+     */
     public long closeEntry(@Nonnull BlockPosition position, @Nonnull SlimefunItem item, long timestamp) {
         Validate.notNull(position, "BlockPosition must not be null!");
         Validate.notNull(item, "You need to specify a SlimefunItem!");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -222,6 +222,11 @@ public class TickerTask implements Runnable {
         halted = true;
     }
 
+    /**
+     * @deprecated
+     * @see TickerTask#queueMove(BlockPosition, BlockPosition)
+     */
+    @Deprecated
     @ParametersAreNonnullByDefault
     public void queueMove(Location from, Location to) {
         Validate.notNull(from, "Source Location cannot be null!");
@@ -238,6 +243,11 @@ public class TickerTask implements Runnable {
         movingQueue.put(from, to);
     }
 
+    /**
+     * @deprecated
+     * @see TickerTask#queueDelete(BlockPosition, boolean)
+     */
+    @Deprecated
     @ParametersAreNonnullByDefault
     public void queueDelete(Location l, boolean destroy) {
         Validate.notNull(l, "Location must not be null!");
@@ -252,7 +262,11 @@ public class TickerTask implements Runnable {
         deletionQueue.put(position, destroy);
     }
 
-
+    /**
+     * @deprecated
+     * @see TickerTask#queueDeletions(Collection, boolean)
+     */
+    @Deprecated
     @ParametersAreNonnullByDefault
     public void queueDelete(Collection<Location> locations, boolean destroy) {
         Validate.notNull(locations, "Locations must not be null");
@@ -271,6 +285,11 @@ public class TickerTask implements Runnable {
         deletionQueue.putAll(toDelete);
     }
 
+    /**
+     * @deprecated
+     * @see TickerTask#queueDeletions(Map)
+     */
+    @Deprecated
     @ParametersAreNonnullByDefault
     public void queueDelete(Map<Location, Boolean> locations) {
         Validate.notNull(locations, "Locations must not be null");
@@ -294,41 +313,51 @@ public class TickerTask implements Runnable {
     }
 
     /**
-     * This method checks if the given {@link Location} has been reserved
-     * by this {@link TickerTask}.
-     * A reserved {@link Location} does not currently hold any data but will
-     * be occupied upon the next tick.
-     * Checking this ensures that our {@link Location} does not get treated like a normal
-     * {@link Location} as it is theoretically "moving".
-     * 
-     * @param l
-     *            The {@link Location} to check
-     * 
-     * @return Whether this {@link Location} has been reserved and will be filled upon the next tick
+     * @deprecated
+     * @see TickerTask#isOccupiedSoon(BlockPosition)
      */
+    @Deprecated
     public boolean isOccupiedSoon(@Nonnull Location l) {
         Validate.notNull(l, "Null is not a valid Location!");
         return isOccupiedSoon(new BlockPosition(l));
     }
 
+    /**
+     * This method checks if the given {@link BlockPosition} has been reserved
+     * by this {@link TickerTask}.
+     * A reserved {@link BlockPosition} does not currently hold any data but will
+     * be occupied upon the next tick.
+     * Checking this ensures that our {@link BlockPosition} does not get treated like a normal
+     * {@link BlockPosition} as it is theoretically "moving".
+     *
+     * @param position
+     *            The {@link BlockPosition} to check
+     *
+     * @return Whether this {@link BlockPosition} has been reserved and will be filled upon the next tick
+     */
     public boolean isOccupiedSoon(@Nonnull BlockPosition position) {
         Validate.notNull(position, "Null is not a valid BlockPosition!");
         return movingQueue.containsValue(position);
     }
 
     /**
-     * This method checks if a given {@link Location} will be deleted on the next tick.
-     * 
-     * @param l
-     *            The {@link Location} to check
-     * 
-     * @return Whether this {@link Location} will be deleted on the next tick
+     * @deprecated
+     * @see TickerTask#isDeletedSoon(BlockPosition)
      */
+    @Deprecated
     public boolean isDeletedSoon(@Nonnull Location l) {
         Validate.notNull(l, "Null is not a valid Location!");
         return isDeletedSoon(new BlockPosition(l));
     }
 
+    /**
+     * This method checks if a given {@link BlockPosition} will be deleted on the next tick.
+     *
+     * @param position
+     *            The {@link BlockPosition} to check
+     *
+     * @return Whether this {@link BlockPosition} will be deleted on the next tick
+     */
     public boolean isDeletedSoon(@Nonnull BlockPosition position) {
         Validate.notNull(position, "Null is not a valid BlockPosition!");
 
@@ -345,43 +374,51 @@ public class TickerTask implements Runnable {
     }
 
     /**
-     * This method returns a <strong>read-only</strong> {@link Map}
-     * representation of every {@link ChunkPosition} and its corresponding
-     * {@link Set} of ticking {@link Location Locations}.
-     * 
-     * This does include any {@link Location} from an unloaded {@link Chunk} too!
-     * 
-     * @return A {@link Map} representation of all ticking {@link Location Locations}
+     * @deprecated
+     * @see TickerTask#getPositions()
      */
-    @Nonnull
-    public Map<ChunkPosition, Set<Location>> getLocations() {
+    @Deprecated
+    public @Nonnull Map<ChunkPosition, Set<Location>> getLocations() {
         return ImmutableMap.of();
     }
 
-    @Nonnull
-    public Map<ChunkPosition, Set<BlockPosition>> getPositions() {
+    /**
+     * This method returns a <strong>read-only</strong> {@link Map}
+     * representation of every {@link ChunkPosition} and its corresponding
+     * {@link Set} of ticking {@link Location Locations}.
+     *
+     * This does include any {@link Location} from an unloaded {@link Chunk} too!
+     *
+     * @return A {@link Map} representation of all ticking {@link Location Locations}
+     */
+    public @Nonnull Map<ChunkPosition, Set<BlockPosition>> getPositions() {
         return Collections.unmodifiableMap(tickingPositions);
     }
 
+
     /**
-     * This method returns a <strong>read-only</strong> {@link Set}
-     * of all ticking {@link Location Locations} in a given {@link Chunk}.
-     * The {@link Chunk} does not have to be loaded.
-     * If no {@link Location} is present, the returned {@link Set} will be empty.
-     * 
-     * @param chunk
-     *            The {@link Chunk}
-     * 
-     * @return A {@link Set} of all ticking {@link Location Locations}
+     * @deprecated
+     * @see TickerTask#getPositions(Chunk)
      */
-    @Nonnull
-    public Set<Location> getLocations(@Nonnull Chunk chunk) {
+    @Deprecated
+    public @Nonnull Set<Location> getLocations(@Nonnull Chunk chunk) {
         Validate.notNull(chunk, "The Chunk cannot be null!");
 
         return ImmutableSet.of();
     }
 
-    public Set<BlockPosition> getPositions(@Nonnull Chunk chunk) {
+    /**
+     * This method returns a <strong>read-only</strong> {@link Set}
+     * of all ticking {@link BlockPosition BlockPositions} in a given {@link Chunk}.
+     * The {@link Chunk} does not have to be loaded.
+     * If no {@link BlockPosition} is present, the returned {@link Set} will be empty.
+     *
+     * @param chunk
+     *            The {@link Chunk}
+     *
+     * @return A {@link Set} of all ticking {@link BlockPosition BlockPositions}
+     */
+    public @Nonnull Set<BlockPosition> getPositions(@Nonnull Chunk chunk) {
         Validate.notNull(chunk, "The Chunk cannot be null!");
 
         Set<BlockPosition> positions = tickingPositions.getOrDefault(new ChunkPosition(chunk), new HashSet<>());
@@ -389,16 +426,21 @@ public class TickerTask implements Runnable {
     }
 
     /**
-     * This enables the ticker at the given {@link Location} and adds it to our "queue".
-     * 
-     * @param l
-     *            The {@link Location} to activate
+     * @deprecated
+     * @see TickerTask#enableTicker(BlockPosition)
      */
+    @Deprecated
     public void enableTicker(@Nonnull Location l) {
         Validate.notNull(l, "Location cannot be null!");
         enableTicker(new BlockPosition(l));
     }
 
+    /**
+     * This enables the ticker at the given {@link BlockPosition} and adds it to our "queue".
+     *
+     * @param position
+     *            The {@link BlockPosition} to activate
+     */
     public void enableTicker(@Nonnull BlockPosition position) {
         Validate.notNull(position, "BlockPosition cannot be null!");
 
@@ -418,17 +460,22 @@ public class TickerTask implements Runnable {
     }
 
     /**
-     * This method disables the ticker at the given {@link Location} and removes it from our internal
-     * "queue".
-     * 
-     * @param l
-     *            The {@link Location} to remove
+     * @deprecated
+     * @see TickerTask#disableTicker(BlockPosition)
      */
+    @Deprecated
     public void disableTicker(@Nonnull Location l) {
         Validate.notNull(l, "Location cannot be null!");
         disableTicker(new BlockPosition(l));
     }
 
+    /**
+     * This method disables the ticker at the given {@link BlockPosition} and removes it from our internal
+     * "queue".
+     *
+     * @param position
+     *            The {@link BlockPosition} to remove
+     */
     public void disableTicker(@Nonnull BlockPosition position) {
         Validate.notNull(position, "BlockPosition cannot be null!");
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockInfoConfig.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockInfoConfig.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.bukkit.Location;
+import io.github.bakedlibs.dough.blocks.BlockPosition;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import com.google.gson.GsonBuilder;
@@ -17,7 +17,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 
 /**
  * This class is used to speed up parsing of a {@link JsonObject} that is stored at
- * a given {@link Location}.
+ * a given {@link BlockPosition}.
  * 
  * This simply utilises a {@link HashMap} to cache the data and then provides the same getters
  * as a normal {@link Config}.

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -64,7 +64,7 @@ public class BlockStorage {
     private static boolean universalInventoriesLoaded = false;
 
     private int changes = 0;
-    private AtomicBoolean isMarkedForRemoval = new AtomicBoolean(false);
+    private final AtomicBoolean isMarkedForRemoval = new AtomicBoolean(false);
 
     @Nullable
     public static BlockStorage getStorage(@Nonnull World world) {
@@ -383,41 +383,42 @@ public class BlockStorage {
     }
 
     /**
-     * This will return an {@link ImmutableMap} of the underline {@code Map<String, Config>} of
+     * @deprecated
+     * @see BlockStorage#toMap()
+     */
+    @Deprecated
+    public @Nonnull Map<Location, Config> getRawStorage() {
+        return ImmutableMap.of();
+    }
+
+    /**
+     * This will return an {@link ImmutableMap copy} of the underlying {@link BlockStorage#storage map} of
      * this worlds {@link BlockStorage}.
      *
      * @return An {@link ImmutableMap} of the raw data.
      */
-    @Nonnull
-    public Map<Location, Config> getRawStorage() {
-        return ImmutableMap.of();
-    }
-
-    public Map<BlockPosition, Config> toMap() {
+    public @Nonnull Map<BlockPosition, Config> toMap() {
         return ImmutableMap.copyOf(this.storage);
     }
 
     /**
-     * This will return an {@link ImmutableMap} of the underline {@code Map<String, Config>} of
+     * @deprecated
+     * @see BlockStorage#toMap(World)
+     */
+    @Deprecated
+    public static @Nonnull Map<Location, Config> getRawStorage(@Nonnull World world) {
+        return ImmutableMap.of();
+    }
+
+    /**
+     * This will return an {@link ImmutableMap copy} of the underlying {@link BlockStorage#storage map} of
      * this worlds {@link BlockStorage}. If there is no registered world then this will return null.
      *
      * @param world
      *            The world of which to fetch the data from.
      * @return An {@link ImmutableMap} of the raw data or null if the world isn't registered.
      */
-    @Nullable
-    public static Map<Location, Config> getRawStorage(@Nonnull World world) {
-        Validate.notNull(world, "World cannot be null!");
-
-        BlockStorage storage = getStorage(world);
-        if (storage != null) {
-            return storage.getRawStorage();
-        } else {
-            return null;
-        }
-    }
-
-    public static Map<BlockPosition, Config> toMap(@Nonnull World world) {
+    public static @Nullable Map<BlockPosition, Config> toMap(@Nonnull World world) {
         Validate.notNull(world, "World cannot be null!");
 
         BlockStorage storage = getStorage(world);
@@ -450,8 +451,7 @@ public class BlockStorage {
      * 
      * @return the SlimefunItem's ItemStack corresponding to the block if it has one, otherwise null
      */
-    @Nullable
-    public static ItemStack retrieve(@Nonnull Block block) {
+    public static @Nullable ItemStack retrieve(@Nonnull Block block) {
         SlimefunItem item = check(block);
 
         if (item == null) {
@@ -462,18 +462,20 @@ public class BlockStorage {
         }
     }
 
-    @Nonnull
-    public static Config getBlockInfo(Block block) {
+    public static @Nonnull Config getBlockInfo(Block block) {
         return getBlockInfo(new BlockPosition(block));
     }
 
-    @Nonnull
-    public static Config getLocationInfo(Location l) {
+    /**
+     * @deprecated
+     * @see BlockStorage#getBlockInfo(BlockPosition)
+     */
+    @Deprecated
+    public static @Nonnull Config getLocationInfo(Location l) {
         return getBlockInfo(new BlockPosition(l));
     }
 
-    @Nonnull
-    public static Config getBlockInfo(BlockPosition position) {
+    public static @Nonnull Config getBlockInfo(BlockPosition position) {
         BlockStorage storage = getStorage(position.getWorld());
 
         if (storage == null) {
@@ -484,8 +486,7 @@ public class BlockStorage {
         return cfg == null ? emptyBlockData : cfg;
     }
 
-    @Nonnull
-    private static Map<String, String> parseJSON(String json) {
+    private static @Nonnull Map<String, String> parseJSON(String json) {
         Map<String, String> map = new HashMap<>();
 
         if (json != null && json.length() > 2) {
@@ -539,26 +540,45 @@ public class BlockStorage {
         return getBlockInfo(new BlockPosition(block), key);
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#getBlockInfo(Block, String)
+     */
+    @Deprecated
     public static String getLocationInfo(Location l, String key) {
-        return getLocationInfo(l).getString(key);
+        return getBlockInfo(new BlockPosition(l)).getString(key);
     }
 
     public static String getBlockInfo(BlockPosition position, String key) {
         return getBlockInfo(position).getString(key);
     }
 
-    public static void addBlockInfo(Location l, String key, String value) {
-        addBlockInfo(l, key, value, false);
-    }
-
     public static void addBlockInfo(Block block, String key, String value) {
         addBlockInfo(block.getLocation(), key, value);
+    }
+
+    /**
+     * @deprecated
+     * @see BlockStorage#addBlockInfo(BlockPosition, String, String)
+     */
+    @Deprecated
+    public static void addBlockInfo(Location l, String key, String value) {
+        addBlockInfo(new BlockPosition(l), key, value, false);
+    }
+
+    public static void addBlockInfo(BlockPosition position, String key, String value) {
+        addBlockInfo(position, key, value, false);
     }
 
     public static void addBlockInfo(Block block, String key, String value, boolean updateTicker) {
         addBlockInfo(block.getLocation(), key, value, updateTicker);
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#addBlockInfo(BlockPosition, String, String, boolean)
+     */
+    @Deprecated
     public static void addBlockInfo(Location l, String key, String value, boolean updateTicker) {
         addBlockInfo(new BlockPosition(l), key, value, updateTicker);
     }
@@ -578,6 +598,11 @@ public class BlockStorage {
         return hasBlockInfo(block.getLocation());
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#hasBlockInfo(BlockPosition)
+     */
+    @Deprecated
     public static boolean hasBlockInfo(Location l) {
         return hasBlockInfo(new BlockPosition(l));
     }
@@ -624,9 +649,14 @@ public class BlockStorage {
     }
 
     public static void setBlockInfo(Block b, String json, boolean updateTicker) {
-        setBlockInfo(b.getLocation(), json, updateTicker);
+        setBlockInfo(new BlockPosition(b), json, updateTicker);
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#setBlockInfo(BlockPosition, String json, boolean updateTicker)
+     */
+    @Deprecated
     public static void setBlockInfo(Location l, String json, boolean updateTicker) {
         setBlockInfo(new BlockPosition(l), json, updateTicker);
     }
@@ -645,6 +675,11 @@ public class BlockStorage {
         clearBlockInfo(new BlockPosition(block));
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#clearBlockInfo(BlockPosition)
+     */
+    @Deprecated
     public static void clearBlockInfo(Location l) {
         clearBlockInfo(new BlockPosition(l));
     }
@@ -657,6 +692,11 @@ public class BlockStorage {
         clearBlockInfo(new BlockPosition(b), destroy);
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#clearBlockInfo(BlockPosition, boolean)
+     */
+    @Deprecated
     public static void clearBlockInfo(Location l, boolean destroy) {
         clearBlockInfo(new BlockPosition(l), destroy);
     }
@@ -685,18 +725,23 @@ public class BlockStorage {
     }
 
     /**
-     * <strong>Do not call this method!</strong>.
-     * This method is used for internal purposes only.
-     * 
-     * @param l
-     *            The {@link Location}
-     * @param destroy
-     *            Whether to completely destroy the block data
+     * @deprecated
+     * @see BlockStorage#deleteLocationInfoUnsafely(BlockPosition, boolean)
      */
+    @Deprecated
     public static void deleteLocationInfoUnsafely(Location l, boolean destroy) {
         deleteLocationInfoUnsafely(new BlockPosition(l), destroy);
     }
 
+    /**
+     * <strong>Do not call this method!</strong>.
+     * This method is used for internal purposes only.
+     *
+     * @param position
+     *            The {@link BlockPosition}
+     * @param destroy
+     *            Whether to completely destroy the block data
+     */
     public static void deleteLocationInfoUnsafely(BlockPosition position, boolean destroy) {
         BlockStorage storage = getStorage(position.getWorld());
 
@@ -725,6 +770,11 @@ public class BlockStorage {
         }
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#moveBlockInfo(BlockPosition, BlockPosition)
+     */
+    @Deprecated
     @ParametersAreNonnullByDefault
     public static void moveBlockInfo(Location from, Location to) {
         moveBlockInfo(new BlockPosition(from), new BlockPosition(to));
@@ -736,19 +786,24 @@ public class BlockStorage {
     }
 
     /**
-     * <strong>Do not call this method!</strong>.
-     * This method is used for internal purposes only.
-     * 
-     * @param from
-     *            The origin {@link Location}
-     * @param to
-     *            The destination {@link Location}
+     * @deprecated
+     * @see BlockStorage#moveLocationInfoUnsafely(BlockPosition, BlockPosition)
      */
+    @Deprecated
     @ParametersAreNonnullByDefault
     public static void moveLocationInfoUnsafely(Location from, Location to) {
         moveLocationInfoUnsafely(new BlockPosition(from), new BlockPosition(to));
     }
 
+    /**
+     * <strong>Do not call this method!</strong>.
+     * This method is used for internal purposes only.
+     *
+     * @param from
+     *            The origin {@link BlockPosition}
+     * @param to
+     *            The destination {@link BlockPosition}
+     */
     @ParametersAreNonnullByDefault
     public static void moveLocationInfoUnsafely(BlockPosition from, BlockPosition to) {
         if (!hasBlockInfo(from)) {
@@ -798,30 +853,26 @@ public class BlockStorage {
         }
     }
 
-    @Nullable
-    public static SlimefunItem check(@Nonnull Block b) {
+    public static @Nullable SlimefunItem check(@Nonnull Block b) {
         String id = checkID(b);
         return id == null ? null : SlimefunItem.getById(id);
     }
 
-    @Nullable
-    public static SlimefunItem check(@Nonnull Location l) {
+    /**
+     * @deprecated
+     * @see BlockStorage#check(BlockPosition)
+     */
+    @Deprecated
+    public static @Nullable SlimefunItem check(@Nonnull Location l) {
         return check(new BlockPosition(l));
     }
 
-    @Nullable
-    public static SlimefunItem check(@Nonnull BlockPosition position) {
+    public static @Nullable SlimefunItem check(@Nonnull BlockPosition position) {
         String id = checkID(position);
         return id == null ? null : SlimefunItem.getById(id);
     }
 
-    public static boolean check(Block block, String slimefunItem) {
-        String id = checkID(block);
-        return id != null && id.equals(slimefunItem);
-    }
-
-    @Nullable
-    public static String checkID(@Nonnull Block b) {
+    public static @Nullable String checkID(@Nonnull Block b) {
         // Only access the BlockState when on the main thread
         if (Bukkit.isPrimaryThread() && Slimefun.getBlockDataService().isTileEntity(b.getType())) {
             Optional<String> blockData = Slimefun.getBlockDataService().getBlockData(b);
@@ -834,16 +885,29 @@ public class BlockStorage {
         return checkID(new BlockPosition(b));
     }
 
-    @Nullable
-    public static String checkID(@Nonnull Location l) {
+    /**
+     * @deprecated
+     * @see BlockStorage#checkID(BlockPosition)
+     */
+    @Deprecated
+    public static @Nullable String checkID(@Nonnull Location l) {
         return checkID(new BlockPosition(l));
     }
 
-    @Nullable
-    public static String checkID(@Nonnull BlockPosition position) {
+    public static @Nullable String checkID(@Nonnull BlockPosition position) {
         return getBlockInfo(position, "id");
     }
 
+    public static boolean check(Block block, String slimefunItem) {
+        String id = checkID(block);
+        return id != null && id.equals(slimefunItem);
+    }
+
+    /**
+     * @deprecated
+     * @see BlockStorage#check(BlockPosition, String)
+     */
+    @Deprecated
     public static boolean check(@Nonnull Location l, @Nullable String slimefunItem) {
         return check(new BlockPosition(l), slimefunItem);
     }
@@ -861,6 +925,11 @@ public class BlockStorage {
         return Slimefun.getRegistry().getWorlds().containsKey(world.getName());
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#loadInventory(BlockPosition, BlockMenuPreset)
+     */
+    @Deprecated
     public BlockMenu loadInventory(Location l, BlockMenuPreset preset) {
         return loadInventory(new BlockPosition(l), preset);
     }
@@ -876,12 +945,10 @@ public class BlockStorage {
     }
 
     /**
-     * Reload a BlockMenu based on the preset. This method is solely for if you wish to reload
-     * based on data from the preset.
-     *
-     * @param l
-     *            The location of the Block.
+     * @deprecated
+     * @see BlockStorage#reloadInventory(BlockPosition)
      */
+    @Deprecated
     public void reloadInventory(Location l) {
         reloadInventory(new BlockPosition(l));
     }
@@ -901,6 +968,11 @@ public class BlockStorage {
         }
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#clearInventory(BlockPosition)
+     */
+    @Deprecated
     public void clearInventory(Location l) {
         clearInventory(new BlockPosition(l));
     }
@@ -920,6 +992,21 @@ public class BlockStorage {
         }
     }
 
+    public static boolean hasInventory(Block b) {
+        BlockStorage storage = getStorage(b.getWorld());
+
+        if (storage == null) {
+            return false;
+        } else {
+            return storage.hasInventory(new BlockPosition(b));
+        }
+    }
+
+    /**
+     * @deprecated
+     * @see BlockStorage#hasInventory(BlockPosition)
+     */
+    @Deprecated
     public boolean hasInventory(Location l) {
         return hasInventory(new BlockPosition(l));
     }
@@ -932,10 +1019,33 @@ public class BlockStorage {
         return Slimefun.getRegistry().getUniversalInventories().containsKey(id);
     }
 
+    public boolean hasUniversalInventory(Block block) {
+        return hasUniversalInventory(new BlockPosition(block));
+    }
+
+    /**
+     * @deprecated
+     * @see BlockStorage#hasUniversalInventory(BlockPosition)
+     */
+    @Deprecated
+    public boolean hasUniversalInventory(Location l) {
+        return hasUniversalInventory(new BlockPosition(l));
+    }
+
+    public boolean hasUniversalInventory(BlockPosition position) {
+        String id = checkID(position);
+        return id != null && hasUniversalInventory(id);
+    }
+
     public static UniversalBlockMenu getUniversalInventory(Block block) {
         return getUniversalInventory(new BlockPosition(block));
     }
 
+    /**
+     * @deprecated
+     * @see BlockStorage#getUniversalInventory(BlockPosition)
+     */
+    @Deprecated
     public static UniversalBlockMenu getUniversalInventory(Location l) {
         return getUniversalInventory(new BlockPosition(l));
     }
@@ -950,19 +1060,14 @@ public class BlockStorage {
     }
 
     public static BlockMenu getInventory(Block b) {
-        return getInventory(b.getLocation());
+        return getInventory(new BlockPosition(b));
     }
 
-    public static boolean hasInventory(Block b) {
-        BlockStorage storage = getStorage(b.getWorld());
-
-        if (storage == null) {
-            return false;
-        } else {
-            return storage.hasInventory(b.getLocation());
-        }
-    }
-
+    /**
+     * @deprecated
+     * @see BlockStorage#getInventory(BlockPosition)
+     */
+    @Deprecated
     public static BlockMenu getInventory(Location l) {
         return getInventory(new BlockPosition(l));
     }
@@ -1029,24 +1134,17 @@ public class BlockStorage {
         return getBlockInfoAsJson(new BlockPosition(block));
     }
 
-    public static String getBlockInfoAsJson(BlockPosition position) {
-        return serializeBlockInfo(getBlockInfo(position));
-    }
-
+    /**
+     * @deprecated
+     * @see BlockStorage#getBlockInfoAsJson(BlockPosition)
+     */
+    @Deprecated
     public static String getBlockInfoAsJson(Location l) {
         return serializeBlockInfo(getLocationInfo(l));
     }
 
-    public boolean hasUniversalInventory(Block block) {
-        return hasUniversalInventory(new BlockPosition(block));
+    public static String getBlockInfoAsJson(BlockPosition position) {
+        return serializeBlockInfo(getBlockInfo(position));
     }
 
-    public boolean hasUniversalInventory(BlockPosition position) {
-        String id = checkID(position);
-        return id != null && hasUniversalInventory(id);
-    }
-
-    public boolean hasUniversalInventory(Location l) {
-        return hasUniversalInventory(new BlockPosition(l));
-    }
 }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/EmptyBlockData.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/EmptyBlockData.java
@@ -2,7 +2,7 @@ package me.mrCookieSlime.Slimefun.api;
 
 /**
  * This package-private class is supposed to be used as a singleton fallback in places where a
- * {@link NullPointerException} should be avoided, like {@link BlockStorage#getLocationInfo(org.bukkit.Location)}.
+ * {@link NullPointerException} should be avoided, like {@link BlockStorage#getBlockInfo(io.github.bakedlibs.dough.blocks.BlockPosition)}.
  * 
  * This object is a read-only variant of {@link BlockInfoConfig} and only serves the purpose of
  * performance and memory optimization.

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -22,10 +22,20 @@ public class BlockMenu extends DirtyChestMenu {
         return position.getWorld().getName() + ';' + position.getX() + ';' + position.getY() + ';' + position.getZ();
     }
 
+    /**
+     * @deprecated
+     * @see BlockMenu#BlockMenu(BlockMenuPreset, BlockPosition)
+     */
+    @Deprecated
     public BlockMenu(BlockMenuPreset preset, Location l) {
         this(preset, new BlockPosition(l));
     }
 
+    /**
+     * @deprecated
+     * @see BlockMenu#BlockMenu(BlockMenuPreset, BlockPosition, Config)
+     */
+    @Deprecated
     public BlockMenu(BlockMenuPreset preset, Location l, Config cfg) {
         this(preset, new BlockPosition(l), cfg);
     }
@@ -57,6 +67,11 @@ public class BlockMenu extends DirtyChestMenu {
         this.getContents();
     }
 
+    /**
+     * @deprecated
+     * @see BlockMenu#save(BlockPosition)
+     */
+    @Deprecated
     public void save(Location l) {
         save(new BlockPosition(l));
     }
@@ -82,6 +97,11 @@ public class BlockMenu extends DirtyChestMenu {
         changes = 0;
     }
 
+    /**
+     * @deprecated
+     * @see BlockMenu#move(BlockPosition)
+     */
+    @Deprecated
     public void move(Location l) {
         move(new BlockPosition(l));
     }
@@ -104,6 +124,11 @@ public class BlockMenu extends DirtyChestMenu {
         return position.getBlock();
     }
 
+    /**
+     * @deprecated
+     * @see BlockMenu#getPosition()
+     */
+    @Deprecated
     public Location getLocation() {
         return position.toLocation();
     }
@@ -132,6 +157,11 @@ public class BlockMenu extends DirtyChestMenu {
         }
     }
 
+    /**
+     * @deprecated
+     * @see BlockMenu#delete(BlockPosition)
+     */
+    @Deprecated
     public void delete(Location l) {
         delete(new BlockPosition(l));
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.logging.Level;
 
+import io.github.bakedlibs.dough.blocks.BlockPosition;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
@@ -15,23 +16,31 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 // This class will be deprecated, relocated and rewritten in a future version.
 public class BlockMenu extends DirtyChestMenu {
 
-    private Location location;
+    private BlockPosition position;
 
-    private static String serializeLocation(Location l) {
-        return l.getWorld().getName() + ';' + l.getBlockX() + ';' + l.getBlockY() + ';' + l.getBlockZ();
+    private static String serializePosition(BlockPosition position) {
+        return position.getWorld().getName() + ';' + position.getX() + ';' + position.getY() + ';' + position.getZ();
     }
 
     public BlockMenu(BlockMenuPreset preset, Location l) {
+        this(preset, new BlockPosition(l));
+    }
+
+    public BlockMenu(BlockMenuPreset preset, Location l, Config cfg) {
+        this(preset, new BlockPosition(l), cfg);
+    }
+
+    public BlockMenu(BlockMenuPreset preset, BlockPosition position) {
         super(preset);
-        this.location = l;
+        this.position = position;
 
         preset.clone(this);
         this.getContents();
     }
 
-    public BlockMenu(BlockMenuPreset preset, Location l, Config cfg) {
+    public BlockMenu(BlockMenuPreset preset, BlockPosition position, Config cfg) {
         super(preset);
-        this.location = l;
+        this.position = position;
 
         for (int i = 0; i < 54; i++) {
             if (cfg.contains(String.valueOf(i))) {
@@ -49,6 +58,10 @@ public class BlockMenu extends DirtyChestMenu {
     }
 
     public void save(Location l) {
+        save(new BlockPosition(l));
+    }
+
+    public void save(BlockPosition position) {
         if (!isDirty()) {
             return;
         }
@@ -56,7 +69,7 @@ public class BlockMenu extends DirtyChestMenu {
         // To force CS-CoreLib to build the Inventory
         this.getContents();
 
-        File file = new File("data-storage/Slimefun/stored-inventories/" + serializeLocation(l) + ".sfi");
+        File file = new File("data-storage/Slimefun/stored-inventories/" + serializePosition(position) + ".sfi");
         Config cfg = new Config(file);
         cfg.setValue("preset", preset.getID());
 
@@ -70,10 +83,14 @@ public class BlockMenu extends DirtyChestMenu {
     }
 
     public void move(Location l) {
-        this.delete(this.location);
-        this.location = l;
-        this.preset.newInstance(this, l);
-        this.save(l);
+        move(new BlockPosition(l));
+    }
+
+    public void move(BlockPosition position) {
+        this.delete(this.position);
+        this.position = position;
+        this.preset.newInstance(this, position);
+        this.save(position);
     }
 
     /**
@@ -84,11 +101,15 @@ public class BlockMenu extends DirtyChestMenu {
     }
 
     public Block getBlock() {
-        return location.getBlock();
+        return position.getBlock();
     }
 
     public Location getLocation() {
-        return location;
+        return position.toLocation();
+    }
+
+    public BlockPosition getPosition() {
+        return position;
     }
 
     /**
@@ -112,7 +133,11 @@ public class BlockMenu extends DirtyChestMenu {
     }
 
     public void delete(Location l) {
-        File file = new File("data-storage/Slimefun/stored-inventories/" + serializeLocation(l) + ".sfi");
+        delete(new BlockPosition(l));
+    }
+
+    public void delete(BlockPosition position) {
+        File file = new File("data-storage/Slimefun/stored-inventories/" + serializePosition(position) + ".sfi");
 
         if (file.exists()) {
             try {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
@@ -248,6 +248,11 @@ public abstract class BlockMenuPreset extends ChestMenu {
         menu.addMenuCloseHandler(getMenuCloseHandler());
     }
 
+    /**
+     * @deprecated
+     * @see BlockMenuPreset#newInstance(BlockMenu, BlockPosition)
+     */
+    @Deprecated
     public void newInstance(@Nonnull BlockMenu menu, @Nonnull Location l) {
         Validate.notNull(l, "Cannot create a new BlockMenu without a Location");
         newInstance(menu, new BlockPosition(l));

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.github.bakedlibs.dough.blocks.BlockPosition;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -234,7 +235,7 @@ public abstract class BlockMenuPreset extends ChestMenu {
         }
 
         if (menu instanceof BlockMenu blockMenu) {
-            newInstance(blockMenu, blockMenu.getLocation());
+            newInstance(blockMenu, blockMenu.getPosition());
         }
 
         for (int slot = 0; slot < 54; slot++) {
@@ -249,12 +250,16 @@ public abstract class BlockMenuPreset extends ChestMenu {
 
     public void newInstance(@Nonnull BlockMenu menu, @Nonnull Location l) {
         Validate.notNull(l, "Cannot create a new BlockMenu without a Location");
+        newInstance(menu, new BlockPosition(l));
+    }
 
+    public void newInstance(@Nonnull BlockMenu menu, @Nonnull BlockPosition position) {
+        Validate.notNull(position, "Cannot create a new BlockMenu without a position");
         Slimefun.runSync(() -> {
             locked = true;
 
             try {
-                newInstance(menu, l.getBlock());
+                newInstance(menu, position.getBlock());
             } catch (Exception | LinkageError x) {
                 getSlimefunItem().error("An Error occurred while trying to create a BlockMenu", x);
             }


### PR DESCRIPTION
## Description
BlockStorage & related classes currently use Locations internally instead of BlockPositions. Locations are comprised of a Reference<World>, 3 doubles, and 2 floats, while BlockPositions are comprised of only a WeakReference<World>, and a long.
By switching to using BlockPositions we would save MASSIVELY on memory with the current implementation of BlockStorage. 

Once this PR is ready to go and approved I will make a matching PR that updates all of Slimefun's internals to use the new methods instead of the deprecated old ones.

## Proposed changes
- (Very simple overview, will write a full blown one later)
- Refactors BlockStorage, TickerTask, BlockMenu, BlockMenuPreset, SlimefunProfiler, ProfiledBlock, and ErrorReport to use BlockPositions instead of Locations
  - A couple methods needed to be renamed due to their signature & to avoid breaking changes
  - I still need to setup the javadocs for the new methods
  - To avoid breaking changes all old methods still exist and just overflow to the new methods.
    - I still need to update java docs and add deprecation warnings to all of these

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
