### PR TITLE
Add powder snow block to the list of blocks that the Explosive Shovel can break

### DIFF
--- a/src/main/resources/tags/explosive_shovel_blocks.json
+++ b/src/main/resources/tags/explosive_shovel_blocks.json
@@ -5,6 +5,7 @@
 		"#slimefun:dirt_variants",
 		"minecraft:snow",
 		"minecraft:snow_block",
+		"minecraft:powder_snow",
 		"minecraft:gravel",
 		"minecraft:clay",
 		"minecraft:soul_sand",


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Hello, I was playing the minecraft 1.20.4 and noticed that the [Explosive Shovel](https://github.com/Slimefun/Slimefun4/wiki/Explosive%20Shovel)  can't break powder snow blocks. I believe they should be able to break this block. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Add powder snow block to the list of blocks that the Explosive Shovel can break.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
An issue is that this block came in minecraft 1.17, so most likely 1.16 would not be compatible.
This might not be an issue but this block drops nothing, since it can only be collected with buckets like a liquid.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.
