### PR TITLE
Add multiversion support to ExplosiveTool#createNewBlockExplodeEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,10 +394,10 @@
         </dependency>
         <!-- This needs to be before Spigot because MockBukkit will fail otherwise. -->
         <dependency>
-            <groupId>com.github.seeseemelk</groupId>
+            <groupId>com.github.MockBukkit</groupId>
             <artifactId>MockBukkit</artifactId>
             <!-- <version>3.123.0</version> -->
-            <version>dev-3fec4e7b</version>
+            <version>673ed0b231</version>
             <scope>test</scope>
 
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <!-- Project Info -->
-    <description>Slimefun is a Spigot/Paper plugin that simulates a modpack-like atmosphere by adding over 500 new items and recipes to your Minecraft Server.</description>
+    <description>Slimefun is a Paper plugin that simulates a modpack-like atmosphere by adding over 500 new items and recipes to your Minecraft Server.</description>
     <url>https://github.com/Slimefun/Slimefun4</url>
 
     <properties>
@@ -29,8 +29,8 @@
         <maven.compiler.testTarget>21</maven.compiler.testTarget>
 
         <!-- Spigot properties -->
-        <spigot.version>1.20.6</spigot.version>
-        <spigot.javadocs>https://hub.spigotmc.org/javadocs/spigot/</spigot.javadocs>
+        <paper.version>1.21.1</paper.version>
+        <paper.javadocs>https://hub.spigotmc.org/javadocs/spigot/</paper.javadocs>
 
         <!-- Default settings for sonarcloud.io -->
         <sonar.projectKey>Slimefun_Slimefun4</sonar.projectKey>
@@ -367,6 +367,13 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- Paper -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
+        </dependency>
+
         <!-- Testing dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -387,9 +394,10 @@
         </dependency>
         <!-- This needs to be before Spigot because MockBukkit will fail otherwise. -->
         <dependency>
-            <groupId>com.github.MockBukkit</groupId>
+            <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit</artifactId>
-            <version>c7cc678834</version>
+            <!-- <version>3.123.0</version> -->
+            <version>dev-3fec4e7b</version>
             <scope>test</scope>
 
             <exclusions>
@@ -400,13 +408,6 @@
                     <artifactId>annotations</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <!-- Override Spigot with Paper tests as a CommandMap ctor which MockBukkit uses only exists on Paper but not in Spigot -->
-        <dependency>
-            <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- Third party plugin integrations / soft dependencies -->
@@ -514,12 +515,6 @@
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>${spigot.version}-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.mojang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
             <groupId>com.github.MockBukkit</groupId>
             <artifactId>MockBukkit</artifactId>
             <!-- <version>3.123.0</version> -->
-            <version>3fec4e7b7a</version>
+            <version>673ed0b231</version>
             <scope>test</scope>
 
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
             <groupId>com.github.MockBukkit</groupId>
             <artifactId>MockBukkit</artifactId>
             <!-- <version>3.123.0</version> -->
-            <version>673ed0b231</version>
+            <version>3fec4e7b7a</version>
             <scope>test</scope>
 
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -394,10 +394,10 @@
         </dependency>
         <!-- This needs to be before Spigot because MockBukkit will fail otherwise. -->
         <dependency>
-            <groupId>com.github.MockBukkit</groupId>
-            <artifactId>MockBukkit</artifactId>
+            <groupId>com.github.seeseemelk</groupId>
+            <artifactId>MockBukkit-v1.21</artifactId>
             <!-- <version>3.123.0</version> -->
-            <version>673ed0b231</version>
+            <version>3.123.0</version>
             <scope>test</scope>
 
             <exclusions>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
