### PR TITLE
feat: Add RadiationDamageEvent to the api

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/RadiationDamageEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/RadiationDamageEvent.java
@@ -1,0 +1,71 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import javax.annotation.Nonnull;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * The {@link RadiationDamageEvent} is called when a player takes radiation damage.
+ * 
+ * @author HoosierTransfer
+ *
+ */
+public class RadiationDamageEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Player player;
+    private int exposure;
+    private boolean cancelled;
+
+    /**
+     * This constructs a new {@link RadiationDamageEvent}.
+     * 
+     * @param player The {@link Player} who took radiation damage
+     * @param exposure The amount of radiation exposure
+     */
+    public RadiationDamageEvent(@Nonnull Player player, int exposure) {
+        this.player = player;
+    }
+
+    /**
+     * This returns the {@link Player} who took radiation damage.
+     * 
+     * @return The {@link Player} who took radiation damage
+     */
+    
+    public @Nonnull Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * This returns the amount of radiation exposure.
+     * 
+     * @return The amount of radiation exposure
+     */
+    public int getExposure() {
+        return exposure;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Nonnull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public @Nonnull HandlerList getHandlers() {
+        return getHandlerList();
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/RadiationTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/armor/RadiationTask.java
@@ -1,6 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.implementation.tasks.armor;
 
 import io.github.bakedlibs.dough.common.ChatColors;
+import io.github.thebusybiscuit.slimefun4.api.events.RadiationDamageEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.attributes.ProtectionType;
@@ -12,6 +13,8 @@ import io.github.thebusybiscuit.slimefun4.utils.RadiationUtils;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
+
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -71,6 +74,13 @@ public class RadiationTask extends AbstractArmorTask {
             int exposureLevelAfter = RadiationUtils.getExposure(p);
 
             Slimefun.runSync(() -> {
+                RadiationDamageEvent e = new RadiationDamageEvent(p, exposureLevelAfter);
+                Bukkit.getPluginManager().callEvent(e);
+
+                if (e.isCancelled()) {
+                    return;
+                }
+
                 for (RadiationSymptom symptom : symptoms) {
                     if (symptom.shouldApply(exposureLevelAfter)) {
                         symptom.apply(p);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Adds a `RadiationDamageEvent` so that addons can cancel radiation damage.

## Proposed changes
Add an event that is called when the player takes radiation damga

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
