### PR TITLE
Feature/flint and steal unbreaking

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
@@ -82,31 +82,32 @@ public class IgnitionChamber extends SlimefunItem {
         }
 
         // Check if the chamber contains a Flint and Steel
-        if (inv.contains(Material.FLINT_AND_STEEL)) {
-            ItemStack item = inv.getItem(inv.first(Material.FLINT_AND_STEEL));
-            ItemMeta meta = item.getItemMeta();
-
-            // Only damage the Flint and Steel if it isn't unbreakable.
-            if (!meta.isUnbreakable()) {
-                // Update the damage value
-                ((Damageable) meta).setDamage(((Damageable) meta).getDamage() + 1);
-
-                if (((Damageable) meta).getDamage() >= item.getType().getMaxDurability()) {
-                    // The Flint and Steel broke
-                    item.setAmount(0);
-                    SoundEffect.IGNITION_CHAMBER_USE_FLINT_AND_STEEL_SOUND.playAt(smelteryBlock);
-                } else {
-                    item.setItemMeta(meta);
-                }
-            }
-
-            SoundEffect.IGNITION_CHAMBER_USE_FLINT_AND_STEEL_SOUND.playAt(smelteryBlock);
-            return true;
-        } else {
+        if (!inv.contains(Material.FLINT_AND_STEEL)) {
             // Notify the Player there is a chamber but without any Flint and Steel
             Slimefun.getLocalization().sendMessage(p, "machines.ignition-chamber-no-flint", true);
             return false;
         }
+
+        ItemStack item = inv.getItem(inv.first(Material.FLINT_AND_STEEL));
+        ItemMeta meta = item.getItemMeta();
+
+        // Only damage the Flint and Steel if it isn't unbreakable.
+        if (!meta.isUnbreakable()) {
+            Damageable damageable = (Damageable) meta;
+            // Update the damage value
+            damageable.setDamage(damageable.getDamage() + 1);
+
+            if (damageable.getDamage() >= item.getType().getMaxDurability()) {
+                // The Flint and Steel broke
+                item.setAmount(0);
+                SoundEffect.IGNITION_CHAMBER_USE_FLINT_AND_STEEL_SOUND.playAt(smelteryBlock);
+            } else {
+                item.setItemMeta(meta);
+            }
+        }
+
+        SoundEffect.IGNITION_CHAMBER_USE_FLINT_AND_STEEL_SOUND.playAt(smelteryBlock);
+        return true;
     }
 
     private static @Nullable Inventory findIgnitionChamber(@Nonnull Block b) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.UnbreakingAlgorithm;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEnchantment;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
@@ -113,10 +114,7 @@ public class IgnitionChamber extends SlimefunItem {
         Enchantment unbreaking = VersionedEnchantment.UNBREAKING;
         int lvl = flintAndSteel.getEnchantmentLevel(unbreaking);
 
-        //Calculation from https://minecraft.fandom.com/wiki/Unbreaking
-        double breakingChance = 1.0 / (lvl + 1.0);
-
-        if (ThreadLocalRandom.current().nextDouble() < breakingChance) {
+        if (UnbreakingAlgorithm.TOOLS.evaluate(lvl)) {
             damageable.setDamage(damageable.getDamage() + 1);
         }
 


### PR DESCRIPTION
## Description
Make the Automatic Ignition chamber respect the level of the Unbreaking enchantment on the tool selected for durability loss (thus, an Unbreaking 3 Flint and Steel would last 4 times as long on average).

## Proposed changes
Refactor the code releated to damaging the flint and steal into a `damageFlintAndSteel` method that uses vanilla MC unbreaking calculation to determine when to damage the flint and steal

## Related Issues (if applicable)
[Suggestion 2429](https://discord.com/channels/565557184348422174/627048923122499584/1273071970149339138
) #approved

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