@@ -56,6 +56,12 @@ public enum MinecraftVersion {
     MINECRAFT_1_20_5(20, 5, "1.20.5+"),
 
     /**
+     * This constant represents Minecraft (Java Edition) Version 1.21
+     * ("Tricky Trials")
+     */
+    MINECRAFT_1_21(21, 0, "1.21+"),
+
+    /**
      * This constant represents an exceptional state in which we were unable
      * to identify the Minecraft Version we are using
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
@@ -307,7 +307,7 @@ public class SlimefunItemStack extends ItemStack {
 
     @Override
     public ItemStack clone() {
-        return new SlimefunItemStack(id, this);
+        return new SlimefunItemStack(id, super.clone());
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -1,12 +1,15 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import dev.lone.itemsadder.api.CustomBlock;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.ExplosionResult;
@@ -192,7 +195,20 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         List<Block> blocks,
         float yield
     ) {
-        // TODO: Support older vers
-        return new BlockExplodeEvent(block, block.getState(), blocks, yield, ExplosionResult.DESTROY);
+        String[] version = Bukkit.getBukkitVersion().split("-");
+
+        return switch (version[1]) {
+            case "21" -> new BlockExplodeEvent(block, block.getState(), blocks, yield, ExplosionResult.DESTROY);
+            default -> {
+                try {
+                    Constructor<?> constructor = BlockExplodeEvent.class.getConstructor(Block.class, List.class, float.class);
+                    yield (BlockExplodeEvent) constructor.newInstance(block, blocks, yield);
+                } catch (Exception e) {
+                    Slimefun.logger().log(Level.SEVERE, "Support not found");
+                }
+
+                yield null;
+            }
+        };
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -9,6 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import dev.lone.itemsadder.api.CustomBlock;
+import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.ExplosionResult;
@@ -194,9 +195,9 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         List<Block> blocks,
         float yield
     ) {
-        String[] version = Bukkit.getBukkitVersion().split("-");
 
-        if (Integer.parseInt(version[1]) >= 21) {
+        var version = Slimefun.getMinecraftVersion();
+        if (version.isAtLeast(MinecraftVersion.MINECRAFT_1_21)) {
             return new BlockExplodeEvent(block, block.getState(), blocks, yield, ExplosionResult.DESTROY);
         } else {
             try {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -9,6 +9,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import dev.lone.itemsadder.api.CustomBlock;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
+import org.bukkit.ExplosionResult;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -78,7 +79,7 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         List<Block> blocksToDestroy = new ArrayList<>();
 
         if (callExplosionEvent.getValue()) {
-            BlockExplodeEvent blockExplodeEvent = new BlockExplodeEvent(b, blocks, 0);
+            BlockExplodeEvent blockExplodeEvent = createNewBlockExplodeEvent(b, blocks, 0);
             Bukkit.getServer().getPluginManager().callEvent(blockExplodeEvent);
 
             if (!blockExplodeEvent.isCancelled()) {
@@ -186,4 +187,12 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         damageItem(p, item);
     }
 
+    private BlockExplodeEvent createNewBlockExplodeEvent(
+        Block block,
+        List<Block> blocks,
+        float yield
+    ) {
+        // TODO: Support older vers
+        return new BlockExplodeEvent(block, block.getState(), blocks, yield, ExplosionResult.DESTROY);
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -9,7 +9,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import dev.lone.itemsadder.api.CustomBlock;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.ExplosionResult;
@@ -197,18 +196,17 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
     ) {
         String[] version = Bukkit.getBukkitVersion().split("-");
 
-        return switch (version[1]) {
-            case "21" -> new BlockExplodeEvent(block, block.getState(), blocks, yield, ExplosionResult.DESTROY);
-            default -> {
-                try {
-                    Constructor<?> constructor = BlockExplodeEvent.class.getConstructor(Block.class, List.class, float.class);
-                    yield (BlockExplodeEvent) constructor.newInstance(block, blocks, yield);
-                } catch (Exception e) {
-                    Slimefun.logger().log(Level.SEVERE, "Support not found");
-                }
-
-                yield null;
+        if (Integer.parseInt(version[1]) >= 21) {
+            return new BlockExplodeEvent(block, block.getState(), blocks, yield, ExplosionResult.DESTROY);
+        } else {
+            try {
+                Constructor<?> constructor = BlockExplodeEvent.class.getConstructor(Block.class, List.class, float.class);
+                return (BlockExplodeEvent) constructor.newInstance(block, blocks, yield);
+            } catch (Exception e) {
+                Slimefun.logger().log(Level.SEVERE, "Support not found");
             }
-        };
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Description
Add multiversion support to ExplosiveTool#createNewBlockExplodeEvent using reflection.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.

This doesn't build yet due to tests of MockBukkit failing
