### PR TITLE
fix: fix JsonParser static methods not exist before 1.18

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
@@ -29,10 +29,10 @@ import org.bukkit.plugin.Plugin;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
 
 import io.github.bakedlibs.dough.common.CommonPatterns;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.JsonUtils;
 
 /**
  * This Class represents a Metrics Service that sends data to https://bstats.org/
@@ -204,7 +204,7 @@ public class MetricsService {
                 return -1;
             }
 
-            JsonElement element = JsonParser.parseString(response.body());
+            JsonElement element = JsonUtils.parseString(response.body());
 
             return element.getAsJsonObject().get("tag_name").getAsInt();
         } catch (IOException | InterruptedException | JsonParseException e) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubConnector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubConnector.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.JsonUtils;
 
 /**
  * The {@link GitHubConnector} is used to connect to the GitHub API service.
@@ -120,7 +121,7 @@ abstract class GitHubConnector {
                 HttpRequest.newBuilder(uri).header("User-Agent", USER_AGENT).build(),
                 HttpResponse.BodyHandlers.ofString()
             );
-            JsonElement element = JsonParser.parseString(response.body());
+            JsonElement element = JsonUtils.parseString(response.body());
 
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 onSuccess(element);


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Quick fix the issues for backward compatibility with 1.16 and 1.17.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Use the parse method from JsonUtils.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
