### PR TITLE
Log non-200 on metrics download

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
@@ -235,7 +235,6 @@ public class MetricsService {
                 downloadMonitor(HttpResponse.BodyHandlers.ofFile(file.toPath()))
             );
 
-
             if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 plugin.getLogger().log(Level.INFO, "Successfully downloaded {0} build: #{1}", new Object[] { JAR_NAME, version });
 
@@ -246,6 +245,8 @@ public class MetricsService {
                 metricVersion = String.valueOf(version);
                 hasDownloadedUpdate = true;
                 return true;
+            } else {
+                plugin.getLogger().log(Level.WARNING, "Failed to download the latest jar file from GitHub. Response code: {0}", response.statusCode());
             }
         } catch (InterruptedException | JsonParseException e) {
             plugin.getLogger().log(Level.WARNING, "Failed to fetch the latest jar file from the builds page. Perhaps GitHub is down? Response: {0}", e.getMessage());


### PR DESCRIPTION
## Description
We didn't have a log line for this previously so it would say "failed to download" but not provide any further info. This provides that info

## Proposed changes
Log that we got a non-200 status code and log the code.

## Related Issues (if applicable)
N/A

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
