### PR TITLE
Add simple BlockPosition based BlockStorage helpers. 

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -35,6 +35,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonWriter;
 
+import io.github.bakedlibs.dough.blocks.BlockPosition;
 import io.github.bakedlibs.dough.common.CommonPatterns;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -513,8 +513,16 @@ public class BlockStorage {
         return getLocationInfo(l).getString(key);
     }
 
+    public static String getLocationInfo(BlockPosition l, String key) {
+        return getLocationInfo(l.toLocation()).getString(key);
+    }
+
     public static void addBlockInfo(Location l, String key, String value) {
         addBlockInfo(l, key, value, false);
+    }
+
+    public static void addBlockInfo(BlockPosition l, String key, String value) {
+        addBlockInfo(l.toLocation(), key, value, false);
     }
 
     public static void addBlockInfo(Block block, String key, String value) {
@@ -523,6 +531,10 @@ public class BlockStorage {
 
     public static void addBlockInfo(Block block, String key, String value, boolean updateTicker) {
         addBlockInfo(block.getLocation(), key, value, updateTicker);
+    }
+
+    public static void addBlockInfo(BlockPosition l, String key, String value, boolean updateTicker) {
+        addBlockInfo(l.toLocation(), key, value, updateTicker);
     }
 
     public static void addBlockInfo(Location l, String key, String value, boolean updateTicker) {


### PR DESCRIPTION
## Description
I don't like using Location so Im trying to move a lot of my stuff to`BlockPosition` instead. This helps ease that transition.

## Proposed changes
Add blockstorage helpers that use BlockPosition instead of `Location` and `Block`

## Related Issues (if applicable)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
