### PR TITLE
[DRAFT] Move away from dough's CustomItemStack

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -22,7 +23,6 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.blocks.BlockPosition;
 import io.github.bakedlibs.dough.config.Config;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.events.GEOResourceGenerationEvent;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -38,9 +38,9 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 /**
  * The {@link ResourceManager} is responsible for registering and managing a {@link GEOResource}.
  * You have to use the {@link ResourceManager} if you want to generate or consume a {@link GEOResource} too.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see GEOResource
  * @see GEOMiner
  * @see GEOScanner
@@ -53,7 +53,7 @@ public class ResourceManager {
 
     /**
      * This will create a new {@link ResourceManager}.
-     * 
+     *
      * @param plugin
      *            Our {@link Slimefun} instance
      */
@@ -64,7 +64,7 @@ public class ResourceManager {
     /**
      * This method registers the given {@link GEOResource}.
      * It may never be called directly, use {@link GEOResource#register()} instead.
-     * 
+     *
      * @param resource
      *            The {@link GEOResource} to register
      */
@@ -93,7 +93,7 @@ public class ResourceManager {
      * This method returns the amount of a certain {@link GEOResource} found in a given {@link Chunk}.
      * The result is an {@link OptionalInt} which will be empty if this {@link GEOResource}
      * has not been generated at that {@link Location} yet.
-     * 
+     *
      * @param resource
      *            The {@link GEOResource} to query
      * @param world
@@ -102,7 +102,7 @@ public class ResourceManager {
      *            The {@link Chunk} x coordinate
      * @param z
      *            The {@link Chunk} z coordinate
-     * 
+     *
      * @return An {@link OptionalInt}, either empty or containing the amount of the given {@link GEOResource}
      */
     public @Nonnull OptionalInt getSupplies(@Nonnull GEOResource resource, @Nonnull World world, int x, int z) {
@@ -121,7 +121,7 @@ public class ResourceManager {
 
     /**
      * This method will set the supplies in a given {@link Chunk} to the specified value.
-     * 
+     *
      * @param resource
      *            The {@link GEOResource}
      * @param world
@@ -147,7 +147,7 @@ public class ResourceManager {
      * <p>
      * This method will invoke {@link #setSupplies(GEOResource, World, int, int, int)} and also calls a
      * {@link GEOResourceGenerationEvent}.
-     * 
+     *
      * @param resource
      *            The {@link GEOResource} to generate
      * @param world
@@ -156,7 +156,7 @@ public class ResourceManager {
      *            The x coordinate of that {@link Chunk}
      * @param z
      *            The z coordinate of that {@link Chunk}
-     * 
+     *
      * @return The new supply value
      */
     private int generate(@Nonnull GEOResource resource, @Nonnull World world, int x, int y, int z) {
@@ -199,11 +199,11 @@ public class ResourceManager {
     /**
      * This method will start a geo-scan at the given {@link Block} and display the result
      * of that scan to the given {@link Player}.
-     * 
+     *
      * Note that scans are always per {@link Chunk}, not per {@link Block}, the {@link Block}
      * parameter only determines the {@link Location} that was clicked but it will still scan
      * the entire {@link Chunk}.
-     * 
+     *
      * @param p
      *            The {@link Player} who requested these results
      * @param block
@@ -227,7 +227,7 @@ public class ResourceManager {
             menu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        menu.addItem(4, new CustomItemStack(HeadTexture.MINECRAFT_CHUNK.getAsItemStack(), ChatColor.YELLOW + Slimefun.getLocalization().getResourceString(p, "tooltips.chunk"), "", "&8\u21E8 &7" + Slimefun.getLocalization().getResourceString(p, "tooltips.world") + ": " + block.getWorld().getName(), "&8\u21E8 &7X: " + x + " Z: " + z), ChestMenuUtils.getEmptyClickHandler());
+        menu.addItem(4, ItemStackUtil.withNameLoreString(HeadTexture.MINECRAFT_CHUNK.getAsItemStack(), ChatColor.YELLOW + Slimefun.getLocalization().getResourceString(p, "tooltips.chunk"), "", "&8\u21E8 &7" + Slimefun.getLocalization().getResourceString(p, "tooltips.world") + ": " + block.getWorld().getName(), "&8\u21E8 &7X: " + x + " Z: " + z), ChestMenuUtils.getEmptyClickHandler());
         List<GEOResource> resources = new ArrayList<>(Slimefun.getRegistry().getGEOResources().values());
         resources.sort(Comparator.comparing(a -> a.getName(p).toLowerCase(Locale.ROOT)));
 
@@ -240,7 +240,7 @@ public class ResourceManager {
             int supplies = optional.orElseGet(() -> generate(resource, block.getWorld(), x, block.getY(), z));
             String suffix = Slimefun.getLocalization().getResourceString(p, ChatUtils.checkPlurality("tooltips.unit", supplies));
 
-            ItemStack item = new CustomItemStack(resource.getItem(), "&f" + resource.getName(p), "&8\u21E8 &e" + supplies + ' ' + suffix);
+            ItemStack item = ItemStackUtil.withNameLoreString(resource.getItem(), "&f" + resource.getName(p), "&8\u21E8 &e" + supplies + ' ' + suffix);
 
             if (supplies > 1) {
                 item.setAmount(Math.min(supplies, item.getMaxStackSize()));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/GPSNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/GPSNetwork.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.gps;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -22,7 +24,6 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.chat.ChatInput;
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.WaypointCreateEvent;
 import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
 import io.github.thebusybiscuit.slimefun4.api.geo.ResourceManager;
@@ -44,9 +45,9 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
  * The {@link GPSNetwork} is a manager class for all {@link GPSTransmitter Transmitters} and waypoints.
  * There can only be one instance of this class per {@link Server}.
  * It is also responsible for teleportation and resource management.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see TeleportationManager
  * @see ResourceManager
  *
@@ -64,7 +65,7 @@ public class GPSNetwork {
     /**
      * This constructs a new {@link GPSNetwork}.
      * Note that this network is per {@link Server} and not per {@link Player}.
-     * 
+     *
      * @param plugin
      *            Our {@link Slimefun} instance
      */
@@ -74,7 +75,7 @@ public class GPSNetwork {
 
     /**
      * This method updates the status of a {@link GPSTransmitter}.
-     * 
+     *
      * @param l
      *            The {@link Location} of the {@link GPSTransmitter}
      * @param uuid
@@ -96,10 +97,10 @@ public class GPSNetwork {
      * This method calculates the GPS complexity for the given {@link UUID}.
      * The complexity is determined by the Y level of each {@link GPSTransmitter}
      * multiplied by the multiplier of that transmitter.
-     * 
+     *
      * @param uuid
      *            The {@link UUID} who to calculate it for
-     * 
+     *
      * @return The network complexity for that {@link UUID}
      */
     public int getNetworkComplexity(@Nonnull UUID uuid) {
@@ -124,10 +125,10 @@ public class GPSNetwork {
     /**
      * This method returns the amount of {@link GPSTransmitter Transmitters} for the
      * given {@link UUID}.
-     * 
+     *
      * @param uuid
      *            The {@link UUID} who these transmitters belong to
-     * 
+     *
      * @return The amount of transmitters
      */
     public int countTransmitters(@Nonnull UUID uuid) {
@@ -138,7 +139,7 @@ public class GPSNetwork {
     /**
      * This method opens the {@link GPSTransmitter} control panel to the given
      * {@link Player}.
-     * 
+     *
      * @param p
      *            The {@link Player}
      */
@@ -149,18 +150,16 @@ public class GPSNetwork {
             menu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        menu.addItem(2, new CustomItemStack(SlimefunItems.GPS_TRANSMITTER, im -> {
-            im.setDisplayName(ChatColor.GRAY + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.transmitters"));
-            im.setLore(null);
-        }));
+        String displayName = ChatColor.GRAY + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.transmitters");
+        menu.addItem(2, ItemStackUtil.withNameLoreString(SlimefunItems.GPS_TRANSMITTER, displayName, Collections.emptyList()));
 
         menu.addMenuClickHandler(2, ChestMenuUtils.getEmptyClickHandler());
 
         int complexity = getNetworkComplexity(p.getUniqueId());
-        menu.addItem(4, new CustomItemStack(SlimefunItems.GPS_CONTROL_PANEL, "&7Network Info", "", "&8\u21E8 &7Status: " + getStatusText(p, complexity), "&8\u21E8 &7Complexity: &f" + complexity));
+        menu.addItem(4, ItemStackUtil.withNameLoreString(SlimefunItems.GPS_CONTROL_PANEL, "&7Network Info", "", "&8\u21E8 &7Status: " + getStatusText(p, complexity), "&8\u21E8 &7Complexity: &f" + complexity));
         menu.addMenuClickHandler(4, ChestMenuUtils.getEmptyClickHandler());
 
-        menu.addItem(6, new CustomItemStack(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.waypoints"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
+        menu.addItem(6, ItemStackUtil.withNameLoreString(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.waypoints"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
         menu.addMenuClickHandler(6, (pl, slot, item, action) -> {
             openWaypointControlPanel(pl);
             return false;
@@ -177,7 +176,7 @@ public class GPSNetwork {
             if (sfi instanceof GPSTransmitter transmitter) {
                 int slot = inventory[index];
 
-                menu.addItem(slot, new CustomItemStack(SlimefunItems.GPS_TRANSMITTER, "&bGPS Transmitter", "&8\u21E8 &7World: &f" + l.getWorld().getName(), "&8\u21E8 &7X: &f" + l.getX(), "&8\u21E8 &7Y: &f" + l.getY(), "&8\u21E8 &7Z: &f" + l.getZ(), "", "&8\u21E8 &7Signal Strength: &f" + transmitter.getMultiplier(l.getBlockY()), "&8\u21E8 &7Ping: &f" + NumberUtils.roundDecimalNumber(1000D / l.getY()) + "ms"));
+                menu.addItem(slot, ItemStackUtil.withNameLoreString(SlimefunItems.GPS_TRANSMITTER, "&bGPS Transmitter", "&8\u21E8 &7World: &f" + l.getWorld().getName(), "&8\u21E8 &7X: &f" + l.getX(), "&8\u21E8 &7Y: &f" + l.getY(), "&8\u21E8 &7Z: &f" + l.getZ(), "", "&8\u21E8 &7Signal Strength: &f" + transmitter.getMultiplier(l.getBlockY()), "&8\u21E8 &7Ping: &f" + NumberUtils.roundDecimalNumber(1000D / l.getY()) + "ms"));
                 menu.addMenuClickHandler(slot, ChestMenuUtils.getEmptyClickHandler());
 
                 index++;
@@ -192,14 +191,14 @@ public class GPSNetwork {
      * The icon is dependent on the {@link Environment} of the waypoint's {@link World}.
      * However if the name of this waypoint indicates that this is actually a deathmarker
      * then a different texture will be used.
-     * 
+     *
      * Otherwise it will return a globe, a nether or end sphere according to the {@link Environment}.
-     * 
+     *
      * @param name
      *            The name of a waypoint
      * @param environment
      *            The {@link Environment} of the waypoint's {@link World}
-     * 
+     *
      * @return An icon for this waypoint
      */
     @ParametersAreNonnullByDefault
@@ -232,17 +231,17 @@ public class GPSNetwork {
                 menu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
             }
 
-            menu.addItem(2, new CustomItemStack(SlimefunItems.GPS_TRANSMITTER, "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.transmitters"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
+            menu.addItem(2, ItemStackUtil.withNameLoreString(SlimefunItems.GPS_TRANSMITTER, "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.transmitters"), "", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
             menu.addMenuClickHandler(2, (pl, slot, item, action) -> {
                 openTransmitterControlPanel(pl);
                 return false;
             });
 
             int complexity = getNetworkComplexity(p.getUniqueId());
-            menu.addItem(4, new CustomItemStack(SlimefunItems.GPS_CONTROL_PANEL, "&7Network Info", "", "&8\u21E8 &7Status: " + (complexity > 0 ? "&2&lONLINE" : "&4&lOFFLINE"), "&8\u21E8 &7Complexity: &f" + complexity));
+            menu.addItem(4, ItemStackUtil.withNameLoreString(SlimefunItems.GPS_CONTROL_PANEL, "&7Network Info", "", "&8\u21E8 &7Status: " + (complexity > 0 ? "&2&lONLINE" : "&4&lOFFLINE"), "&8\u21E8 &7Complexity: &f" + complexity));
             menu.addMenuClickHandler(4, ChestMenuUtils.getEmptyClickHandler());
 
-            menu.addItem(6, new CustomItemStack(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.waypoints")));
+            menu.addItem(6, ItemStackUtil.withNameString(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), "&7" + Slimefun.getLocalization().getMessage(p, "machines.GPS_CONTROL_PANEL.waypoints")));
             menu.addMenuClickHandler(6, ChestMenuUtils.getEmptyClickHandler());
 
             int index = 0;
@@ -254,7 +253,7 @@ public class GPSNetwork {
                 int slot = inventory[index];
 
                 Location l = waypoint.getLocation();
-                menu.addItem(slot, new CustomItemStack(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""), "&8\u21E8 &7World: &f" + l.getWorld().getName(), "&8\u21E8 &7X: &f" + l.getX(), "&8\u21E8 &7Y: &f" + l.getY(), "&8\u21E8 &7Z: &f" + l.getZ(), "", "&8\u21E8 &cClick to delete"));
+                menu.addItem(slot, ItemStackUtil.withNameLoreString(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""), "&8\u21E8 &7World: &f" + l.getWorld().getName(), "&8\u21E8 &7X: &f" + l.getX(), "&8\u21E8 &7Y: &f" + l.getY(), "&8\u21E8 &7Z: &f" + l.getZ(), "", "&8\u21E8 &cClick to delete"));
                 menu.addMenuClickHandler(slot, (pl, s, item, action) -> {
                     profile.removeWaypoint(waypoint);
                     SoundEffect.GPS_NETWORK_OPEN_PANEL_SOUND.playFor(p);
@@ -273,7 +272,7 @@ public class GPSNetwork {
     /**
      * This method will prompt the given {@link Player} to enter a name for a waypoint.
      * After entering the name, it will be added to his waypoint list.
-     * 
+     *
      * @param p
      *            The {@link Player} who should get a new waypoint
      * @param l
@@ -298,7 +297,7 @@ public class GPSNetwork {
 
     /**
      * This method adds a new waypoint with the given name and {@link Location} for that {@link Player}.
-     * 
+     *
      * @param p
      *            The {@link Player} to get the new waypoint
      * @param name
@@ -343,10 +342,10 @@ public class GPSNetwork {
     /**
      * This method returns a {@link Set} of {@link Location Locations} for all {@link GPSTransmitter Transmitters}
      * owned by the given {@link UUID}.
-     * 
+     *
      * @param uuid
      *            The {@link UUID} owning those transmitters
-     * 
+     *
      * @return A {@link Set} with all {@link Location Locations} of transmitters for this {@link UUID}
      */
     @Nonnull
@@ -357,7 +356,7 @@ public class GPSNetwork {
     /**
      * This returns the {@link TeleportationManager} for this {@link GPSNetwork}.
      * It is responsible for all actions that relate to the {@link Teleporter}.
-     * 
+     *
      * @return The {@link TeleportationManager} for this {@link GPSNetwork}
      */
     @Nonnull
@@ -368,7 +367,7 @@ public class GPSNetwork {
     /**
      * This returns the {@link ResourceManager} for this {@link GPSNetwork}.
      * Use this to access {@link GEOResource GEOResources}.
-     * 
+     *
      * @return The {@link ResourceManager} for this {@link GPSNetwork}
      */
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -18,7 +19,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -34,9 +34,9 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 /**
  * The {@link TeleportationManager} handles the process of teleportation for a {@link Player}
  * who is using a {@link Teleporter}.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see GPSNetwork
  * @see Teleporter
  *
@@ -79,7 +79,7 @@ public final class TeleportationManager {
                     menu.addItem(slot, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
                 }
 
-                menu.addItem(4, new CustomItemStack(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "machines.TELEPORTER.gui.title")));
+                menu.addItem(4, ItemStackUtil.withNameString(HeadTexture.GLOBE_OVERWORLD.getAsItemStack(), ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "machines.TELEPORTER.gui.title")));
                 menu.addMenuClickHandler(4, ChestMenuUtils.getEmptyClickHandler());
 
                 Location source = new Location(b.getWorld(), b.getX() + 0.5D, b.getY() + 2D, b.getZ() + 0.5D);
@@ -107,7 +107,7 @@ public final class TeleportationManager {
                     };
                     // @formatter:on
 
-                    menu.addItem(slot, new CustomItemStack(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""), lore));
+                    menu.addItem(slot, ItemStackUtil.withNameLoreString(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""),lore));
                     menu.addMenuClickHandler(slot, (pl, s, item, action) -> {
                         pl.closeInventory();
                         teleport(pl.getUniqueId(), complexity, source, l, false);
@@ -136,21 +136,21 @@ public final class TeleportationManager {
      * to the destination {@link Location}, given the specified complexity.
      * <p>
      * The returned time will be measured in 500ms intervals.
-     * 
+     *
      * <ul>
      * <li>A returned time of {@literal 100} will mean 50,000ms (50s) of real-life time.</li>
      * <li>A returned time of {@literal 10} will mean 5,000ms (5s) of real-life time.</li>
      * <li>A returned time of {@literal 2} will mean 1,000ms (1s) of real-life time.</li>
      * <li>and so on...</li>
      * </ul>
-     * 
+     *
      * @param complexity
      *            The complexity of the {@link GPSNetwork}
      * @param source
      *            The source {@link Location}
      * @param destination
      *            The destination {@link Location}
-     * 
+     *
      * @return The amount of time the teleportation will take
      */
     public int getTeleportationTime(int complexity, @Nonnull Location source, @Nonnull Location destination) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackEditor;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
@@ -19,7 +20,6 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.LockedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.SeasonalItemGroup;
@@ -30,12 +30,12 @@ import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedItemFlag;
 /**
  * Represents an item group, which structure
  * multiple {@link SlimefunItem} in the {@link SlimefunGuide}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  * @see LockedItemGroup
  * @see SeasonalItemGroup
- * 
+ *
  */
 public class ItemGroup implements Keyed {
 
@@ -51,7 +51,7 @@ public class ItemGroup implements Keyed {
      * Constructs a new {@link ItemGroup} with the given {@link NamespacedKey} as an identifier
      * and the given {@link ItemStack} as its display item.
      * The tier is set to a default value of {@code 3}.
-     * 
+     *
      * @param key
      *            The {@link NamespacedKey} that is used to identify this {@link ItemGroup}
      * @param item
@@ -65,7 +65,7 @@ public class ItemGroup implements Keyed {
     /**
      * Constructs a new {@link ItemGroup} with the given {@link NamespacedKey} as an identifier
      * and the given {@link ItemStack} as its display item.
-     * 
+     *
      * @param key
      *            The {@link NamespacedKey} that is used to identify this {@link ItemGroup}
      * @param item
@@ -101,7 +101,7 @@ public class ItemGroup implements Keyed {
      * <p>
      * By default, an {@link ItemGroup} is automatically registered when
      * a {@link SlimefunItem} was added to it.
-     * 
+     *
      * @param addon
      *            The {@link SlimefunAddon} that wants to register this {@link ItemGroup}
      */
@@ -121,7 +121,7 @@ public class ItemGroup implements Keyed {
     /**
      * This method returns whether this {@link ItemGroup} has been registered yet.
      * More specifically: Whether {@link #register(SlimefunAddon)} was called or not.
-     * 
+     *
      * @return Whether this {@link ItemGroup} has been registered
      */
     public boolean isRegistered() {
@@ -131,7 +131,7 @@ public class ItemGroup implements Keyed {
     /**
      * Returns the tier of this {@link ItemGroup}.
      * The tier determines the position of this {@link ItemGroup} in the {@link SlimefunGuide}.
-     * 
+     *
      * @return the tier of this {@link ItemGroup}
      */
     public int getTier() {
@@ -141,7 +141,7 @@ public class ItemGroup implements Keyed {
     /**
      * This sets the tier of this {@link ItemGroup}.
      * The tier determines the position of this {@link ItemGroup} in the {@link SlimefunGuide}.
-     * 
+     *
      * @param tier
      *            The tier for this {@link ItemGroup}
      */
@@ -165,7 +165,7 @@ public class ItemGroup implements Keyed {
     /**
      * This returns the {@link SlimefunAddon} which has registered this {@link ItemGroup}.
      * Or null if it has not been registered yet.
-     * 
+     *
      * @return The {@link SlimefunAddon} or null if unregistered
      */
     public final @Nullable SlimefunAddon getAddon() {
@@ -174,7 +174,7 @@ public class ItemGroup implements Keyed {
 
     /**
      * Adds the given {@link SlimefunItem} to this {@link ItemGroup}.
-     * 
+     *
      * @param item
      *            the {@link SlimefunItem} that should be added to this {@link ItemGroup}
      */
@@ -195,7 +195,7 @@ public class ItemGroup implements Keyed {
 
     /**
      * Removes the given {@link SlimefunItem} from this {@link ItemGroup}.
-     * 
+     *
      * @param item
      *            the {@link SlimefunItem} that should be removed from this {@link ItemGroup}
      */
@@ -207,34 +207,32 @@ public class ItemGroup implements Keyed {
     /**
      * This method returns a localized display item of this {@link ItemGroup}
      * for the specified {@link Player}.
-     * 
+     *
      * @param p
      *            The Player to create this {@link ItemStack} for
-     * 
+     *
      * @return A localized display item for this {@link ItemGroup}
      */
     public @Nonnull ItemStack getItem(@Nonnull Player p) {
-        return new CustomItemStack(item, meta -> {
-            String name = Slimefun.getLocalization().getItemGroupName(p, getKey());
+        ChatColor color = this instanceof SeasonalItemGroup ? ChatColor.GOLD : ChatColor.YELLOW;
+        List<String> lore = Arrays.asList("", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup"));
 
-            if (name == null) {
-                name = item.getItemMeta().getDisplayName();
-            }
-
-            if (this instanceof SeasonalItemGroup) {
-                meta.setDisplayName(ChatColor.GOLD + name);
-            } else {
-                meta.setDisplayName(ChatColor.YELLOW + name);
-            }
-
-            meta.setLore(Arrays.asList("", ChatColor.GRAY + "\u21E8 " + ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup")));
-        });
+        return new ItemStackEditor()
+                .withLoreString(lore)
+                .withMetaTransform(meta -> {
+                    String name = Slimefun.getLocalization().getItemGroupName(p, getKey());
+                    if (name == null) {
+                        name = item.getItemMeta().getDisplayName();
+                    }
+                    meta.setDisplayName(color + name);
+                })
+                .editCopy(this.item);
     }
 
     /**
      * This method makes Walshy happy.
      * It adds a way to get the name of a {@link ItemGroup} without localization nor coloring.
-     * 
+     *
      * @return The unlocalized name of this {@link ItemGroup}
      */
     public @Nonnull String getUnlocalizedName() {
@@ -244,10 +242,10 @@ public class ItemGroup implements Keyed {
     /**
      * This returns the localized display name of this {@link ItemGroup} for the given {@link Player}.
      * The method will fall back to {@link #getUnlocalizedName()} if no translation was found.
-     * 
+     *
      * @param p
      *            The {@link Player} who to translate the name for
-     * 
+     *
      * @return The localized name of this {@link ItemGroup}
      */
     public @Nonnull String getDisplayName(@Nonnull Player p) {
@@ -262,7 +260,7 @@ public class ItemGroup implements Keyed {
 
     /**
      * Returns all instances of {@link SlimefunItem} bound to this {@link ItemGroup}.
-     * 
+     *
      * @return the list of SlimefunItems bound to this {@link ItemGroup}
      */
     public @Nonnull List<SlimefunItem> getItems() {
@@ -271,10 +269,10 @@ public class ItemGroup implements Keyed {
 
     /**
      * This method returns whether a given {@link SlimefunItem} exists in this {@link ItemGroup}.
-     * 
+     *
      * @param item
      *            The {@link SlimefunItem} to find
-     * 
+     *
      * @return Whether the given {@link SlimefunItem} was found in this {@link ItemGroup}
      */
     public boolean contains(@Nullable SlimefunItem item) {
@@ -286,10 +284,10 @@ public class ItemGroup implements Keyed {
      * by the given {@link Player}. If an {@link ItemGroup} is not accessible,
      * it will not show up in the {@link SlimefunGuide} nor will items from this
      * {@link ItemGroup} show up in the guide search.
-     * 
+     *
      * @param p
      *            The {@link Player} to check for
-     * 
+     *
      * @return Whether this {@link ItemGroup} is accessible by the given {@link Player}
      */
     public boolean isAccessible(@Nonnull Player p) {
@@ -302,10 +300,10 @@ public class ItemGroup implements Keyed {
      * be visible. This includes {@link ItemGroup ItemGroups} where every {@link SlimefunItem}
      * is disabled. If an {@link ItemGroup} is not accessible by the {@link Player},
      * see {@link #isAccessible(Player)}, this method will also return false.
-     * 
+     *
      * @param p
      *            The {@link Player} to check for
-     * 
+     *
      * @return Whether this {@link ItemGroup} is visible to the given {@link Player}
      */
     public boolean isVisible(@Nonnull Player p) {
@@ -372,12 +370,12 @@ public class ItemGroup implements Keyed {
     /**
      * This method checks whether this {@link ItemGroup} will be hidden for the specified
      * {@link Player}.
-     * 
+     *
      * Categories are hidden if all of their items have been disabled.
-     * 
+     *
      * @param p
      *            The {@link Player} to check for
-     * 
+     *
      * @return Whether this {@link ItemGroup} will be hidden to the given {@link Player}
      */
     @Deprecated

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/NestedItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/NestedItemGroup.java
@@ -6,13 +6,13 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.guide.GuideHistory;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
@@ -41,7 +41,7 @@ public class NestedItemGroup extends FlexItemGroup {
 
     /**
      * This will add the given {@link SubItemGroup} to this {@link NestedItemGroup}.
-     * 
+     *
      * @param group
      *            The {@link SubItemGroup} to add.
      */
@@ -53,7 +53,7 @@ public class NestedItemGroup extends FlexItemGroup {
 
     /**
      * This will remove the given {@link SubItemGroup} from this {@link NestedItemGroup} (if present).
-     * 
+     *
      * @param group
      *            The {@link SubItemGroup} to remove.
      */
@@ -90,7 +90,7 @@ public class NestedItemGroup extends FlexItemGroup {
         menu.addMenuOpeningHandler(SoundEffect.GUIDE_BUTTON_CLICK_SOUND::playFor);
         guide.createHeader(p, profile, menu);
 
-        menu.addItem(1, new CustomItemStack(ChestMenuUtils.getBackButton(p, "", ChatColor.GRAY + Slimefun.getLocalization().getMessage(p, "guide.back.guide"))));
+        menu.addItem(1, ItemStackUtil.withLoreString(ChestMenuUtils.getBackButton(p, "", ChatColor.GRAY + Slimefun.getLocalization().getMessage(p, "guide.back.guide"))));
         menu.addMenuClickHandler(1, (pl, s, is, action) -> {
             SlimefunGuide.openMainMenu(profile, mode, history.getMainMenuPage());
             return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/recipes/RecipeType.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/recipes/RecipeType.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
@@ -21,7 +22,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.recipes.MinecraftRecipe;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -34,7 +34,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAlta
 // TODO: Remove this class and rewrite the recipe system
 public class RecipeType implements Keyed {
 
-    public static final RecipeType MULTIBLOCK = new RecipeType(new NamespacedKey(Slimefun.instance(), "multiblock"), new CustomItemStack(Material.BRICKS, "&bMultiBlock", "", "&a&oBuild it in the World"));
+    public static final RecipeType MULTIBLOCK = new RecipeType(new NamespacedKey(Slimefun.instance(), "multiblock"), ItemStackUtil.withNameLoreString(Material.BRICKS, "&bMultiBlock", "", "&a&oBuild it in the World"));
     public static final RecipeType ARMOR_FORGE = new RecipeType(new NamespacedKey(Slimefun.instance(), "armor_forge"), SlimefunItems.ARMOR_FORGE, "", "&a&oCraft it in an Armor Forge");
     public static final RecipeType GRIND_STONE = new RecipeType(new NamespacedKey(Slimefun.instance(), "grind_stone"), SlimefunItems.GRIND_STONE, "", "&a&oGrind it using the Grind Stone");
     public static final RecipeType SMELTERY = new RecipeType(new NamespacedKey(Slimefun.instance(), "smeltery"), SlimefunItems.SMELTERY, "", "&a&oSmelt it using a Smeltery");
@@ -53,9 +53,9 @@ public class RecipeType implements Keyed {
         altar.getRecipes().add(altarRecipe);
     });
 
-    public static final RecipeType MOB_DROP = new RecipeType(new NamespacedKey(Slimefun.instance(), "mob_drop"), new CustomItemStack(Material.IRON_SWORD, "&bMob Drop"), RecipeType::registerMobDrop, "", "&rKill the specified Mob to obtain this Item");
-    public static final RecipeType BARTER_DROP = new RecipeType(new NamespacedKey(Slimefun.instance(), "barter_drop"), new CustomItemStack(Material.GOLD_INGOT, "&bBarter Drop"), RecipeType::registerBarterDrop, "&aBarter with piglins for a chance", "&ato obtain this item");
-    public static final RecipeType INTERACT = new RecipeType(new NamespacedKey(Slimefun.instance(), "interact"), new CustomItemStack(Material.PLAYER_HEAD, "&bInteract", "", "&a&oRight click with this item"));
+    public static final RecipeType MOB_DROP = new RecipeType(new NamespacedKey(Slimefun.instance(), "mob_drop"), ItemStackUtil.withNameString(Material.IRON_SWORD, "&bMob Drop"), RecipeType::registerMobDrop, "", "&rKill the specified Mob to obtain this Item");
+    public static final RecipeType BARTER_DROP = new RecipeType(new NamespacedKey(Slimefun.instance(), "barter_drop"), ItemStackUtil.withNameString(Material.GOLD_INGOT, "&bBarter Drop"), RecipeType::registerBarterDrop, "&aBarter with piglins for a chance", "&ato obtain this item");
+    public static final RecipeType INTERACT = new RecipeType(new NamespacedKey(Slimefun.instance(), "interact"), ItemStackUtil.withNameLoreString(Material.PLAYER_HEAD, "&bInteract", "", "&a&oRight click with this item"));
 
     public static final RecipeType HEATED_PRESSURE_CHAMBER = new RecipeType(new NamespacedKey(Slimefun.instance(), "heated_pressure_chamber"), SlimefunItems.HEATED_PRESSURE_CHAMBER);
     public static final RecipeType FOOD_FABRICATOR = new RecipeType(new NamespacedKey(Slimefun.instance(), "food_fabricator"), SlimefunItems.FOOD_FABRICATOR);
@@ -95,7 +95,7 @@ public class RecipeType implements Keyed {
     }
 
     public RecipeType(NamespacedKey key, ItemStack item, BiConsumer<ItemStack[], ItemStack> callback, String... lore) {
-        this.item = new CustomItemStack(item, null, lore);
+        this.item = ItemStackUtil.withLoreString(item,lore);
         this.key = key;
         this.consumer = callback;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
@@ -12,7 +12,6 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.common.CommonPatterns;
 import io.github.bakedlibs.dough.common.PlayerList;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
 import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
@@ -65,7 +64,7 @@ class GiveCommand extends SubCommand {
 
             if (amount > 0) {
                 Slimefun.getLocalization().sendMessage(p, "messages.given-item", true, msg -> msg.replace(PLACEHOLDER_ITEM, sfItem.getItemName()).replace(PLACEHOLDER_AMOUNT, String.valueOf(amount)));
-                Map<Integer, ItemStack> excess = p.getInventory().addItem(new CustomItemStack(sfItem.getItem(), amount));
+                Map<Integer, ItemStack> excess = p.getInventory().addItem(sfItem.getItem().asQuantity(amount));
                 if (Slimefun.getCfg().getBoolean("options.drop-excess-sf-give-items") && !excess.isEmpty()) {
                     for (ItemStack is : excess.values()) {
                         p.getWorld().dropItem(p.getLocation(), is);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/ContributorsMenu.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/ContributorsMenu.java
@@ -6,13 +6,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 
 import io.github.bakedlibs.dough.common.ChatColors;
 import io.github.bakedlibs.dough.common.CommonPatterns;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.core.services.github.Contributor;
 import io.github.thebusybiscuit.slimefun4.core.services.sounds.SoundEffect;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -24,7 +24,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 
 /**
  * This menu shows a list of every {@link Contributor} to this project.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -40,7 +40,7 @@ final class ContributorsMenu {
 
         ChestMenuUtils.drawBackground(menu, 0, 2, 3, 4, 5, 6, 7, 8, 45, 47, 48, 49, 50, 51, 53);
 
-        menu.addItem(1, new CustomItemStack(ChestMenuUtils.getBackButton(p, "", "&7" + Slimefun.getLocalization().getMessage(p, "guide.back.settings"))));
+        menu.addItem(1, ItemStackUtil.withLoreString(ChestMenuUtils.getBackButton(p, "", "&7" + Slimefun.getLocalization().getMessage(p, "guide.back.settings"))));
         menu.addMenuClickHandler(1, (pl, slot, item, action) -> {
             SlimefunGuideSettings.openSettings(pl, p.getInventory().getItemInMainHand());
             return false;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/FireworksOption.java
@@ -3,13 +3,13 @@ package io.github.thebusybiscuit.slimefun4.core.guide.options;
 import java.util.List;
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.core.SlimefunRegistry;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -38,7 +38,7 @@ class FireworksOption implements SlimefunGuideOption<Boolean> {
             lore.add("");
             lore.add("&7\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.options.fireworks." + optionState + ".click"));
 
-            ItemStack item = new CustomItemStack(Material.FIREWORK_ROCKET, lore);
+            ItemStack item = ItemStackUtil.withLoreString(Material.FIREWORK_ROCKET, lore);
             return Optional.of(item);
         } else {
             return Optional.empty();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/LearningAnimationOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/LearningAnimationOption.java
@@ -5,13 +5,13 @@ import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.core.SlimefunRegistry;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -51,7 +51,7 @@ class LearningAnimationOption implements SlimefunGuideOption<Boolean> {
             lore.add("");
             lore.add("&7\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.options.learning-animation." + optionState + ".click"));
 
-            ItemStack item = new CustomItemStack(enabled ? Material.MAP : Material.PAPER, lore);
+            ItemStack item = ItemStackUtil.withLoreString(enabled ? Material.MAP : Material.PAPER, lore);
             return Optional.of(item);
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/PlayerLanguageOption.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/PlayerLanguageOption.java
@@ -4,13 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerLanguageChangeEvent;
 import io.github.thebusybiscuit.slimefun4.core.services.localization.Language;
@@ -49,7 +49,7 @@ class PlayerLanguageOption implements SlimefunGuideOption<String> {
             lore.add("");
             lore.add("&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.change"));
 
-            ItemStack item = new CustomItemStack(language.getItem(), "&7" + Slimefun.getLocalization().getMessage(p, "guide.languages.selected-language") + " &a" + languageName, lore.toArray(new String[0]));
+            ItemStack item = ItemStackUtil.withNameLoreString(language.getItem(), "&7" + Slimefun.getLocalization().getMessage(p, "guide.languages.selected-language") + " &a" + languageName,lore.toArray(new String[0]));
             return Optional.of(item);
         } else {
             return Optional.empty();
@@ -88,7 +88,7 @@ class PlayerLanguageOption implements SlimefunGuideOption<String> {
                     return false;
                 });
             } else if (i == 7) {
-                menu.addItem(7, new CustomItemStack(SlimefunUtils.getCustomHead(HeadTexture.ADD_NEW_LANGUAGE.getTexture()), Slimefun.getLocalization().getMessage(p, "guide.languages.translations.name"), "", "&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.translations.lore")), (pl, slot, item, action) -> {
+                menu.addItem(7, ItemStackUtil.withNameLoreString(SlimefunUtils.getCustomHead(HeadTexture.ADD_NEW_LANGUAGE.getTexture()), Slimefun.getLocalization().getMessage(p, "guide.languages.translations.name"), "", "&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.translations.lore")), (pl, slot, item, action) -> {
                     ChatUtils.sendURL(pl, "https://github.com/Slimefun/Slimefun4/wiki/Translating-Slimefun");
                     pl.closeInventory();
                     return false;
@@ -101,7 +101,7 @@ class PlayerLanguageOption implements SlimefunGuideOption<String> {
         Language defaultLanguage = Slimefun.getLocalization().getDefaultLanguage();
         String defaultLanguageString = Slimefun.getLocalization().getMessage(p, "languages.default");
 
-        menu.addItem(9, new CustomItemStack(defaultLanguage.getItem(), ChatColor.GRAY + defaultLanguageString + ChatColor.DARK_GRAY + " (" + defaultLanguage.getName(p) + ")", "", "&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.select-default")), (pl, i, item, action) -> {
+        menu.addItem(9, ItemStackUtil.withNameLoreString(defaultLanguage.getItem(), ChatColor.GRAY + defaultLanguageString + ChatColor.DARK_GRAY + " (" + defaultLanguage.getName(p) + ")", "", "&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.select-default")), (pl, i, item, action) -> {
             Slimefun.instance().getServer().getPluginManager().callEvent(new PlayerLanguageChangeEvent(pl, Slimefun.getLocalization().getLanguage(pl), defaultLanguage));
             setSelectedOption(pl, guide, null);
 
@@ -114,7 +114,7 @@ class PlayerLanguageOption implements SlimefunGuideOption<String> {
         int slot = 10;
 
         for (Language language : Slimefun.getLocalization().getLanguages()) {
-            menu.addItem(slot, new CustomItemStack(language.getItem(), ChatColor.GREEN + language.getName(p), "&b" + language.getTranslationProgress() + '%', "", "&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.select")), (pl, i, item, action) -> {
+            menu.addItem(slot, ItemStackUtil.withNameLoreString(language.getItem(), ChatColor.GREEN + language.getName(p), "&b" + language.getTranslationProgress() + '%', "", "&7\u21E8 &e" + Slimefun.getLocalization().getMessage(p, "guide.languages.select")), (pl, i, item, action) -> {
                 Slimefun.instance().getServer().getPluginManager().callEvent(new PlayerLanguageChangeEvent(pl, Slimefun.getLocalization().getLanguage(pl), language));
                 setSelectedOption(pl, guide, language.getId());
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/SlimefunGuideSettings.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/options/SlimefunGuideSettings.java
@@ -7,13 +7,13 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideMode;
@@ -32,11 +32,11 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 /**
  * This static utility class offers various methods that provide access to the
  * Settings menu of our {@link SlimefunGuide}.
- * 
+ *
  * This menu is used to allow a {@link Player} to change things such as the {@link Language}.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see SlimefunGuide
  *
  */
@@ -78,11 +78,8 @@ public final class SlimefunGuideSettings {
         LocalizationService locale = Slimefun.getLocalization();
 
         // @formatter:off
-        menu.addItem(0, new CustomItemStack(SlimefunGuide.getItem(SlimefunGuideMode.SURVIVAL_MODE),
-            "&e\u21E6 " + locale.getMessage(p, "guide.back.title"),
-            "",
-            "&7" + locale.getMessage(p, "guide.back.guide")
-        ));
+        menu.addItem(0, ItemStackUtil.withNameLoreString(SlimefunGuide.getItem(SlimefunGuideMode.SURVIVAL_MODE), "&e\u21E6 " + locale.getMessage(p, "guide.back.title"), "",
+            "&7" + locale.getMessage(p, "guide.back.guide")));
         // @formatter:on
 
         menu.addMenuClickHandler(0, (pl, slot, item, action) -> {
@@ -99,10 +96,7 @@ public final class SlimefunGuideSettings {
         contributorsLore.add("&7\u21E8 &e" + locale.getMessage(p, "guide.credits.open"));
 
         // @formatter:off
-        menu.addItem(2, new CustomItemStack(SlimefunUtils.getCustomHead("e952d2b3f351a6b0487cc59db31bf5f2641133e5ba0006b18576e996a0293e52"),
-            "&c" + locale.getMessage(p, "guide.title.credits"),
-            contributorsLore.toArray(new String[0])
-        ));
+        menu.addItem(2, ItemStackUtil.withNameLoreString(SlimefunUtils.getCustomHead("e952d2b3f351a6b0487cc59db31bf5f2641133e5ba0006b18576e996a0293e52"), "&c" + locale.getMessage(p, "guide.title.credits"),contributorsLore.toArray(new String[0])));
         // @formatter:on
 
         menu.addMenuClickHandler(2, (pl, slot, action, item) -> {
@@ -111,9 +105,7 @@ public final class SlimefunGuideSettings {
         });
 
         // @formatter:off
-        menu.addItem(4, new CustomItemStack(Material.WRITABLE_BOOK, 
-            ChatColor.GREEN + locale.getMessage(p, "guide.title.versions"),
-            "&7&o" + locale.getMessage(p, "guide.tooltips.versions-notice"),
+        menu.addItem(4, ItemStackUtil.withNameLoreString(Material.WRITABLE_BOOK, ChatColor.GREEN + locale.getMessage(p, "guide.title.versions"), "&7&o" + locale.getMessage(p, "guide.tooltips.versions-notice"),
             "",
             "&fMinecraft: &a" + Bukkit.getBukkitVersion(),
             "&fSlimefun: &a" + Slimefun.getVersion()),
@@ -122,9 +114,7 @@ public final class SlimefunGuideSettings {
         // @formatter:on
 
         // @formatter:off
-        menu.addItem(6, new CustomItemStack(Material.COMPARATOR, 
-           "&e" + locale.getMessage(p, "guide.title.source"),
-           "", "&7Last Activity: &a" + NumberUtils.getElapsedTime(github.getLastUpdate()) + " ago",
+        menu.addItem(6, ItemStackUtil.withNameLoreString(Material.COMPARATOR, "&e" + locale.getMessage(p, "guide.title.source"), "", "&7Last Activity: &a" + NumberUtils.getElapsedTime(github.getLastUpdate()) + " ago",
            "&7Forks: &e" + github.getForks(),
            "&7Stars: &e" + github.getStars(),
            "",
@@ -133,8 +123,7 @@ public final class SlimefunGuideSettings {
            "&7&oand if you want to keep this Plugin alive,",
            "&7&othen please consider contributing to it",
            "",
-           "&7\u21E8 &eClick to go to GitHub"
-        ));
+           "&7\u21E8 &eClick to go to GitHub"));
         // @formatter:on
 
         menu.addMenuClickHandler(6, (pl, slot, item, action) -> {
@@ -144,15 +133,12 @@ public final class SlimefunGuideSettings {
         });
 
         // @formatter:off
-        menu.addItem(8, new CustomItemStack(Material.KNOWLEDGE_BOOK,
-            "&3" + locale.getMessage(p, "guide.title.wiki"),
-            "", "&7Do you need help with an Item or machine?",
+        menu.addItem(8, ItemStackUtil.withNameLoreString(Material.KNOWLEDGE_BOOK, "&3" + locale.getMessage(p, "guide.title.wiki"), "", "&7Do you need help with an Item or machine?",
             "&7You cannot figure out what to do?",
             "&7Check out our community-maintained Wiki",
             "&7and become one of our Editors!",
             "",
-            "&7\u21E8 &eClick to go to the official Slimefun Wiki"
-        ));
+            "&7\u21E8 &eClick to go to the official Slimefun Wiki"));
         // @formatter:on
 
         menu.addMenuClickHandler(8, (pl, slot, item, action) -> {
@@ -162,17 +148,14 @@ public final class SlimefunGuideSettings {
         });
 
         // @formatter:off
-        menu.addItem(47, new CustomItemStack(Material.BOOKSHELF,
-            "&3" + locale.getMessage(p, "guide.title.addons"),
-            "",
+        menu.addItem(47, ItemStackUtil.withNameLoreString(Material.BOOKSHELF, "&3" + locale.getMessage(p, "guide.title.addons"), "",
             "&7Slimefun is huge. But its addons are what makes",
             "&7this plugin truly shine. Go check them out, some",
             "&7of them may be exactly what you were missing out on!",
             "",
             "&7Installed on this Server: &b" + Slimefun.getInstalledAddons().size(),
             "",
-            "&7\u21E8 &eClick to see all available addons for Slimefun4"
-        ));
+            "&7\u21E8 &eClick to see all available addons for Slimefun4"));
         // @formatter:on
 
         menu.addMenuClickHandler(47, (pl, slot, item, action) -> {
@@ -183,16 +166,13 @@ public final class SlimefunGuideSettings {
 
         if (Slimefun.getUpdater().getBranch().isOfficial()) {
             // @formatter:off
-            menu.addItem(49, new CustomItemStack(Material.REDSTONE_TORCH,
-                "&4" + locale.getMessage(p, "guide.title.bugs"),
-                "",
+            menu.addItem(49, ItemStackUtil.withNameLoreString(Material.REDSTONE_TORCH, "&4" + locale.getMessage(p, "guide.title.bugs"), "",
                 "&7&oBug reports have to be made in English!",
                 "",
                 "&7Open Issues: &a" + github.getOpenIssues(),
                 "&7Pending Pull Requests: &a" + github.getPendingPullRequests(),
                 "",
-                "&7\u21E8 &eClick to go to the Slimefun4 Bug Tracker"
-            ));
+                "&7\u21E8 &eClick to go to the Slimefun4 Bug Tracker"));
             // @formatter:on
 
             menu.addMenuClickHandler(49, (pl, slot, item, action) -> {
@@ -204,7 +184,7 @@ public final class SlimefunGuideSettings {
             menu.addItem(49, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        menu.addItem(51, new CustomItemStack(Material.TOTEM_OF_UNDYING, ChatColor.RED + locale.getMessage(p, "guide.work-in-progress")), (pl, slot, item, action) -> {
+        menu.addItem(51, ItemStackUtil.withNameString(Material.TOTEM_OF_UNDYING, ChatColor.RED + locale.getMessage(p, "guide.work-in-progress")), (pl, slot, item, action) -> {
             // Add something here
             return false;
         });
@@ -233,10 +213,10 @@ public final class SlimefunGuideSettings {
      * This method checks if the given {@link Player} has enabled the {@link FireworksOption}
      * in their {@link SlimefunGuide}.
      * If they enabled this setting, they will see fireworks when they unlock a {@link Research}.
-     * 
+     *
      * @param p
      *            The {@link Player}
-     * 
+     *
      * @return Whether this {@link Player} wants to see fireworks when unlocking a {@link Research}
      */
     public static boolean hasFireworksEnabled(@Nonnull Player p) {
@@ -271,7 +251,7 @@ public final class SlimefunGuideSettings {
      *            Type of the {@link SlimefunGuideOption}
      * @param <V>
      *            Type of the {@link SlimefunGuideOption} value
-     * 
+     *
      * @return The value of given {@link SlimefunGuideOption}
      */
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackEditor;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
@@ -25,7 +26,6 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.common.ChatColors;
 import io.github.bakedlibs.dough.config.Config;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -68,7 +68,7 @@ public abstract class SlimefunLocalization implements Keyed {
      * This returns the chat prefix for our messages.
      * Every message (unless explicitly omitted) will have this
      * prefix prepended.
-     * 
+     *
      * @return The chat prefix
      */
     public @Nonnull String getChatPrefix() {
@@ -321,25 +321,21 @@ public abstract class SlimefunLocalization implements Keyed {
         Language language = getLanguage(p);
         NamespacedKey key = recipeType.getKey();
 
-        return new CustomItemStack(item, meta -> {
-            String displayName = getStringOrNull(language, LanguageFile.RECIPES, key.getNamespace() + "." + key.getKey() + ".name");
+        String displayName = getStringOrNull(language, LanguageFile.RECIPES, key.getNamespace() + "." + key.getKey() + ".name");
+        List<String> lore = getStringListOrNull(language, LanguageFile.RECIPES, key.getNamespace() + "." + key.getKey() + ".lore");
 
+        ItemStackEditor editor = new ItemStackEditor();
+
+        if (displayName != null) {
             // Set the display name if possible, else keep the default item name.
-            if (displayName != null) {
-                meta.setDisplayName(ChatColor.AQUA + displayName);
-            }
-
-            List<String> lore = getStringListOrNull(language, LanguageFile.RECIPES, key.getNamespace() + "." + key.getKey() + ".lore");
-
-            // Set the lore if possible, else keep the default lore.
-            if (lore != null) {
-                lore.replaceAll(line -> ChatColor.GRAY + line);
-                meta.setLore(lore);
-            }
-
-            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        });
+            editor.withNameString(ChatColor.AQUA + displayName);
+        }
+        // Set the lore if possible, else keep the default lore.
+        if (lore != null) {
+            lore.replaceAll(line -> ChatColor.GRAY + line);
+            editor.withLoreString(lore);
+        }
+        return editor.withAdditionalFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS).editCopy(item);
     }
 
     public void sendMessage(@Nonnull CommandSender recipient, @Nonnull String key, boolean addPrefix) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -640,19 +640,19 @@ public final class SlimefunItems {
     public static final SlimefunItemStack SOULBOUND_BOOTS = new SlimefunItemStack("SOULBOUND_BOOTS", Material.DIAMOND_BOOTS, "&cSoulbound Boots");
 
     /* Runes */
-    public static final SlimefunItemStack BLANK_RUNE = new SlimefunItemStack("BLANK_RUNE", new ColoredFireworkStar(Color.BLACK, "&8Blank Rune"));
+    public static final SlimefunItemStack BLANK_RUNE = new SlimefunItemStack("BLANK_RUNE", ColoredFireworkStar.createItem(Color.BLACK, "&8Blank Rune"));
 
-    public static final SlimefunItemStack AIR_RUNE = new SlimefunItemStack("ANCIENT_RUNE_AIR", new ColoredFireworkStar(Color.AQUA, "&7Ancient Rune &8&l[&b&lAir&8&l]"));
-    public static final SlimefunItemStack WATER_RUNE = new SlimefunItemStack("ANCIENT_RUNE_WATER", new ColoredFireworkStar(Color.BLUE, "&7Ancient Rune &8&l[&1&lWater&8&l]"));
-    public static final SlimefunItemStack FIRE_RUNE = new SlimefunItemStack("ANCIENT_RUNE_FIRE", new ColoredFireworkStar(Color.RED, "&7Ancient Rune &8&l[&4&lFire&8&l]"));
-    public static final SlimefunItemStack EARTH_RUNE = new SlimefunItemStack("ANCIENT_RUNE_EARTH", new ColoredFireworkStar(Color.fromRGB(112, 47, 7), "&7Ancient Rune &8&l[&c&lEarth&8&l]"));
-    public static final SlimefunItemStack ENDER_RUNE = new SlimefunItemStack("ANCIENT_RUNE_ENDER", new ColoredFireworkStar(Color.PURPLE, "&7Ancient Rune &8&l[&5&lEnder&8&l]"));
+    public static final SlimefunItemStack AIR_RUNE = new SlimefunItemStack("ANCIENT_RUNE_AIR", ColoredFireworkStar.createItem(Color.AQUA, "&7Ancient Rune &8&l[&b&lAir&8&l]"));
+    public static final SlimefunItemStack WATER_RUNE = new SlimefunItemStack("ANCIENT_RUNE_WATER", ColoredFireworkStar.createItem(Color.BLUE, "&7Ancient Rune &8&l[&1&lWater&8&l]"));
+    public static final SlimefunItemStack FIRE_RUNE = new SlimefunItemStack("ANCIENT_RUNE_FIRE", ColoredFireworkStar.createItem(Color.RED, "&7Ancient Rune &8&l[&4&lFire&8&l]"));
+    public static final SlimefunItemStack EARTH_RUNE = new SlimefunItemStack("ANCIENT_RUNE_EARTH", ColoredFireworkStar.createItem(Color.fromRGB(112, 47, 7), "&7Ancient Rune &8&l[&c&lEarth&8&l]"));
+    public static final SlimefunItemStack ENDER_RUNE = new SlimefunItemStack("ANCIENT_RUNE_ENDER", ColoredFireworkStar.createItem(Color.PURPLE, "&7Ancient Rune &8&l[&5&lEnder&8&l]"));
 
-    public static final SlimefunItemStack RAINBOW_RUNE = new SlimefunItemStack("ANCIENT_RUNE_RAINBOW", new ColoredFireworkStar(Color.FUCHSIA, "&7Ancient Rune &8&l[&d&lRainbow&8&l]"));
-    public static final SlimefunItemStack LIGHTNING_RUNE = new SlimefunItemStack("ANCIENT_RUNE_LIGHTNING", new ColoredFireworkStar(Color.fromRGB(255, 255, 95), "&7Ancient Rune &8&l[&e&lLightning&8&l]"));
-    public static final SlimefunItemStack SOULBOUND_RUNE = new SlimefunItemStack("ANCIENT_RUNE_SOULBOUND", new ColoredFireworkStar(Color.fromRGB(47, 0, 117), "&7Ancient Rune &8&l[&5&lSoulbound&8&l]", "&eDrop this rune onto a dropped item to", "&5bind &ethat item to your soul.", " ", "&eIt is advised that you only use this rune", "&eon &6important &eitems.", " ", "&eItems bound to your soul won't drop on death."));
-    public static final SlimefunItemStack ENCHANTMENT_RUNE = new SlimefunItemStack("ANCIENT_RUNE_ENCHANTMENT", new ColoredFireworkStar(Color.fromRGB(255, 217, 25), "&7Ancient Rune &8&l[&6&lEnchantment&8&l]", "&eDrop this rune onto a dropped item to", "&6enchant &ethat item with a random enchantment."));
-    public static final SlimefunItemStack VILLAGER_RUNE = new SlimefunItemStack("ANCIENT_RUNE_VILLAGERS", new ColoredFireworkStar(Color.fromRGB(160, 20, 5), "&7Ancient Rune &8&l[&4&lVillagers&8&l]", "&eRight click a villager to clear", "&etheir current job and trades.", "&eThe villager will start looking", "&efor a job again after some", "&etime has passed."));
+    public static final SlimefunItemStack RAINBOW_RUNE = new SlimefunItemStack("ANCIENT_RUNE_RAINBOW", ColoredFireworkStar.createItem(Color.FUCHSIA, "&7Ancient Rune &8&l[&d&lRainbow&8&l]"));
+    public static final SlimefunItemStack LIGHTNING_RUNE = new SlimefunItemStack("ANCIENT_RUNE_LIGHTNING", ColoredFireworkStar.createItem(Color.fromRGB(255, 255, 95), "&7Ancient Rune &8&l[&e&lLightning&8&l]"));
+    public static final SlimefunItemStack SOULBOUND_RUNE = new SlimefunItemStack("ANCIENT_RUNE_SOULBOUND", ColoredFireworkStar.createItem(Color.fromRGB(47, 0, 117), "&7Ancient Rune &8&l[&5&lSoulbound&8&l]", "&eDrop this rune onto a dropped item to", "&5bind &ethat item to your soul.", " ", "&eIt is advised that you only use this rune", "&eon &6important &eitems.", " ", "&eItems bound to your soul won't drop on death."));
+    public static final SlimefunItemStack ENCHANTMENT_RUNE = new SlimefunItemStack("ANCIENT_RUNE_ENCHANTMENT", ColoredFireworkStar.createItem(Color.fromRGB(255, 217, 25), "&7Ancient Rune &8&l[&6&lEnchantment&8&l]", "&eDrop this rune onto a dropped item to", "&6enchant &ethat item with a random enchantment."));
+    public static final SlimefunItemStack VILLAGER_RUNE = new SlimefunItemStack("ANCIENT_RUNE_VILLAGERS", ColoredFireworkStar.createItem(Color.fromRGB(160, 20, 5), "&7Ancient Rune &8&l[&4&lVillagers&8&l]", "&eRight click a villager to clear", "&etheir current job and trades.", "&eThe villager will start looking", "&efor a job again after some", "&etime has passed."));
 
     /* Electricity */
     public static final SlimefunItemStack SOLAR_GENERATOR = new SlimefunItemStack("SOLAR_GENERATOR", Material.DAYLIGHT_DETECTOR, "&bSolar Generator", "", LoreBuilder.machine(MachineTier.BASIC, MachineType.GENERATOR), LoreBuilder.powerBuffer(0), LoreBuilder.powerPerSecond(4));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -18,7 +19,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.Vector;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSpawnReason;
@@ -40,11 +40,11 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
  * The {@link AncientPedestal} is a part of the {@link AncientAltar}.
  * You can place any {@link ItemStack} onto the {@link AncientPedestal} to provide it to
  * the altar as a crafting ingredient.
- * 
+ *
  * @author Redemption198
  * @author TheBusyBiscuit
  * @author JustAHuman
- * 
+ *
  * @see AncientAltar
  * @see AncientAltarListener
  * @see AncientAltarTask
@@ -68,7 +68,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
             public void onBlockBreak(@Nonnull Block b) {
                 Optional<Item> entity = getPlacedItem(b);
                 ArmorStand armorStand = getArmorStand(b, false);
-                
+
                 if (entity.isPresent()) {
                     Item stack = entity.get();
 
@@ -78,7 +78,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
                         stack.remove();
                     }
                 }
-                
+
                 if (armorStand != null && armorStand.isValid()) {
                     armorStand.remove();
                 }
@@ -102,21 +102,21 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
 
         return Optional.empty();
     }
-    
+
     public @Nullable ArmorStand getArmorStand(@Nonnull Block pedestal, boolean createIfNoneExists) {
         Optional<Item> entity = getPlacedItem(pedestal);
-        
+
         if (entity.isPresent() && entity.get().getVehicle() instanceof ArmorStand armorStand) {
             return armorStand;
         }
-    
+
         Location l = pedestal.getLocation().add(0.5, 1.2, 0.5);
         for (Entity n : l.getWorld().getNearbyEntities(l, 0.5, 0.5, 0.5, this::testArmorStand)) {
             if (n instanceof ArmorStand armorStand) {
                 return armorStand;
             }
         }
-        
+
         return createIfNoneExists ? ArmorStandUtils.spawnArmorStand(l) : null;
     }
 
@@ -129,7 +129,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
             return false;
         }
     }
-    
+
     private boolean testArmorStand(@Nullable Entity n) {
         if (n instanceof ArmorStand && n.isValid()) {
             String customName = n.getCustomName();
@@ -157,7 +157,7 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
     public void placeItem(@Nonnull Player p, @Nonnull Block b) {
         ItemStack hand = p.getInventory().getItemInMainHand();
         String displayName = ITEM_PREFIX + System.nanoTime();
-        ItemStack displayItem = new CustomItemStack(hand, displayName);
+        ItemStack displayItem = ItemStackUtil.withNameString(hand, displayName);
         displayItem.setAmount(1);
 
         // Get the display name of the original Item in the Player's hand

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/AndroidFuelSource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/AndroidFuelSource.java
@@ -2,14 +2,14 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.androids;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
 
 /**
  * This enum covers all different fuel sources a {@link ProgrammableAndroid} can have.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -38,12 +38,12 @@ public enum AndroidFuelSource {
 
     /**
      * This returns a display {@link ItemStack} for this {@link AndroidFuelSource}.
-     * 
+     *
      * @return An {@link ItemStack} to display
      */
     @Nonnull
     public ItemStack getItem() {
-        return new CustomItemStack(HeadTexture.GENERATOR.getAsItemStack(), "&8\u21E9 &cFuel Input &8\u21E9", lore);
+        return ItemStackUtil.withNameLoreString(HeadTexture.GENERATOR.getAsItemStack(), "&8\u21E9 &cFuel Input &8\u21E9",lore);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -10,6 +10,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -32,7 +33,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import io.github.bakedlibs.dough.chat.ChatInput;
 import io.github.bakedlibs.dough.common.ChatColors;
 import io.github.bakedlibs.dough.common.CommonPatterns;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.bakedlibs.dough.skins.PlayerHead;
 import io.github.bakedlibs.dough.skins.PlayerSkin;
@@ -102,7 +102,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
             @Override
             public void newInstance(BlockMenu menu, Block b) {
-                menu.replaceExistingItem(15, new CustomItemStack(HeadTexture.SCRIPT_START.getAsItemStack(), "&aStart/Continue"));
+                menu.replaceExistingItem(15, ItemStackUtil.withNameString(HeadTexture.SCRIPT_START.getAsItemStack(), "&aStart/Continue"));
                 menu.addMenuClickHandler(15, (p, slot, item, action) -> {
                     Slimefun.getLocalization().sendMessage(p, "android.started", true);
                     BlockStorage.addBlockInfo(b, "paused", "false");
@@ -110,14 +110,14 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                     return false;
                 });
 
-                menu.replaceExistingItem(17, new CustomItemStack(HeadTexture.SCRIPT_PAUSE.getAsItemStack(), "&4Pause"));
+                menu.replaceExistingItem(17, ItemStackUtil.withNameString(HeadTexture.SCRIPT_PAUSE.getAsItemStack(), "&4Pause"));
                 menu.addMenuClickHandler(17, (p, slot, item, action) -> {
                     BlockStorage.addBlockInfo(b, "paused", "true");
                     Slimefun.getLocalization().sendMessage(p, "android.stopped", true);
                     return false;
                 });
 
-                menu.replaceExistingItem(16, new CustomItemStack(HeadTexture.ENERGY_REGULATOR.getAsItemStack(), "&bMemory Core", "", "&8\u21E8 &7Click to open the Script Editor"));
+                menu.replaceExistingItem(16, ItemStackUtil.withNameLoreString(HeadTexture.ENERGY_REGULATOR.getAsItemStack(), "&bMemory Core", "", "&8\u21E8 &7Click to open the Script Editor"));
                 menu.addMenuClickHandler(16, (p, slot, item, action) -> {
                     BlockStorage.addBlockInfo(b, "paused", "true");
                     Slimefun.getLocalization().sendMessage(p, "android.stopped", true);
@@ -189,7 +189,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
     /**
      * This returns the {@link AndroidType} that is associated with this {@link ProgrammableAndroid}.
-     * 
+     *
      * @return The type of this {@link ProgrammableAndroid}
      */
     public AndroidType getAndroidType() {
@@ -199,7 +199,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
     /**
      * This returns the {@link AndroidFuelSource} for this {@link ProgrammableAndroid}.
      * It determines what kind of fuel is required to run it.
-     * 
+     *
      * @return The required type of fuel
      */
     public AndroidFuelSource getFuelSource() {
@@ -236,7 +236,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         ChestMenu menu = new ChestMenu(ChatColor.DARK_AQUA + Slimefun.getLocalization().getMessage(p, "android.scripts.editor"));
         menu.setEmptySlotsClickable(false);
 
-        menu.addItem(0, new CustomItemStack(Instruction.START.getItem(), Slimefun.getLocalization().getMessage(p, "android.scripts.instructions.START"), "", "&7\u21E8 &eLeft Click &7to return to the Android's interface"));
+        menu.addItem(0, ItemStackUtil.withNameLoreString(Instruction.START.getItem(), Slimefun.getLocalization().getMessage(p, "android.scripts.instructions.START"), "", "&7\u21E8 &eLeft Click &7to return to the Android's interface"));
         menu.addMenuClickHandler(0, (pl, slot, item, action) -> {
             BlockMenu inv = BlockStorage.getInventory(b);
             // Fixes #2937
@@ -257,7 +257,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                 boolean hasFreeSlot = script.length < 54;
 
                 if (hasFreeSlot) {
-                    menu.addItem(i, new CustomItemStack(HeadTexture.SCRIPT_NEW.getAsItemStack(), "&7> Add new Command"));
+                    menu.addItem(i, ItemStackUtil.withNameString(HeadTexture.SCRIPT_NEW.getAsItemStack(), "&7> Add new Command"));
                     menu.addMenuClickHandler(i, (pl, slot, item, action) -> {
                         editInstruction(pl, b, script, index);
                         return false;
@@ -265,7 +265,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                 }
 
                 int slot = i + (hasFreeSlot ? 1 : 0);
-                menu.addItem(slot, new CustomItemStack(Instruction.REPEAT.getItem(), Slimefun.getLocalization().getMessage(p, "android.scripts.instructions.REPEAT"), "", "&7\u21E8 &eLeft Click &7to return to the Android's interface"));
+                menu.addItem(slot, ItemStackUtil.withNameLoreString(Instruction.REPEAT.getItem(), Slimefun.getLocalization().getMessage(p, "android.scripts.instructions.REPEAT"), "", "&7\u21E8 &eLeft Click &7to return to the Android's interface"));
                 menu.addMenuClickHandler(slot, (pl, s, item, action) -> {
                     BlockMenu inv = BlockStorage.getInventory(b);
                     // Fixes #2937
@@ -285,7 +285,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
                 }
 
                 ItemStack stack = instruction.getItem();
-                menu.addItem(i, new CustomItemStack(stack, Slimefun.getLocalization().getMessage(p, "android.scripts.instructions." + instruction.name()), "", "&7\u21E8 &eLeft Click &7to edit", "&7\u21E8 &eRight Click &7to delete", "&7\u21E8 &eShift + Right Click &7to duplicate"));
+                menu.addItem(i, ItemStackUtil.withNameLoreString(stack, Slimefun.getLocalization().getMessage(p, "android.scripts.instructions." + instruction.name()), "", "&7\u21E8 &eLeft Click &7to edit", "&7\u21E8 &eRight Click &7to delete", "&7\u21E8 &eShift + Right Click &7to duplicate"));
                 menu.addMenuClickHandler(i, (pl, slot, item, action) -> {
                     if (action.isRightClicked() && action.isShiftClicked()) {
                         if (script.length == 54) {
@@ -392,7 +392,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
             return false;
         });
 
-        menu.addItem(48, new CustomItemStack(HeadTexture.SCRIPT_UP.getAsItemStack(), "&eUpload a Script", "", "&6Click &7to upload your Android's Script", "&7to the Server's database"));
+        menu.addItem(48, ItemStackUtil.withNameLoreString(HeadTexture.SCRIPT_UP.getAsItemStack(), "&eUpload a Script", "", "&6Click &7to upload your Android's Script", "&7to the Server's database"));
         menu.addMenuClickHandler(48, (pl, slot, item, action) -> {
             uploadScript(pl, b, page);
             return false;
@@ -410,7 +410,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
             return false;
         });
 
-        menu.addItem(53, new CustomItemStack(HeadTexture.SCRIPT_LEFT.getAsItemStack(), "&6> Back", "", "&7Return to the Android's interface"));
+        menu.addItem(53, ItemStackUtil.withNameLoreString(HeadTexture.SCRIPT_LEFT.getAsItemStack(), "&6> Back", "", "&7Return to the Android's interface"));
         menu.addMenuClickHandler(53, (pl, slot, item, action) -> {
             openScriptEditor(pl, b);
             return false;
@@ -487,7 +487,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         ChestMenu menu = new ChestMenu(ChatColor.DARK_AQUA + Slimefun.getLocalization().getMessage(p, "android.scripts.editor"));
         menu.setEmptySlotsClickable(false);
 
-        menu.addItem(1, new CustomItemStack(HeadTexture.SCRIPT_FORWARD.getAsItemStack(), "&2> Edit Script", "", "&aEdits your current Script"));
+        menu.addItem(1, ItemStackUtil.withNameLoreString(HeadTexture.SCRIPT_FORWARD.getAsItemStack(), "&2> Edit Script", "", "&aEdits your current Script"));
         menu.addMenuClickHandler(1, (pl, slot, item, action) -> {
             String script = BlockStorage.getLocationInfo(b.getLocation()).getString("script");
             // Fixes #2937
@@ -504,19 +504,19 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
             return false;
         });
 
-        menu.addItem(3, new CustomItemStack(HeadTexture.SCRIPT_NEW.getAsItemStack(), "&4> Create new Script", "", "&cDeletes your current Script", "&cand creates a blank one"));
+        menu.addItem(3, ItemStackUtil.withNameLoreString(HeadTexture.SCRIPT_NEW.getAsItemStack(), "&4> Create new Script", "", "&cDeletes your current Script", "&cand creates a blank one"));
         menu.addMenuClickHandler(3, (pl, slot, item, action) -> {
             openScript(pl, b, DEFAULT_SCRIPT);
             return false;
         });
 
-        menu.addItem(5, new CustomItemStack(HeadTexture.SCRIPT_DOWN.getAsItemStack(), "&6> Download a Script", "", "&eDownload a Script from the Server", "&eYou can edit or simply use it"));
+        menu.addItem(5, ItemStackUtil.withNameLoreString(HeadTexture.SCRIPT_DOWN.getAsItemStack(), "&6> Download a Script", "", "&eDownload a Script from the Server", "&eYou can edit or simply use it"));
         menu.addMenuClickHandler(5, (pl, slot, item, action) -> {
             openScriptDownloader(pl, b, 1);
             return false;
         });
 
-        menu.addItem(8, new CustomItemStack(HeadTexture.SCRIPT_LEFT.getAsItemStack(), "&6> Back", "", "&7Return to the Android's interface"));
+        menu.addItem(8, ItemStackUtil.withNameLoreString(HeadTexture.SCRIPT_LEFT.getAsItemStack(), "&6> Back", "", "&7Return to the Android's interface"));
         menu.addMenuClickHandler(8, (pl, slot, item, action) -> {
             BlockMenu inv = BlockStorage.getInventory(b);
             // Fixes #2937
@@ -553,7 +553,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
         ChestMenuUtils.drawBackground(menu, 0, 1, 2, 3, 4, 5, 6, 7, 8);
 
         menu.setEmptySlotsClickable(false);
-        menu.addItem(9, new CustomItemStack(HeadTexture.SCRIPT_PAUSE.getAsItemStack(), "&fDo nothing"), (pl, slot, item, action) -> {
+        menu.addItem(9, ItemStackUtil.withNameString(HeadTexture.SCRIPT_PAUSE.getAsItemStack(), "&fDo nothing"), (pl, slot, item, action) -> {
             String code = deleteInstruction(script, index);
             setScript(b.getLocation(), code);
             openScript(p, b, code);
@@ -562,7 +562,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
         int i = 10;
         for (Instruction instruction : getValidScriptInstructions()) {
-            menu.addItem(i, new CustomItemStack(instruction.getItem(), Slimefun.getLocalization().getMessage(p, "android.scripts.instructions." + instruction.name())), (pl, slot, item, action) -> {
+            menu.addItem(i, ItemStackUtil.withNameString(instruction.getItem(), Slimefun.getLocalization().getMessage(p, "android.scripts.instructions." + instruction.name())), (pl, slot, item, action) -> {
                 String code = addInstruction(script, index, instruction);
                 setScript(b.getLocation(), code);
                 openScript(p, b, code);
@@ -808,7 +808,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
             if (rest > 0) {
                 int amount = newFuel.getAmount() > rest ? rest : newFuel.getAmount();
-                menu.replaceExistingItem(43, new CustomItemStack(newFuel, currentFuel.getAmount() + amount));
+                menu.replaceExistingItem(43, newFuel.asQuantity(currentFuel.getAmount() + amount));
                 ItemUtils.consumeItem(newFuel, amount, false);
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Script.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Script.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -20,14 +21,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.config.Config;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 
 /**
  * A {@link Script} represents runnable code for a {@link ProgrammableAndroid}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -40,7 +40,7 @@ public final class Script {
 
     /**
      * This constructs a new {@link Script} from the given {@link Config}.
-     * 
+     *
      * @param config
      *            The {@link Config}
      */
@@ -64,7 +64,7 @@ public final class Script {
 
     /**
      * This returns the name of this {@link Script}.
-     * 
+     *
      * @return The name
      */
     @Nonnull
@@ -75,7 +75,7 @@ public final class Script {
     /**
      * This returns the author of this {@link Script}.
      * The author is the person who initially created and uploaded this {@link Script}.
-     * 
+     *
      * @return The author of this {@link Script}
      */
     @Nonnull
@@ -87,7 +87,7 @@ public final class Script {
      * This method returns the actual code of this {@link Script}.
      * It is basically a {@link String} describing the order of {@link Instruction Instructions} that
      * shall be executed.
-     * 
+     *
      * @return The code for this {@link Script}
      */
     @Nonnull
@@ -98,10 +98,10 @@ public final class Script {
     /**
      * This method determines whether the given {@link OfflinePlayer} is the author of
      * this {@link Script}.
-     * 
+     *
      * @param p
      *            The {@link OfflinePlayer} to check for
-     * 
+     *
      * @return Whether the given {@link OfflinePlayer} is the author of this {@link Script}.
      */
     public boolean isAuthor(@Nonnull OfflinePlayer p) {
@@ -111,10 +111,10 @@ public final class Script {
     /**
      * This method checks whether a given {@link Player} is able to leave a rating for this {@link Script}.
      * A {@link Player} is unable to rate his own {@link Script} or a {@link Script} he already rated before.
-     * 
+     *
      * @param p
      *            The {@link Player} to check for
-     * 
+     *
      * @return Whether the given {@link Player} is able to rate this {@link Script}
      */
     public boolean canRate(@Nonnull Player p) {
@@ -145,7 +145,7 @@ public final class Script {
             lore.add("&eShift + Right Click &fto leave a negative Rating");
         }
 
-        return new CustomItemStack(android.getItem(), "&b" + getName(), lore.toArray(new String[0]));
+        return ItemStackUtil.withNameLoreString(android.getItem(), "&b" + getName(),lore.toArray(new String[0]));
     }
 
     @Nonnull
@@ -156,7 +156,7 @@ public final class Script {
 
     /**
      * This method returns the amount of upvotes this {@link Script} has received.
-     * 
+     *
      * @return The amount of upvotes
      */
     public int getUpvotes() {
@@ -165,7 +165,7 @@ public final class Script {
 
     /**
      * This method returns the amount of downvotes this {@link Script} has received.
-     * 
+     *
      * @return The amount of downvotes
      */
     public int getDownvotes() {
@@ -174,7 +174,7 @@ public final class Script {
 
     /**
      * This returns how often this {@link Script} has been downloaded.
-     * 
+     *
      * @return The amount of downloads for this {@link Script}.
      */
     public int getDownloads() {
@@ -184,7 +184,7 @@ public final class Script {
     /**
      * This returns the "rating" of this {@link Script}.
      * This value is calculated from the up- and downvotes this {@link Script} received.
-     * 
+     *
      * @return The rating for this {@link Script}
      */
     public float getRating() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -24,7 +25,6 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -52,9 +52,9 @@ import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 
 /**
  * This is the abstract super class for our auto crafters.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see VanillaAutoCrafter
  * @see EnhancedAutoCrafter
  *
@@ -117,7 +117,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * <p>
      * Do not call this method directly, see our {@link AutoCrafterListener} for the intended
      * use case.
-     * 
+     *
      * @param b
      *            The {@link Block} that was clicked
      * @param p
@@ -153,7 +153,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
     /**
      * This method performs one tick for the {@link AbstractAutoCrafter}.
-     * 
+     *
      * @param b
      *            The block for this {@link AbstractAutoCrafter}
      * @param data
@@ -192,10 +192,10 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * where the Auto Crafter could be placed upon.
      * Right now this only supports chests and a few select tile entities but it can change or
      * be overridden in the future.
-     * 
+     *
      * @param block
      *            The {@link Block} to check
-     * 
+     *
      * @return Whether that {@link Block} has a valid {@link Inventory}
      */
     protected boolean isValidInventory(@Nonnull Block block) {
@@ -207,10 +207,10 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
     /**
      * This method returns the currently selected {@link AbstractRecipe} for the given
      * {@link Block}.
-     * 
+     *
      * @param b
      *            The {@link Block}
-     * 
+     *
      * @return The currently selected {@link AbstractRecipe} or null
      */
     @Nullable
@@ -220,7 +220,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * This method is called when a {@link Player} right clicks the {@link AbstractAutoCrafter}
      * while holding the shift button.
      * Use it to choose the {@link AbstractRecipe}.
-     * 
+     *
      * @param b
      *            The {@link Block} which was clicked
      * @param p
@@ -231,7 +231,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
     /**
      * This method sets the selected {@link AbstractRecipe} for the given {@link Block}.
      * The recipe will be stored using the {@link PersistentDataAPI}.
-     * 
+     *
      * @param b
      *            The {@link Block} to store the data on
      * @param recipe
@@ -264,7 +264,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
     /**
      * This shows the given {@link AbstractRecipe} to the {@link Player} in a preview window.
-     * 
+     *
      * @param p
      *            The {@link Player}
      * @param b
@@ -286,7 +286,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
         ChestMenuUtils.drawBackground(menu, 45, 46, 47, 48, 50, 51, 52, 53);
 
         if (recipe.isEnabled()) {
-            menu.addItem(49, new CustomItemStack(Material.BARRIER, Slimefun.getLocalization().getMessages(p, "messages.auto-crafting.tooltips.enabled")));
+            menu.addItem(49, ItemStackUtil.withLoreString(Material.BARRIER, Slimefun.getLocalization().getMessages(p, "messages.auto-crafting.tooltips.enabled")));
             menu.addMenuClickHandler(49, (pl, item, slot, action) -> {
                 if (action.isRightClicked()) {
                     deleteRecipe(pl, b);
@@ -297,7 +297,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
                 return false;
             });
         } else {
-            menu.addItem(49, new CustomItemStack(HeadTexture.EXCLAMATION_MARK.getAsItemStack(), Slimefun.getLocalization().getMessages(p, "messages.auto-crafting.tooltips.disabled")));
+            menu.addItem(49, ItemStackUtil.withLoreString(HeadTexture.EXCLAMATION_MARK.getAsItemStack(), Slimefun.getLocalization().getMessages(p, "messages.auto-crafting.tooltips.disabled")));
             menu.addMenuClickHandler(49, (pl, item, slot, action) -> {
                 if (action.isRightClicked()) {
                     deleteRecipe(pl, b);
@@ -350,12 +350,12 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
     /**
      * This method checks whether the given {@link Predicate} matches the provided {@link ItemStack}.
-     * 
+     *
      * @param item
      *            The {@link ItemStack} to check
      * @param predicate
      *            The {@link Predicate}
-     * 
+     *
      * @return Whether the {@link Predicate} matches the {@link ItemStack}
      */
     @ParametersAreNonnullByDefault
@@ -390,12 +390,12 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * the given {@link Inventory}.
      * This will consume items and add the result to the {@link Inventory}.
      * This method does not handle energy consumption.
-     * 
+     *
      * @param inv
      *            The {@link Inventory} to take resources from
      * @param recipe
      *            The {@link AbstractRecipe} to craft
-     * 
+     *
      * @return Whether this crafting operation was successful or not
      */
     public boolean craft(@Nonnull Inventory inv, @Nonnull AbstractRecipe recipe) {
@@ -461,10 +461,10 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * However we cannot use this method as it is only available in the latest 1.16 snapshots
      * of Spigot, not even on earlier 1.16 builds...
      * But this gives us more control over the leftovers anyway!
-     * 
+     *
      * @param item
      *            The {@link ItemStack} that is being consumed
-     * 
+     *
      * @return The leftover item or null if the item is fully consumed
      */
     @Nullable
@@ -484,7 +484,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
     /**
      * This method returns the max amount of electricity this machine can hold.
-     * 
+     *
      * @return The max amount of electricity this Block can store.
      */
     @Override
@@ -494,7 +494,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
     /**
      * This method returns the amount of energy that is consumed per operation.
-     * 
+     *
      * @return The rate of energy consumption
      */
     public int getEnergyConsumption() {
@@ -505,10 +505,10 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * This sets the energy capacity for this machine.
      * This method <strong>must</strong> be called before registering the item
      * and only before registering.
-     * 
+     *
      * @param capacity
      *            The amount of energy this machine can store
-     * 
+     *
      * @return This method will return the current instance of {@link AContainer}, so that it can be chained.
      */
     @Nonnull
@@ -525,10 +525,10 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
     /**
      * This method sets the energy consumed by this machine per tick.
-     * 
+     *
      * @param energyConsumption
      *            The energy consumed per tick
-     * 
+     *
      * @return This method will return the current instance of {@link AContainer}, so that it can be chained.
      */
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -15,7 +16,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -33,9 +33,9 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
  * {@link RecipeType}.
  * The concrete implementation for this can be seen in the {@link EnhancedAutoCrafter} but
  * it theoretically works for any {@link RecipeType}.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see EnhancedAutoCrafter
  *
  */
@@ -95,7 +95,7 @@ public class SlimefunAutoCrafter extends AbstractAutoCrafter {
                     ChestMenuUtils.drawBackground(menu, background);
                     ChestMenuUtils.drawBackground(menu, 45, 46, 47, 48, 50, 51, 52, 53);
 
-                    menu.addItem(49, new CustomItemStack(Material.CRAFTING_TABLE, ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "messages.auto-crafting.select")));
+                    menu.addItem(49, ItemStackUtil.withNameString(Material.CRAFTING_TABLE, ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "messages.auto-crafting.select")));
                     menu.addMenuClickHandler(49, (pl, stack, slot, action) -> {
                         setSelectedRecipe(b, recipe);
                         SoundEffect.AUTO_CRAFTER_UPDATE_RECIPE.playAt(b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaAutoCrafter.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -25,7 +26,6 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
 import io.github.bakedlibs.dough.common.CommonPatterns;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -43,9 +43,9 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
  * The {@link VanillaAutoCrafter} is an implementation of the {@link AbstractAutoCrafter}.
  * It can craft items that are crafted using a normal crafting table.
  * Only {@link ShapedRecipe} and {@link ShapelessRecipe} are therefore supported.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see AbstractAutoCrafter
  * @see EnhancedAutoCrafter
  * @see VanillaRecipe
@@ -154,7 +154,7 @@ public class VanillaAutoCrafter extends AbstractAutoCrafter {
 
         AbstractRecipe recipe = AbstractRecipe.of(recipes.get(index));
 
-        menu.replaceExistingItem(49, new CustomItemStack(Material.CRAFTING_TABLE, ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "messages.auto-crafting.select")));
+        menu.replaceExistingItem(49, ItemStackUtil.withNameString(Material.CRAFTING_TABLE, ChatColor.GREEN + Slimefun.getLocalization().getMessage(p, "messages.auto-crafting.select")));
         menu.addMenuClickHandler(49, (pl, slot, item, action) -> {
             setSelectedRecipe(b, recipe);
             pl.closeInventory();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.blocks;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -13,7 +14,6 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -35,11 +35,11 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 /**
  * The {@link HologramProjector} is a very simple block which allows the {@link Player}
  * to create a floating text that is completely configurable.
- * 
+ *
  * @author TheBusyBiscuit
  * @author Kry-Vosa
  * @author SoSeDiK
- * 
+ *
  * @see HologramOwner
  * @see HologramsService
  *
@@ -97,7 +97,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
     private void openEditor(@Nonnull Player p, @Nonnull Block projector) {
         ChestMenu menu = new ChestMenu(Slimefun.getLocalization().getMessage(p, "machines.HOLOGRAM_PROJECTOR.inventory-title"));
 
-        menu.addItem(0, new CustomItemStack(Material.NAME_TAG, "&7Text &e(Click to edit)", "", "&f" + ChatColors.color(BlockStorage.getLocationInfo(projector.getLocation(), "text"))));
+        menu.addItem(0, ItemStackUtil.withNameLoreString(Material.NAME_TAG, "&7Text &e(Click to edit)", "", "&f" + ChatColors.color(BlockStorage.getLocationInfo(projector.getLocation(), "text"))));
         menu.addMenuClickHandler(0, (pl, slot, item, action) -> {
             pl.closeInventory();
             Slimefun.getLocalization().sendMessage(pl, "machines.HOLOGRAM_PROJECTOR.enter-text", true);
@@ -119,7 +119,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
             return false;
         });
 
-        menu.addItem(1, new CustomItemStack(Material.CLOCK, "&7Offset: &e" + NumberUtils.roundDecimalNumber(Double.valueOf(BlockStorage.getLocationInfo(projector.getLocation(), OFFSET_PARAMETER)) + 1.0D), "", "&fLeft Click: &7+0.1", "&fRight Click: &7-0.1"));
+        menu.addItem(1, ItemStackUtil.withNameLoreString(Material.CLOCK, "&7Offset: &e" + NumberUtils.roundDecimalNumber(Double.valueOf(BlockStorage.getLocationInfo(projector.getLocation(), OFFSET_PARAMETER)) + 1.0D), "", "&fLeft Click: &7+0.1", "&fRight Click: &7-0.1"));
         menu.addMenuClickHandler(1, (pl, slot, item, action) -> {
             double offset = NumberUtils.reparseDouble(Double.valueOf(BlockStorage.getLocationInfo(projector.getLocation(), OFFSET_PARAMETER)) + (action.isRightClicked() ? -0.1F : 0.1F));
             ArmorStand hologram = getArmorStand(projector, true);
@@ -152,7 +152,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
         if (!createIfNoneExists) {
             return null;
         }
-        
+
         return ArmorStandUtils.spawnArmorStand(l, nametag);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -11,7 +12,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -32,7 +32,7 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 /**
  * This abstract class is the super class of all cargo nodes.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -91,7 +91,7 @@ abstract class AbstractCargoNode extends SimpleSlimefunItem<BlockPlaceHandler> i
     protected void addChannelSelector(Block b, BlockMenu menu, int slotPrev, int slotCurrent, int slotNext) {
         int channel = getSelectedChannel(b);
 
-        menu.replaceExistingItem(slotPrev, new CustomItemStack(HeadTexture.CARGO_ARROW_LEFT.getAsItemStack(), "&bPrevious Channel", "", "&e> Click to decrease the Channel ID by 1"));
+        menu.replaceExistingItem(slotPrev, ItemStackUtil.withNameLoreString(HeadTexture.CARGO_ARROW_LEFT.getAsItemStack(), "&bPrevious Channel", "", "&e> Click to decrease the Channel ID by 1"));
         menu.addMenuClickHandler(slotPrev, (p, slot, item, action) -> {
             int newChannel = channel - 1;
 
@@ -105,14 +105,14 @@ abstract class AbstractCargoNode extends SimpleSlimefunItem<BlockPlaceHandler> i
         });
 
         if (channel == 16) {
-            menu.replaceExistingItem(slotCurrent, new CustomItemStack(HeadTexture.CHEST_TERMINAL.getAsItemStack(), "&bChannel ID: &3" + (channel + 1)));
+            menu.replaceExistingItem(slotCurrent, ItemStackUtil.withNameString(HeadTexture.CHEST_TERMINAL.getAsItemStack(), "&bChannel ID: &3" + (channel + 1)));
             menu.addMenuClickHandler(slotCurrent, ChestMenuUtils.getEmptyClickHandler());
         } else {
-            menu.replaceExistingItem(slotCurrent, new CustomItemStack(ColoredMaterial.WOOL.get(channel), "&bChannel ID: &3" + (channel + 1)));
+            menu.replaceExistingItem(slotCurrent, ItemStackUtil.withNameString(ColoredMaterial.WOOL.get(channel), "&bChannel ID: &3" + (channel + 1)));
             menu.addMenuClickHandler(slotCurrent, ChestMenuUtils.getEmptyClickHandler());
         }
 
-        menu.replaceExistingItem(slotNext, new CustomItemStack(HeadTexture.CARGO_ARROW_RIGHT.getAsItemStack(), "&bNext Channel", "", "&e> Click to increase the Channel ID by 1"));
+        menu.replaceExistingItem(slotNext, ItemStackUtil.withNameLoreString(HeadTexture.CARGO_ARROW_RIGHT.getAsItemStack(), "&bNext Channel", "", "&e> Click to increase the Channel ID by 1"));
         menu.addMenuClickHandler(slotNext, (p, slot, item, action) -> {
             int newChannel = channel + 1;
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
@@ -4,13 +4,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -25,9 +25,9 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 
 /**
  * This abstract super class represents all filtered Cargo nodes.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see CargoInputNode
  * @see AdvancedCargoOutputNode
  *
@@ -80,10 +80,10 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
     @Override
     protected void createBorder(BlockMenuPreset preset) {
         for (int i : getBorder()) {
-            preset.addItem(i, new CustomItemStack(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+            preset.addItem(i, ItemStackUtil.withNameString(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        preset.addItem(2, new CustomItemStack(Material.PAPER, "&3Items", "", "&bPut in all Items you want to", "&bblacklist/whitelist"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(2, ItemStackUtil.withNameLoreString(Material.PAPER, "&3Items", "", "&bPut in all Items you want to", "&bblacklist/whitelist"), ChestMenuUtils.getEmptyClickHandler());
     }
 
     @Override
@@ -92,14 +92,14 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
         String filterType = BlockStorage.getLocationInfo(loc, FILTER_TYPE);
 
         if (!BlockStorage.hasBlockInfo(b) || filterType == null || filterType.equals("whitelist")) {
-            menu.replaceExistingItem(15, new CustomItemStack(Material.WHITE_WOOL, "&7Type: &rWhitelist", "", "&e> Click to change it to Blacklist"));
+            menu.replaceExistingItem(15, ItemStackUtil.withNameLoreString(Material.WHITE_WOOL, "&7Type: &rWhitelist", "", "&e> Click to change it to Blacklist"));
             menu.addMenuClickHandler(15, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, FILTER_TYPE, "blacklist");
                 updateBlockMenu(menu, b);
                 return false;
             });
         } else {
-            menu.replaceExistingItem(15, new CustomItemStack(Material.BLACK_WOOL, "&7Type: &8Blacklist", "", "&e> Click to change it to Whitelist"));
+            menu.replaceExistingItem(15, ItemStackUtil.withNameLoreString(Material.BLACK_WOOL, "&7Type: &8Blacklist", "", "&e> Click to change it to Whitelist"));
             menu.addMenuClickHandler(15, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, FILTER_TYPE, "whitelist");
                 updateBlockMenu(menu, b);
@@ -110,14 +110,14 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
         String lore = BlockStorage.getLocationInfo(b.getLocation(), FILTER_LORE);
 
         if (!BlockStorage.hasBlockInfo(b) || lore == null || lore.equals(String.valueOf(true))) {
-            menu.replaceExistingItem(25, new CustomItemStack(Material.MAP, "&7Include Lore: &2\u2714", "", "&e> Click to toggle whether the Lore has to match"));
+            menu.replaceExistingItem(25, ItemStackUtil.withNameLoreString(Material.MAP, "&7Include Lore: &2\u2714", "", "&e> Click to toggle whether the Lore has to match"));
             menu.addMenuClickHandler(25, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, FILTER_LORE, String.valueOf(false));
                 updateBlockMenu(menu, b);
                 return false;
             });
         } else {
-            menu.replaceExistingItem(25, new CustomItemStack(Material.MAP, "&7Include Lore: &4\u2718", "", "&e> Click to toggle whether the Lore has to match"));
+            menu.replaceExistingItem(25, ItemStackUtil.withNameLoreString(Material.MAP, "&7Include Lore: &4\u2718", "", "&e> Click to toggle whether the Lore has to match"));
             menu.addMenuClickHandler(25, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, FILTER_LORE, String.valueOf(true));
                 updateBlockMenu(menu, b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
@@ -2,12 +2,12 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -47,14 +47,14 @@ public class CargoInputNode extends AbstractFilterNode {
 
         String roundRobinMode = BlockStorage.getLocationInfo(b.getLocation(), ROUND_ROBIN_MODE);
         if (!BlockStorage.hasBlockInfo(b) || roundRobinMode == null || roundRobinMode.equals(String.valueOf(false))) {
-            menu.replaceExistingItem(24, new CustomItemStack(HeadTexture.ENERGY_REGULATOR.getAsItemStack(), "&7Round-Robin Mode: &4\u2718", "", "&e> Click to enable Round Robin Mode", "&e(Items will be equally distributed on the Channel)"));
+            menu.replaceExistingItem(24, ItemStackUtil.withNameLoreString(HeadTexture.ENERGY_REGULATOR.getAsItemStack(), "&7Round-Robin Mode: &4\u2718", "", "&e> Click to enable Round Robin Mode", "&e(Items will be equally distributed on the Channel)"));
             menu.addMenuClickHandler(24, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, ROUND_ROBIN_MODE, String.valueOf(true));
                 updateBlockMenu(menu, b);
                 return false;
             });
         } else {
-            menu.replaceExistingItem(24, new CustomItemStack(HeadTexture.ENERGY_REGULATOR.getAsItemStack(), "&7Round-Robin Mode: &2\u2714", "", "&e> Click to disable Round Robin Mode", "&e(Items will be equally distributed on the Channel)"));
+            menu.replaceExistingItem(24, ItemStackUtil.withNameLoreString(HeadTexture.ENERGY_REGULATOR.getAsItemStack(), "&7Round-Robin Mode: &2\u2714", "", "&e> Click to disable Round Robin Mode", "&e(Items will be equally distributed on the Channel)"));
             menu.addMenuClickHandler(24, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, ROUND_ROBIN_MODE, String.valueOf(false));
                 updateBlockMenu(menu, b);
@@ -64,14 +64,14 @@ public class CargoInputNode extends AbstractFilterNode {
 
         String smartFillNode = BlockStorage.getLocationInfo(b.getLocation(), SMART_FILL_MODE);
         if (!BlockStorage.hasBlockInfo(b) || smartFillNode == null || smartFillNode.equals(String.valueOf(false))) {
-            menu.replaceExistingItem(16, new CustomItemStack(Material.WRITABLE_BOOK, "&7\"Smart-Filling\" Mode: &4\u2718", "", "&e> Click to enable \"Smart-Filling\" Mode", "", "&fIn this mode, the Cargo node will attempt", "&fto keep a constant amount of items", "&fin the inventory. This is not perfect", "&fand will still fill in empty slots that", "&fcome before a stack of a configured item."));
+            menu.replaceExistingItem(16, ItemStackUtil.withNameLoreString(Material.WRITABLE_BOOK, "&7\"Smart-Filling\" Mode: &4\u2718", "", "&e> Click to enable \"Smart-Filling\" Mode", "", "&fIn this mode, the Cargo node will attempt", "&fto keep a constant amount of items", "&fin the inventory. This is not perfect", "&fand will still fill in empty slots that", "&fcome before a stack of a configured item."));
             menu.addMenuClickHandler(16, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, SMART_FILL_MODE, String.valueOf(true));
                 updateBlockMenu(menu, b);
                 return false;
             });
         } else {
-            menu.replaceExistingItem(16, new CustomItemStack(Material.WRITTEN_BOOK, "&7\"Smart-Filling\" Mode: &2\u2714", "", "&e> Click to disable \"Smart-Filling\" Mode", "", "&fIn this mode, the Cargo node will attempt", "&fto keep a constant amount of items", "&fin the inventory. This is not perfect", "&fand will still fill in empty slots that", "&fcome before a stack of a configured item."));
+            menu.replaceExistingItem(16, ItemStackUtil.withNameLoreString(Material.WRITTEN_BOOK, "&7\"Smart-Filling\" Mode: &2\u2714", "", "&e> Click to disable \"Smart-Filling\" Mode", "", "&fIn this mode, the Cargo node will attempt", "&fto keep a constant amount of items", "&fin the inventory. This is not perfect", "&fand will still fill in empty slots that", "&fcome before a stack of a configured item."));
             menu.addMenuClickHandler(16, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, SMART_FILL_MODE, String.valueOf(false));
                 updateBlockMenu(menu, b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
@@ -2,13 +2,13 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -39,7 +39,7 @@ public class CargoOutputNode extends AbstractCargoNode {
     @Override
     protected void createBorder(BlockMenuPreset preset) {
         for (int i : BORDER) {
-            preset.addItem(i, new CustomItemStack(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+            preset.addItem(i, ItemStackUtil.withNameString(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
@@ -4,13 +4,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -35,7 +35,7 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
  * The {@link ReactorAccessPort} is a block which acts as an interface
  * between a {@link Reactor} and a {@link CargoNet}.
  * Any item placed into the port will get transferred to the {@link Reactor}.
- * 
+ *
  * @author TheBusyBiscuit
  * @author AlexLander123
  *
@@ -72,7 +72,7 @@ public class ReactorAccessPort extends SlimefunItem {
                 BlockMenu reactor = getReactor(b.getLocation());
 
                 if (reactor != null) {
-                    menu.replaceExistingItem(INFO_SLOT, new CustomItemStack(Material.GREEN_WOOL, "&7Reactor", "", "&6Detected", "", "&7> Click to view Reactor"));
+                    menu.replaceExistingItem(INFO_SLOT, ItemStackUtil.withNameLoreString(Material.GREEN_WOOL, "&7Reactor", "", "&6Detected", "", "&7> Click to view Reactor"));
                     menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
                         if (reactor != null) {
                             reactor.open(p);
@@ -83,7 +83,7 @@ public class ReactorAccessPort extends SlimefunItem {
                         return false;
                     });
                 } else {
-                    menu.replaceExistingItem(INFO_SLOT, new CustomItemStack(Material.RED_WOOL, "&7Reactor", "", "&cNot detected", "", "&7Reactor must be", "&7placed 3 blocks below", "&7the access port!"));
+                    menu.replaceExistingItem(INFO_SLOT, ItemStackUtil.withNameLoreString(Material.RED_WOOL, "&7Reactor", "", "&cNot detected", "", "&7Reactor must be", "&7placed 3 blocks below", "&7the access port!"));
                     menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
                         newInstance(menu, b);
                         return false;
@@ -135,13 +135,13 @@ public class ReactorAccessPort extends SlimefunItem {
     private void constructMenu(@Nonnull BlockMenuPreset preset) {
         preset.drawBackground(ChestMenuUtils.getBackground(), background);
 
-        preset.drawBackground(new CustomItemStack(Material.LIME_STAINED_GLASS_PANE, " "), fuelBorder);
-        preset.drawBackground(new CustomItemStack(Material.CYAN_STAINED_GLASS_PANE, " "), inputBorder);
-        preset.drawBackground(new CustomItemStack(Material.GREEN_STAINED_GLASS_PANE, " "), outputBorder);
+        preset.drawBackground(ItemStackUtil.withNameString(Material.LIME_STAINED_GLASS_PANE, " "), fuelBorder);
+        preset.drawBackground(ItemStackUtil.withNameString(Material.CYAN_STAINED_GLASS_PANE, " "), inputBorder);
+        preset.drawBackground(ItemStackUtil.withNameString(Material.GREEN_STAINED_GLASS_PANE, " "), outputBorder);
 
-        preset.addItem(1, new CustomItemStack(SlimefunItems.URANIUM, "&7Fuel Slot", "", "&rThis Slot accepts radioactive Fuel such as:", "&2Uranium &ror &aNeptunium"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(22, new CustomItemStack(SlimefunItems.PLUTONIUM, "&7Byproduct Slot", "", "&rThis Slot contains the Reactor's Byproduct", "&rsuch as &aNeptunium &ror &7Plutonium"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(7, new CustomItemStack(SlimefunItems.REACTOR_COOLANT_CELL, "&bCoolant Slot", "", "&rThis Slot accepts Coolant Cells", "&4Without any Coolant Cells, your Reactor", "&4will explode"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(1, ItemStackUtil.withNameLoreString(SlimefunItems.URANIUM, "&7Fuel Slot", "", "&rThis Slot accepts radioactive Fuel such as:", "&2Uranium &ror &aNeptunium"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(22, ItemStackUtil.withNameLoreString(SlimefunItems.PLUTONIUM, "&7Byproduct Slot", "", "&rThis Slot contains the Reactor's Byproduct", "&rsuch as &aNeptunium &ror &7Plutonium"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(7, ItemStackUtil.withNameLoreString(SlimefunItems.REACTOR_COOLANT_CELL, "&bCoolant Slot", "", "&rThis Slot accepts Coolant Cells", "&4Without any Coolant Cells, your Reactor", "&4will explode"), ChestMenuUtils.getEmptyClickHandler());
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/TrashCan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/TrashCan.java
@@ -2,11 +2,11 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -23,14 +23,14 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 /**
  * The {@link TrashCan} is a simple container which simply voids all
  * items that enter it.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
 public class TrashCan extends SlimefunItem implements InventoryBlock {
 
     private final int[] border = { 0, 1, 2, 3, 5, 4, 6, 7, 8, 9, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 };
-    private final ItemStack background = new CustomItemStack(Material.RED_STAINED_GLASS_PANE, " ");
+    private final ItemStack background = ItemStackUtil.withNameString(Material.RED_STAINED_GLASS_PANE, " ");
 
     @ParametersAreNonnullByDefault
     public TrashCan(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CarbonPress.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CarbonPress.java
@@ -5,7 +5,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -26,7 +25,7 @@ public class CarbonPress extends AContainer implements RecipeDisplayItem {
         registerRecipe(15, new ItemStack[] { new ItemStack(Material.CHARCOAL, 4) }, new ItemStack[] { new ItemStack(Material.COAL) });
         registerRecipe(20, new ItemStack[] { new ItemStack(Material.COAL, 8) }, new ItemStack[] { SlimefunItems.CARBON });
         registerRecipe(180, new ItemStack[] { new ItemStack(Material.COAL_BLOCK, 8) }, new ItemStack[] { new SlimefunItemStack(SlimefunItems.CARBON, 9) });
-        registerRecipe(30, new ItemStack[] { new CustomItemStack(SlimefunItems.CARBON, 4) }, new ItemStack[] { SlimefunItems.COMPRESSED_CARBON });
+        registerRecipe(30, new ItemStack[] { SlimefunItems.CARBON.asQuantity(4) }, new ItemStack[] { SlimefunItems.COMPRESSED_CARBON });
         registerRecipe(60, new ItemStack[] { SlimefunItems.CARBON_CHUNK, SlimefunItems.SYNTHETIC_DIAMOND }, new ItemStack[] { SlimefunItems.RAW_CARBONADO });
         registerRecipe(60, new ItemStack[] { SlimefunItems.CARBON_CHUNK }, new ItemStack[] { SlimefunItems.SYNTHETIC_DIAMOND });
         registerRecipe(90, new ItemStack[] { SlimefunItems.RAW_CARBONADO }, new ItemStack[] { SlimefunItems.CARBONADO });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
@@ -5,7 +5,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -19,7 +18,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 /**
  * The {@link ElectricPress} is a pretty simple electrical machine.
  * It allows you to compact items into their block variant, e.g. 9 diamonds into a diamond block.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -44,15 +43,15 @@ public class ElectricPress extends AContainer implements RecipeDisplayItem {
         addRecipe(3, new ItemStack(Material.CLAY_BALL, 4), new ItemStack(Material.CLAY));
         addRecipe(3, new ItemStack(Material.BRICK, 4), new ItemStack(Material.BRICKS));
 
-        addRecipe(6, SlimefunItems.COPPER_INGOT, new CustomItemStack(SlimefunItems.COPPER_WIRE, 3));
+        addRecipe(6, SlimefunItems.COPPER_INGOT, SlimefunItems.COPPER_WIRE.asQuantity(3));
         addRecipe(16, new SlimefunItemStack(SlimefunItems.STEEL_INGOT, 8), SlimefunItems.STEEL_PLATE);
         addRecipe(18, new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 8), SlimefunItems.REINFORCED_PLATE);
 
-        addRecipe(8, new ItemStack(Material.NETHER_WART), new CustomItemStack(SlimefunItems.MAGIC_LUMP_1, 2));
+        addRecipe(8, new ItemStack(Material.NETHER_WART), SlimefunItems.MAGIC_LUMP_1.asQuantity(2));
         addRecipe(10, new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 4), SlimefunItems.MAGIC_LUMP_2);
         addRecipe(12, new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_2, 4), SlimefunItems.MAGIC_LUMP_3);
 
-        addRecipe(10, new ItemStack(Material.ENDER_EYE), new CustomItemStack(SlimefunItems.ENDER_LUMP_1, 2));
+        addRecipe(10, new ItemStack(Material.ENDER_EYE), SlimefunItems.ENDER_LUMP_1.asQuantity(2));
         addRecipe(12, new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 4), SlimefunItems.ENDER_LUMP_2);
         addRecipe(14, new SlimefunItemStack(SlimefunItems.ENDER_LUMP_2, 4), SlimefunItems.ENDER_LUMP_3);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricSmeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricSmeltery.java
@@ -8,12 +8,12 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -31,7 +31,7 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 /**
  * The {@link ElectricSmeltery} is an electric version of the standard {@link Smeltery}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -120,7 +120,7 @@ public class ElectricSmeltery extends AContainer implements NotHopperable {
             preset.addItem(i, ChestMenuUtils.getOutputSlotTexture(), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        preset.addItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(22, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
 
         for (int i : getOutputSlots()) {
             preset.addMenuClickHandler(i, ChestMenuUtils.getDefaultOutputHandler());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/HeatedPressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/HeatedPressureChamber.java
@@ -12,7 +12,6 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -85,13 +84,13 @@ public class HeatedPressureChamber extends AContainer {
 
     @Override
     protected void registerDefaultRecipes() {
-        registerRecipe(45, new ItemStack[] { SlimefunItems.OIL_BUCKET }, new ItemStack[] { new CustomItemStack(SlimefunItems.PLASTIC_SHEET, 8) });
+        registerRecipe(45, new ItemStack[] { SlimefunItems.OIL_BUCKET }, new ItemStack[] { SlimefunItems.PLASTIC_SHEET.asQuantity(8) });
         registerRecipe(30, new ItemStack[] { SlimefunItems.GOLD_24K, SlimefunItems.URANIUM }, new ItemStack[] { SlimefunItems.BLISTERING_INGOT });
         registerRecipe(30, new ItemStack[] { SlimefunItems.BLISTERING_INGOT, SlimefunItems.CARBONADO }, new ItemStack[] { SlimefunItems.BLISTERING_INGOT_2 });
         registerRecipe(60, new ItemStack[] { SlimefunItems.BLISTERING_INGOT_2, new ItemStack(Material.NETHER_STAR) }, new ItemStack[] { SlimefunItems.BLISTERING_INGOT_3 });
         registerRecipe(90, new ItemStack[] { SlimefunItems.PLUTONIUM, SlimefunItems.URANIUM }, new ItemStack[] { SlimefunItems.BOOSTED_URANIUM });
-        registerRecipe(60, new ItemStack[] { SlimefunItems.NETHER_ICE, SlimefunItems.PLUTONIUM }, new ItemStack[] { new CustomItemStack(SlimefunItems.ENRICHED_NETHER_ICE, 4) });
-        registerRecipe(45, new ItemStack[] { SlimefunItems.ENRICHED_NETHER_ICE }, new ItemStack[] { new CustomItemStack(SlimefunItems.NETHER_ICE_COOLANT_CELL, 8) });
+        registerRecipe(60, new ItemStack[] { SlimefunItems.NETHER_ICE, SlimefunItems.PLUTONIUM }, new ItemStack[] { SlimefunItems.ENRICHED_NETHER_ICE.asQuantity(4) });
+        registerRecipe(45, new ItemStack[] { SlimefunItems.ENRICHED_NETHER_ICE }, new ItemStack[] {SlimefunItems.NETHER_ICE_COOLANT_CELL.asQuantity(8) });
         registerRecipe(8, new ItemStack[] { SlimefunItems.MAGNESIUM_DUST, SlimefunItems.SALT }, new ItemStack[] { SlimefunItems.MAGNESIUM_SALT });
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AbstractGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AbstractGrowthAccelerator.java
@@ -3,11 +3,11 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machine
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -54,7 +54,7 @@ public abstract class AbstractGrowthAccelerator extends SlimefunItem implements 
 
     private void constructMenu(BlockMenuPreset preset) {
         for (int i : BORDER) {
-            preset.addItem(i, new CustomItemStack(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+            preset.addItem(i, ItemStackUtil.withNameString(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/enchanting/AbstractEnchantmentMachine.java
@@ -6,13 +6,12 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
-import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -67,7 +66,7 @@ abstract class AbstractEnchantmentMachine extends AContainer {
 
         String notice = ChatColors.color(Slimefun.getLocalization().getMessage("messages.above-limit-level"));
         notice = notice.replace("%level%", String.valueOf(levelLimit.getValue()));
-        ItemStack progressBar = new CustomItemStack(Material.BARRIER, " ", notice);
+        ItemStack progressBar = ItemStackUtil.withNameLoreString(Material.BARRIER, " ", notice);
         menu.replaceExistingItem(22, progressBar);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AbstractEntityAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AbstractEntityAssembler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -16,7 +17,6 @@ import org.bukkit.event.block.BlockEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -43,9 +43,9 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 /**
  * This is an abstract super class for Entity Assemblers.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see WitherAssembler
  * @see IronGolemAssembler
  *
@@ -75,8 +75,8 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
             @Override
             public void init() {
                 drawBackground(border);
-                drawBackground(new CustomItemStack(getHeadBorder(), " "), headBorder);
-                drawBackground(new CustomItemStack(getBodyBorder(), " "), bodyBorder);
+                drawBackground(ItemStackUtil.withNameString(getHeadBorder(), " "), headBorder);
+                drawBackground(ItemStackUtil.withNameString(getBodyBorder(), " "), bodyBorder);
 
                 constructMenu(this);
             }
@@ -159,14 +159,14 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
 
     private void updateBlockInventory(BlockMenu menu, Block b) {
         if (!BlockStorage.hasBlockInfo(b) || BlockStorage.getLocationInfo(b.getLocation(), KEY_ENABLED) == null || BlockStorage.getLocationInfo(b.getLocation(), KEY_ENABLED).equals(String.valueOf(false))) {
-            menu.replaceExistingItem(22, new CustomItemStack(Material.GUNPOWDER, "&7Enabled: &4\u2718", "", "&e> Click to enable this Machine"));
+            menu.replaceExistingItem(22, ItemStackUtil.withNameLoreString(Material.GUNPOWDER, "&7Enabled: &4\u2718", "", "&e> Click to enable this Machine"));
             menu.addMenuClickHandler(22, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, KEY_ENABLED, String.valueOf(true));
                 updateBlockInventory(menu, b);
                 return false;
             });
         } else {
-            menu.replaceExistingItem(22, new CustomItemStack(Material.REDSTONE, "&7Enabled: &2\u2714", "", "&e> Click to disable this Machine"));
+            menu.replaceExistingItem(22, ItemStackUtil.withNameLoreString(Material.REDSTONE, "&7Enabled: &2\u2714", "", "&e> Click to disable this Machine"));
             menu.addMenuClickHandler(22, (p, slot, item, action) -> {
                 BlockStorage.addBlockInfo(b, KEY_ENABLED, String.valueOf(false));
                 updateBlockInventory(menu, b);
@@ -176,7 +176,7 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
 
         double offset = (!BlockStorage.hasBlockInfo(b) || BlockStorage.getLocationInfo(b.getLocation(), KEY_OFFSET) == null) ? 3.0F : Double.valueOf(BlockStorage.getLocationInfo(b.getLocation(), KEY_OFFSET));
 
-        menu.replaceExistingItem(31, new CustomItemStack(Material.PISTON, "&7Offset: &3" + offset + " Block(s)", "", "&fLeft Click: &7+0.1", "&fRight Click: &7-0.1"));
+        menu.replaceExistingItem(31, ItemStackUtil.withNameLoreString(Material.PISTON, "&7Offset: &3" + offset + " Block(s)", "", "&fLeft Click: &7+0.1", "&fRight Click: &7-0.1"));
         menu.addMenuClickHandler(31, (p, slot, item, action) -> {
             double offsetv = NumberUtils.reparseDouble(Double.valueOf(BlockStorage.getLocationInfo(b.getLocation(), KEY_OFFSET)) + (action.isRightClicked() ? -0.1F : 0.1F));
             BlockStorage.addBlockInfo(b, KEY_OFFSET, String.valueOf(offsetv));
@@ -279,9 +279,9 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
     }
 
     protected void constructMenu(BlockMenuPreset preset) {
-        preset.addItem(1, new CustomItemStack(getHead(), "&7Head Slot", "", "&fThis Slot accepts the head type"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(7, new CustomItemStack(getBody(), "&7Body Slot", "", "&fThis Slot accepts the body type"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(13, new CustomItemStack(Material.CLOCK, "&7Cooldown: &b30 Seconds", "", "&fThis Machine takes up to half a Minute to operate", "&fso give it some Time!"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(1, ItemStackUtil.withNameLoreString(getHead(), "&7Head Slot", "", "&fThis Slot accepts the head type"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(7, ItemStackUtil.withNameLoreString(getBody(), "&7Body Slot", "", "&fThis Slot accepts the body type"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(13, ItemStackUtil.withNameLoreString(Material.CLOCK, "&7Cooldown: &b30 Seconds", "", "&fThis Machine takes up to half a Minute to operate", "&fso give it some Time!"), ChestMenuUtils.getEmptyClickHandler());
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AutoBreeder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AutoBreeder.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machine
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
@@ -11,7 +12,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemHandler;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -65,7 +65,7 @@ public class AutoBreeder extends SlimefunItem implements InventoryBlock, EnergyN
 
     protected void constructMenu(BlockMenuPreset preset) {
         for (int i : border) {
-            preset.addItem(i, new CustomItemStack(new ItemStack(Material.CYAN_STAINED_GLASS_PANE), " "), (p, slot, item, action) -> false);
+            preset.addItem(i, ItemStackUtil.withNameString(new ItemStack(Material.CYAN_STAINED_GLASS_PANE), " "), (p, slot, item, action) -> false);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ExpCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ExpCollector.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -13,7 +14,6 @@ import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemHandler;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -36,7 +36,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 /**
  * The {@link ExpCollector} is a machine which picks up any nearby {@link ExperienceOrb}
  * and produces a {@link KnowledgeFlask}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -104,7 +104,7 @@ public class ExpCollector extends SlimefunItem implements InventoryBlock, Energy
 
     protected void constructMenu(BlockMenuPreset preset) {
         for (int slot : border) {
-            preset.addItem(slot, new CustomItemStack(Material.PURPLE_STAINED_GLASS_PANE, " "), (p, s, item, action) -> false);
+            preset.addItem(slot, ItemStackUtil.withNameString(Material.PURPLE_STAINED_GLASS_PANE, " "), (p, s, item, action) -> false);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/IronGolemAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/IronGolemAssembler.java
@@ -2,13 +2,13 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machine
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.SoundCategory;
 import org.bukkit.entity.IronGolem;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -20,9 +20,9 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 /**
  * The {@link IronGolemAssembler} is an electrical machine that can automatically spawn
  * a {@link IronGolem} if the required ingredients have been provided.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see WitherAssembler
  *
  */
@@ -65,9 +65,9 @@ public class IronGolemAssembler extends AbstractEntityAssembler<IronGolem> {
 
     @Override
     protected void constructMenu(BlockMenuPreset preset) {
-        preset.addItem(1, new CustomItemStack(getHead(), "&7Pumpkin Slot", "", "&fThis Slot accepts Pumpkins"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(7, new CustomItemStack(getBody(), "&7Iron Block Slot", "", "&fThis Slot accepts Iron Blocks"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(13, new CustomItemStack(Material.CLOCK, "&7Cooldown: &b30 Seconds", "", "&fThis Machine takes up to half a Minute to operate", "&fso give it some Time!"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(1, ItemStackUtil.withNameLoreString(getHead(), "&7Pumpkin Slot", "", "&fThis Slot accepts Pumpkins"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(7, ItemStackUtil.withNameLoreString(getBody(), "&7Iron Block Slot", "", "&fThis Slot accepts Iron Blocks"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(13, ItemStackUtil.withNameLoreString(Material.CLOCK, "&7Cooldown: &b30 Seconds", "", "&fThis Machine takes up to half a Minute to operate", "&fso give it some Time!"), ChestMenuUtils.getEmptyClickHandler());
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -22,7 +23,6 @@ import org.bukkit.entity.MushroomCow;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.inventory.InvUtils;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
@@ -43,7 +43,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 /**
  * The {@link ProduceCollector} allows you to collect produce from animals.
  * Providing it with a bucket and a nearby {@link Cow} will allow you to obtain milk.
- * 
+ *
  * @author TheBusyBiscuit
  * @author Walshy
  *
@@ -85,7 +85,7 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
 
     /**
      * This method adds a new {@link AnimalProduce} to this machine.
-     * 
+     *
      * @param produce
      *            The {@link AnimalProduce} to add
      */
@@ -116,15 +116,15 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
     public @Nonnull List<ItemStack> getDisplayRecipes() {
         List<ItemStack> displayRecipes = new ArrayList<>();
 
-        displayRecipes.add(new CustomItemStack(Material.BUCKET, null, "&fRequires &bCow &fnearby"));
+        displayRecipes.add(ItemStackUtil.withNameString(Material.BUCKET, "&fRequires &bCow &fnearby"));
         displayRecipes.add(new ItemStack(Material.MILK_BUCKET));
 
         if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
-            displayRecipes.add(new CustomItemStack(Material.BUCKET, null, "&fRequires &bGoat &fnearby"));
+            displayRecipes.add(ItemStackUtil.withNameString(Material.BUCKET, "&fRequires &bGoat &fnearby"));
             displayRecipes.add(new ItemStack(Material.MILK_BUCKET));
         }
 
-        displayRecipes.add(new CustomItemStack(Material.BOWL, null, "&fRequires &bMooshroom &fnearby"));
+        displayRecipes.add(ItemStackUtil.withNameString(Material.BOWL, "&fRequires &bMooshroom &fnearby"));
         displayRecipes.add(new ItemStack(Material.MUSHROOM_STEW));
 
         return displayRecipes;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/WitherAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/WitherAssembler.java
@@ -2,12 +2,12 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machine
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Wither;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -18,9 +18,9 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 /**
  * The {@link WitherAssembler} is an electrical machine that can automatically spawn
  * a {@link Wither} if the required ingredients have been provided.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see IronGolemAssembler
  *
  */
@@ -63,9 +63,9 @@ public class WitherAssembler extends AbstractEntityAssembler<Wither> {
 
     @Override
     protected void constructMenu(BlockMenuPreset preset) {
-        preset.addItem(1, new CustomItemStack(getHead(), "&7Wither Skeleton Skull Slot", "", "&fThis Slot accepts Wither Skeleton Skulls"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(7, new CustomItemStack(getBody(), "&7Soul Sand Slot", "", "&fThis Slot accepts Soul Sand"), ChestMenuUtils.getEmptyClickHandler());
-        preset.addItem(13, new CustomItemStack(Material.CLOCK, "&7Cooldown: &b30 Seconds", "", "&fThis Machine takes up to half a Minute to operate", "&fso give it some Time!"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(1, ItemStackUtil.withNameLoreString(getHead(), "&7Wither Skeleton Skull Slot", "", "&fThis Slot accepts Wither Skeleton Skulls"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(7, ItemStackUtil.withNameLoreString(getBody(), "&7Soul Sand Slot", "", "&fThis Slot accepts Soul Sand"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(13, ItemStackUtil.withNameLoreString(Material.CLOCK, "&7Cooldown: &b30 Seconds", "", "&fThis Machine takes up to half a Minute to operate", "&fso give it some Time!"), ChestMenuUtils.getEmptyClickHandler());
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -19,7 +20,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.events.ReactorExplodeEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -50,11 +50,11 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 /**
  * The abstract {@link Reactor} class is very similar to {@link AGenerator} but is
  * exclusively used for Reactors.
- * 
+ *
  * @author John000708
  * @author AlexLander123
  * @author TheBusyBiscuit
- * 
+ *
  * @see AGenerator
  * @see NuclearReactor
  * @see NetherStarReactor
@@ -145,7 +145,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
 
         switch (mode) {
             case GENERATOR:
-                menu.replaceExistingItem(4, new CustomItemStack(SlimefunItems.NUCLEAR_REACTOR, "&7Focus: &eElectricity", "", "&6Your Reactor will focus on Power Generation", "&6If your Energy Network doesn't need Power", "&6it will not produce any either", "", "&7\u21E8 Click to change the Focus to &eProduction"));
+                menu.replaceExistingItem(4, ItemStackUtil.withNameLoreString(SlimefunItems.NUCLEAR_REACTOR, "&7Focus: &eElectricity", "", "&6Your Reactor will focus on Power Generation", "&6If your Energy Network doesn't need Power", "&6it will not produce any either", "", "&7\u21E8 Click to change the Focus to &eProduction"));
                 menu.addMenuClickHandler(4, (p, slot, item, action) -> {
                     BlockStorage.addBlockInfo(b, MODE, ReactorMode.PRODUCTION.toString());
                     updateInventory(menu, b);
@@ -153,7 +153,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
                 });
                 break;
             case PRODUCTION:
-                menu.replaceExistingItem(4, new CustomItemStack(SlimefunItems.PLUTONIUM, "&7Focus: &eProduction", "", "&6Your Reactor will focus on producing goods", "&6If your Energy Network doesn't need Power", "&6it will continue to run and simply will", "&6not generate any Power in the mean time", "", "&7\u21E8 Click to change the Focus to &ePower Generation"));
+                menu.replaceExistingItem(4, ItemStackUtil.withNameLoreString(SlimefunItems.PLUTONIUM, "&7Focus: &eProduction", "", "&6Your Reactor will focus on producing goods", "&6If your Energy Network doesn't need Power", "&6it will continue to run and simply will", "&6not generate any Power in the mean time", "", "&7\u21E8 Click to change the Focus to &ePower Generation"));
                 menu.addMenuClickHandler(4, (p, slot, item, action) -> {
                     BlockStorage.addBlockInfo(b, MODE, ReactorMode.GENERATOR.toString());
                     updateInventory(menu, b);
@@ -167,7 +167,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
         BlockMenu port = getAccessPort(b.getLocation());
 
         if (port != null) {
-            menu.replaceExistingItem(INFO_SLOT, new CustomItemStack(Material.GREEN_WOOL, "&7Access Port", "", "&6Detected", "", "&7> Click to view Access Port"));
+            menu.replaceExistingItem(INFO_SLOT, ItemStackUtil.withNameLoreString(Material.GREEN_WOOL, "&7Access Port", "", "&6Detected", "", "&7> Click to view Access Port"));
             menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
                 port.open(p);
                 updateInventory(menu, b);
@@ -175,7 +175,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
                 return false;
             });
         } else {
-            menu.replaceExistingItem(INFO_SLOT, new CustomItemStack(Material.RED_WOOL, "&7Access Port", "", "&cNot detected", "", "&7Access Port must be", "&7placed 3 blocks above", "&7a reactor!"));
+            menu.replaceExistingItem(INFO_SLOT, ItemStackUtil.withNameLoreString(Material.RED_WOOL, "&7Access Port", "", "&cNot detected", "", "&7Access Port must be", "&7placed 3 blocks above", "&7a reactor!"));
             menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
                 updateInventory(menu, b);
                 menu.open(p);
@@ -190,28 +190,28 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
         }
 
         for (int i : border_1) {
-            preset.addItem(i, new CustomItemStack(Material.LIME_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+            preset.addItem(i, ItemStackUtil.withNameString(Material.LIME_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
         }
 
         for (int i : border_3) {
-            preset.addItem(i, new CustomItemStack(Material.GREEN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+            preset.addItem(i, ItemStackUtil.withNameString(Material.GREEN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        preset.addItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(22, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
 
-        preset.addItem(1, new CustomItemStack(getFuelIcon(), "&7Fuel Slot", "", "&fThis Slot accepts radioactive Fuel such as:", "&2Uranium &for &aNeptunium"), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(1, ItemStackUtil.withNameLoreString(getFuelIcon(), "&7Fuel Slot", "", "&fThis Slot accepts radioactive Fuel such as:", "&2Uranium &for &aNeptunium"), ChestMenuUtils.getEmptyClickHandler());
 
         for (int i : border_2) {
-            preset.addItem(i, new CustomItemStack(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+            preset.addItem(i, ItemStackUtil.withNameString(Material.CYAN_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
         }
 
         if (needsCooling()) {
-            preset.addItem(7, new CustomItemStack(getCoolant(), "&bCoolant Slot", "", "&fThis Slot accepts Coolant Cells", "&4Without any Coolant Cells, your Reactor", "&4will explode"));
+            preset.addItem(7, ItemStackUtil.withNameLoreString(getCoolant(), "&bCoolant Slot", "", "&fThis Slot accepts Coolant Cells", "&4Without any Coolant Cells, your Reactor", "&4will explode"));
         } else {
-            preset.addItem(7, new CustomItemStack(Material.BARRIER, "&bCoolant Slot", "", "&fThis Slot accepts Coolant Cells"));
+            preset.addItem(7, ItemStackUtil.withNameLoreString(Material.BARRIER, "&bCoolant Slot", "", "&fThis Slot accepts Coolant Cells"));
 
             for (int i : border_4) {
-                preset.addItem(i, new CustomItemStack(Material.BARRIER, "&cNo Coolant Required"), ChestMenuUtils.getEmptyClickHandler());
+                preset.addItem(i, ItemStackUtil.withNameString(Material.BARRIER, "&cNo Coolant Required"), ChestMenuUtils.getEmptyClickHandler());
             }
         }
     }
@@ -232,7 +232,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
     /**
      * This method returns the {@link ItemStack} that is required to cool this {@link Reactor}.
      * If it returns null, then no cooling is required.
-     * 
+     *
      * @return The {@link ItemStack} required to cool this {@link Reactor}
      */
     @Nullable
@@ -242,7 +242,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
      * This method returns the displayed icon above the fuel input slot.
      * It should reflect the {@link ItemStack} used to power the reactor.
      * This method does <b>not</b> determine the fuel input, only the icon.
-     * 
+     *
      * @return The {@link ItemStack} used as the fuel icon for this {@link Reactor}.
      */
     @Nonnull
@@ -252,7 +252,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
      * This method returns whether this {@link Reactor} requires as some form of
      * coolant.
      * It is a not-null check performed on {@link #getCoolant()}
-     * 
+     *
      * @return Whether this {@link Reactor} requires cooling
      */
     protected final boolean needsCooling() {
@@ -364,7 +364,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
     }
 
     private void createByproduct(@Nonnull Location l, @Nonnull BlockMenu inv, @Nullable BlockMenu accessPort, @Nonnull FuelOperation operation) {
-        inv.replaceExistingItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "));
+        inv.replaceExistingItem(22, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "));
         ItemStack result = operation.getResult();
 
         if (result != null) {
@@ -401,7 +401,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
 
     /**
      * This method cools the given {@link Reactor}.
-     * 
+     *
      * @param reactor
      *            The {@link Location} of this {@link Reactor}
      * @param menu
@@ -410,7 +410,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
      *            The {@link ReactorAccessPort}, if available
      * @param operation
      *            The {@link FuelOperation} of this {@link Reactor}
-     * 
+     *
      * @return Whether the {@link Reactor} was successfully cooled, if not it should explode
      */
     private boolean hasEnoughCoolant(@Nonnull Location reactor, @Nonnull BlockMenu menu, @Nullable BlockMenu accessPort, @Nonnull FuelOperation operation) {
@@ -453,7 +453,7 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
     private void restockFuel(BlockMenu menu, BlockMenu port) {
         for (int slot : getFuelSlots()) {
             for (MachineFuel fuelType : fuelTypes) {
-                if (fuelType.test(port.getItemInSlot(slot)) && menu.fits(new CustomItemStack(port.getItemInSlot(slot), 1), getFuelSlots())) {
+                if (fuelType.test(port.getItemInSlot(slot)) && menu.fits(port.getItemInSlot(slot).asOne(), getFuelSlots())) {
                     port.replaceExistingItem(slot, menu.pushItem(port.getItemInSlot(slot), getFuelSlots()));
                     return;
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/elevator/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/elevator/ElevatorPlate.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -19,7 +20,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -141,17 +141,9 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
 
             // @formatter:off
             if (floor.getAltitude() == b.getY()) {
-                menu.addItem(i, new CustomItemStack(
-                    Material.COMPASS,
-                    ChatColor.GRAY.toString() + floor.getNumber() + ". " + ChatColor.BLACK + floor.getName(),
-                    Slimefun.getLocalization().getMessage(p, "machines.ELEVATOR.current-floor") + ' ' + ChatColor.WHITE + floor.getName()
-                ), ChestMenuUtils.getEmptyClickHandler());
+                menu.addItem(i, ItemStackUtil.withNameLoreString(Material.COMPASS, ChatColor.GRAY.toString() + floor.getNumber() + ". " + ChatColor.BLACK + floor.getName(), Slimefun.getLocalization().getMessage(p, "machines.ELEVATOR.current-floor") + ' ' + ChatColor.WHITE + floor.getName()), ChestMenuUtils.getEmptyClickHandler());
             } else {
-                menu.addItem(i, new CustomItemStack(
-                    Material.PAPER,
-                    ChatColor.GRAY.toString() + floor.getNumber() + ". " + ChatColor.BLACK + floor.getName(),
-                    Slimefun.getLocalization().getMessage(p, "machines.ELEVATOR.click-to-teleport") + ' ' + ChatColor.WHITE + floor.getName()
-                ), (player, slot, itemStack, clickAction) -> {
+                menu.addItem(i, ItemStackUtil.withNameLoreString(Material.PAPER, ChatColor.GRAY.toString() + floor.getNumber() + ". " + ChatColor.BLACK + floor.getName(), Slimefun.getLocalization().getMessage(p, "machines.ELEVATOR.click-to-teleport") + ' ' + ChatColor.WHITE + floor.getName()), (player, slot, itemStack, clickAction) -> {
                     teleport(player, floor);
                     return false;
                 });
@@ -207,7 +199,7 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
     public void openEditor(Player p, Block b) {
         ChestMenu menu = new ChestMenu(Slimefun.getLocalization().getMessage(p, "machines.ELEVATOR.editor-title"));
 
-        menu.addItem(4, new CustomItemStack(Material.NAME_TAG, "&7Floor Name &e(Click to edit)", "", ChatColor.WHITE + ChatColors.color(BlockStorage.getLocationInfo(b.getLocation(), DATA_KEY))));
+        menu.addItem(4, ItemStackUtil.withNameLoreString(Material.NAME_TAG, "&7Floor Name &e(Click to edit)", "", ChatColor.WHITE + ChatColors.color(BlockStorage.getLocationInfo(b.getLocation(), DATA_KEY))));
         menu.addMenuClickHandler(4, (pl, slot, item, action) -> {
             pl.closeInventory();
             pl.sendMessage("");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
@@ -7,6 +7,7 @@ import java.util.OptionalInt;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -14,7 +15,6 @@ import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -44,7 +44,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 
 /**
  * The {@link GEOMiner} is an electrical machine that allows you to obtain a {@link GEOResource}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  * @see GEOResource
@@ -79,7 +79,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
     /**
      * This method returns the max amount of electricity this machine can hold.
-     * 
+     *
      * @return The max amount of electricity this Block can store.
      */
     @Override
@@ -89,7 +89,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
     /**
      * This method returns the amount of energy that is consumed per operation.
-     * 
+     *
      * @return The rate of energy consumption
      */
     public int getEnergyConsumption() {
@@ -100,7 +100,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
      * This method returns the speed at which this machine will operate.
      * This can be implemented on an instantiation-level to create different tiers
      * of machines.
-     * 
+     *
      * @return The speed of this machine
      */
     public int getSpeed() {
@@ -111,10 +111,10 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
      * This sets the energy capacity for this machine.
      * This method <strong>must</strong> be called before registering the item
      * and only before registering.
-     * 
+     *
      * @param capacity
      *            The amount of energy this machine can store
-     * 
+     *
      * @return This method will return the current instance of {@link GEOMiner}, so that can be chained.
      */
     public final GEOMiner setCapacity(int capacity) {
@@ -130,10 +130,10 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
     /**
      * This sets the speed of this machine.
-     * 
+     *
      * @param speed
      *            The speed multiplier for this machine, must be above zero
-     * 
+     *
      * @return This method will return the current instance of {@link GEOMiner}, so that can be chained.
      */
     public final GEOMiner setProcessingSpeed(int speed) {
@@ -145,10 +145,10 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
     /**
      * This method sets the energy consumed by this machine per tick.
-     * 
+     *
      * @param energyConsumption
      *            The energy consumed per tick
-     * 
+     *
      * @return This method will return the current instance of {@link GEOMiner}, so that can be chained.
      */
     public final GEOMiner setEnergyConsumption(int energyConsumption) {
@@ -232,7 +232,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
         for (GEOResource resource : Slimefun.getRegistry().getGEOResources().values()) {
             if (resource.isObtainableFromGEOMiner()) {
-                displayRecipes.add(new CustomItemStack(resource.getItem(), ChatColor.RESET + resource.getName()));
+                displayRecipes.add(ItemStackUtil.withNameString(resource.getItem(), ChatColor.RESET + resource.getName()));
             }
         }
 
@@ -258,7 +258,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
             preset.addItem(i, ChestMenuUtils.getOutputSlotTexture(), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        preset.addItem(4, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(4, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
 
         for (int i : OUTPUT_SLOTS) {
             preset.addMenuClickHandler(i, ChestMenuUtils.getDefaultOutputHandler());
@@ -296,7 +296,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
                 removeCharge(b.getLocation(), getEnergyConsumption());
                 operation.addProgress(getSpeed());
             } else {
-                inv.replaceExistingItem(4, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "));
+                inv.replaceExistingItem(4, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "));
                 inv.pushItem(operation.getResult(), OUTPUT_SLOTS);
 
                 processor.endOperation(b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/EnderTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/EnderTalisman.java
@@ -2,11 +2,11 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.magical.talisman
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.EnderChest;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.LockedItemGroup;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -15,13 +15,13 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 /**
  * An {@link EnderTalisman} is a special version of {@link Talisman}
  * that works while it is in your {@link EnderChest}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
 class EnderTalisman extends Talisman {
 
-    private static final LockedItemGroup ENDER_TALISMANS_ITEMGROUP = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "ender_talismans"), new CustomItemStack(SlimefunItems.ENDER_TALISMAN, "&7Talismans - &aTier II"), 3, Talisman.TALISMANS_ITEMGROUP.getKey());
+    private static final LockedItemGroup ENDER_TALISMANS_ITEMGROUP = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "ender_talismans"), ItemStackUtil.withNameString(SlimefunItems.ENDER_TALISMAN,"&7Talismans - &aTier II"), 3, Talisman.TALISMANS_ITEMGROUP.getKey());
 
     @ParametersAreNonnullByDefault
     public EnderTalisman(Talisman parent, SlimefunItemStack item) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -9,6 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -26,7 +27,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.api.events.TalismanActivateEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -40,7 +40,7 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
 public class Talisman extends SlimefunItem {
 
-    protected static final ItemGroup TALISMANS_ITEMGROUP = new ItemGroup(new NamespacedKey(Slimefun.instance(), "talismans"), new CustomItemStack(SlimefunItems.COMMON_TALISMAN, "&7Talismans - &aTier I"), 2);
+    protected static final ItemGroup TALISMANS_ITEMGROUP = new ItemGroup(new NamespacedKey(Slimefun.instance(), "talismans"), ItemStackUtil.withNameString(SlimefunItems.COMMON_TALISMAN,"&7Talismans - &aTier I"), 2);
     private static final String WIKI_PAGE = "Talismans";
 
     private final SlimefunItemStack enderTalisman;
@@ -68,7 +68,7 @@ public class Talisman extends SlimefunItem {
 
     @ParametersAreNonnullByDefault
     protected Talisman(ItemGroup itemGroup, SlimefunItemStack item, ItemStack[] recipe, boolean consumable, boolean cancelEvent, @Nullable String messageSuffix, int chance, PotionEffect... effects) {
-        super(itemGroup, item, RecipeType.MAGIC_WORKBENCH, recipe, new CustomItemStack(item, consumable ? 4 : 1));
+        super(itemGroup, item, RecipeType.MAGIC_WORKBENCH, recipe, item.asQuantity(consumable ? 4 : 1));
 
         this.consumable = consumable;
         this.cancel = cancelEvent;
@@ -95,7 +95,7 @@ public class Talisman extends SlimefunItem {
 
     /**
      * This returns whether the {@link Talisman} will be consumed upon use.
-     * 
+     *
      * @return Whether this {@link Talisman} is consumed on use.
      */
     public boolean isConsumable() {
@@ -105,7 +105,7 @@ public class Talisman extends SlimefunItem {
     /**
      * This returns the chance of this {@link Talisman} activating.
      * The chance will be between 1 and 100.
-     * 
+     *
      * @return The chance of this {@link Talisman} activating.
      */
     public int getChance() {
@@ -259,7 +259,7 @@ public class Talisman extends SlimefunItem {
      * This returns whether the {@link Talisman} is silent.
      * A silent {@link Talisman} will not send a message to a {@link Player}
      * when activated.
-     * 
+     *
      * @return Whether this {@link Talisman} is silent
      */
     public boolean isSilent() {
@@ -275,7 +275,7 @@ public class Talisman extends SlimefunItem {
      * This method sends the given {@link Player} the message of this {@link Talisman}.
      * Dependent on the selected config setting, the message will be sent via the actionbar
      * or in the chat window.
-     * 
+     *
      * @param p
      *            The {@link Player} who shall receive the message
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -14,7 +15,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -29,7 +29,7 @@ public class ArmorForge extends AbstractCraftingTable {
 
     @ParametersAreNonnullByDefault
     public ArmorForge(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.ANVIL), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.ANVIL), null, null, ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -16,7 +17,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -32,7 +32,7 @@ public class Compressor extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
     public Compressor(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.PISTON), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.PISTON) }, BlockFace.SELF);
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.PISTON), ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.PISTON) }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -16,7 +17,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -33,7 +33,7 @@ public class GrindStone extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
     public GrindStone(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.OAK_FENCE), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.OAK_FENCE), null, null, ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Juicer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Juicer.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -17,7 +18,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -32,10 +32,10 @@ import io.papermc.lib.PaperLib;
 /**
  * The {@link Juicer} is a {@link MultiBlockMachine} which can be used to
  * craft {@link Juice}.
- * 
+ *
  * @author TheBusyBiscuit
  * @author Liruxo
- * 
+ *
  * @see Juice
  *
  */
@@ -43,7 +43,7 @@ public class Juicer extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
     public Juicer(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.GLASS), null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, null, new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
+        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.GLASS), null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, null, ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing up)"), null }, BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -15,7 +15,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -86,7 +85,7 @@ public class MagicWorkbench extends AbstractCraftingTable {
             for (int j = 0; j < 9; j++) {
                 if (inv.getContents()[j] != null && inv.getContents()[j].getType() != Material.AIR) {
                     if (inv.getContents()[j].getAmount() > 1) {
-                        inv.setItem(j, new CustomItemStack(inv.getContents()[j], inv.getContents()[j].getAmount() - 1));
+                        inv.setItem(j, inv.getContents()[j].asQuantity(inv.getContents()[j].getAmount() - 1));
                     } else {
                         inv.setItem(j, null);
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MakeshiftSmeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MakeshiftSmeltery.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -13,16 +14,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 
 /**
  * The {@link MakeshiftSmeltery} is a simpler version of the {@link Smeltery}.
  * Its functionality is very limited and it cannot be used to smelt alloys.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see Smeltery
  *
  */
@@ -30,7 +30,7 @@ public class MakeshiftSmeltery extends AbstractSmeltery {
 
     @ParametersAreNonnullByDefault
     public MakeshiftSmeltery(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.OAK_FENCE), null, new ItemStack(Material.BRICKS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
+        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.OAK_FENCE), null, new ItemStack(Material.BRICKS), ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -18,7 +19,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -35,7 +35,7 @@ import io.papermc.lib.PaperLib;
 /**
  * The {@link OreCrusher} is a {@link MultiBlockMachine} which allows you to double ores
  * and crush some other {@link Material Materials} into various resources.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -45,7 +45,7 @@ public class OreCrusher extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
     public OreCrusher(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.IRON_BARS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.IRON_BARS) }, BlockFace.SELF);
+        super(itemGroup, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.IRON_BARS), ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.IRON_BARS) }, BlockFace.SELF);
 
         addItemSetting(doubleOres);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
@@ -17,7 +18,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockCraftEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -32,7 +32,7 @@ public class PressureChamber extends MultiBlockMachine {
 
     @ParametersAreNonnullByDefault
     public PressureChamber(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { new ItemStack(Material.SMOOTH_STONE_SLAB), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing down)"), new ItemStack(Material.SMOOTH_STONE_SLAB), new ItemStack(Material.PISTON), new ItemStack(Material.GLASS), new ItemStack(Material.PISTON), new ItemStack(Material.PISTON), new ItemStack(Material.CAULDRON), new ItemStack(Material.PISTON) }, BlockFace.UP);
+        super(itemGroup, item, new ItemStack[] { new ItemStack(Material.SMOOTH_STONE_SLAB), ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing down)"), new ItemStack(Material.SMOOTH_STONE_SLAB), new ItemStack(Material.PISTON), new ItemStack(Material.GLASS), new ItemStack(Material.PISTON), new ItemStack(Material.PISTON), new ItemStack(Material.CAULDRON), new ItemStack(Material.PISTON) }, BlockFace.UP);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -17,7 +18,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -30,7 +30,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.misc.AlloyIngot;
  * The {@link Smeltery} is an upgraded version of the {@link MakeshiftSmeltery}
  * with the additional capabilities to create {@link AlloyIngot}s and utilise an
  * {@link IgnitionChamber}.
- * 
+ *
  * @author TheBusyBiscuit
  * @author AtomicScience
  * @author Sfiguz7
@@ -38,7 +38,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.misc.AlloyIngot;
  * @author emanueljg
  * @author SoSeDiK
  * @author Redemption198
- * 
+ *
  * @see AbstractSmeltery
  * @see MakeshiftSmeltery
  * @see IgnitionChamber
@@ -50,7 +50,7 @@ public class Smeltery extends AbstractSmeltery {
 
     @ParametersAreNonnullByDefault
     public Smeltery(ItemGroup itemGroup, SlimefunItemStack item) {
-        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.NETHER_BRICKS), new CustomItemStack(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.NETHER_BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
+        super(itemGroup, item, new ItemStack[] { null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.NETHER_BRICKS), ItemStackUtil.withNameString(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.NETHER_BRICKS), null, new ItemStack(Material.FLINT_AND_STEEL), null }, BlockFace.DOWN);
 
         addItemSetting(fireBreakingChance);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -22,7 +23,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
@@ -37,12 +37,12 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 /**
  * The {@link IndustrialMiner} is a {@link MultiBlockMachine} that can mine any
  * ores it finds in a given range underneath where it was placed.
- * 
+ *
  * <i>And for those of you who are wondering... yes this is the replacement for the
  * long-time deprecated Digital Miner.</i>
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see AdvancedIndustrialMiner
  * @see MiningTask
  *
@@ -63,7 +63,7 @@ public class IndustrialMiner extends MultiBlockMachine {
         // @formatter:off
         super(itemGroup, item, new ItemStack[] {
             null, null, null,
-            new CustomItemStack(Material.PISTON, "Piston (facing up)"), new ItemStack(Material.CHEST), new CustomItemStack(Material.PISTON, "Piston (facing up)"),
+            ItemStackUtil.withNameString(Material.PISTON, "Piston (facing up)"), new ItemStack(Material.CHEST), ItemStackUtil.withNameString(Material.PISTON, "Piston (facing up)"),
             new ItemStack(baseMaterial), new ItemStack(Material.BLAST_FURNACE), new ItemStack(baseMaterial)
         }, BlockFace.UP);
         // @formatter:on
@@ -80,7 +80,7 @@ public class IndustrialMiner extends MultiBlockMachine {
     /**
      * This returns whether this {@link IndustrialMiner} will output ores as they are.
      * Similar to the Silk Touch {@link Enchantment}.
-     * 
+     *
      * @return Whether to treat ores with Silk Touch
      */
     public boolean hasSilkTouch() {
@@ -91,10 +91,10 @@ public class IndustrialMiner extends MultiBlockMachine {
      * This method returns the range of the {@link IndustrialMiner}.
      * The total area will be determined by the range multiplied by 2 plus the actual center
      * of the machine.
-     * 
+     *
      * So a range of 3 will make the {@link IndustrialMiner} affect an area of 7x7 blocks.
      * 3 on all axis, plus the center of the machine itself.
-     * 
+     *
      * @return The range of this {@link IndustrialMiner}
      */
     public int getRange() {
@@ -122,10 +122,10 @@ public class IndustrialMiner extends MultiBlockMachine {
 
     /**
      * This method returns the outcome that mining certain ores yields.
-     * 
+     *
      * @param material
      *            The {@link Material} of the ore that was mined
-     * 
+     *
      * @return The outcome when mining this ore
      */
     public @Nonnull ItemStack getOutcome(@Nonnull Material material) {
@@ -139,7 +139,7 @@ public class IndustrialMiner extends MultiBlockMachine {
 
     /**
      * This registers a new fuel type for this {@link IndustrialMiner}.
-     * 
+     *
      * @param ores
      *            The amount of ores this allows you to mine
      * @param item
@@ -207,7 +207,7 @@ public class IndustrialMiner extends MultiBlockMachine {
      *
      * @param block
      *            The {@link Block} to check
-     * 
+     *
      * @return Whether this {@link IndustrialMiner} is capable of mining this {@link Block}
      */
     public boolean canMine(@Nonnull Block block) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.blocks.Vein;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
@@ -28,7 +27,7 @@ import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 /**
  * The {@link PickaxeOfVeinMining} is a powerful tool which allows you to mine an entire vein of ores
  * at once. It even works with the fortune {@link Enchantment}.
- * 
+ *
  * @author TheBusyBiscuit
  * @author Linox
  *
@@ -63,7 +62,7 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<ToolUseHandler> {
                     b.getWorld().dropItemNaturally(b.getLocation(), new ItemStack(b.getType()));
                 } else {
                     for (ItemStack drop : b.getDrops(tool)) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), drop.getType().isBlock() ? drop : new CustomItemStack(drop, fortune));
+                        b.getWorld().dropItemNaturally(b.getLocation(), drop.getType().isBlock() ? drop : drop.asQuantity(fortune));
                     }
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -27,7 +27,6 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
@@ -48,7 +47,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 /**
  * This {@link Listener} is responsible for providing the core mechanics of the {@link AncientAltar}
  * and the {@link AncientPedestal}, it also handles the crafting of items using the Altar.
- * 
+ *
  * @author Redemption198
  * @author TheBusyBiscuit
  *
@@ -73,7 +72,7 @@ public class AncientAltarListener implements Listener {
 
     /**
      * This returns all {@link AncientAltar Altars} that are currently in use.
-     * 
+     *
      * @return A {@link Set} of every {@link AncientAltar} currently in use
      */
     public @Nonnull Set<Location> getAltarsInUse() {
@@ -179,7 +178,7 @@ public class AncientAltarListener implements Listener {
             return;
         }
 
-        ItemStack catalyst = new CustomItemStack(p.getInventory().getItemInMainHand(), 1);
+        ItemStack catalyst = p.getInventory().getItemInMainHand().asOne();
         List<Block> pedestals = getPedestals(altar);
 
         if (!altars.contains(altar)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -43,7 +43,6 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.Vector;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.magical.talismans.MagicianTalisman;
@@ -55,13 +54,13 @@ import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 /**
  * This {@link Listener} is responsible for handling any {@link Event}
  * that is required for activating a {@link Talisman}.
- * 
+ *
  * @author TheBusyBiscuit
  * @author StarWishsama
  * @author svr333
  * @author martinbrom
  * @author Sfiguz7
- * 
+ *
  * @see Talisman
  *
  */
@@ -124,7 +123,7 @@ public class TalismanListener implements Listener {
     /**
      * This method is used for the {@link Talisman} of the whirlwind, it returns a copy
      * of a {@link Projectile} that was fired at a {@link Player}.
-     * 
+     *
      * @param p
      *            The {@link Player} who was hit
      * @param projectile
@@ -210,7 +209,7 @@ public class TalismanListener implements Listener {
         /*
          * WARNING: This check is broken as entities now set their
          * equipment to NULL before calling the event!
-         * 
+         *
          * It prevents duplication of handheld items or armor.
          */
         EntityEquipment equipment = entity.getEquipment();
@@ -290,7 +289,7 @@ public class TalismanListener implements Listener {
         if (enchantment != null && Talisman.trigger(e, SlimefunItems.TALISMAN_MAGICIAN)) {
             /*
              * Fixes #2679
-             * 
+             *
              * By default, the Bukkit API doesn't allow us to give enchantment books
              * extra enchantments.
              */
@@ -364,7 +363,7 @@ public class TalismanListener implements Listener {
                     // We do not want to dupe blocks
                     if (!droppedItem.getType().isBlock()) {
                         int amount = Math.max(1, (dropAmount * 2) - droppedItem.getAmount());
-                        e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), new CustomItemStack(droppedItem, amount));
+                        e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), droppedItem.asQuantity(amount));
                         doubledDrops = true;
                     }
                 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/DefaultItemGroups.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/DefaultItemGroups.java
@@ -2,10 +2,10 @@ package io.github.thebusybiscuit.slimefun4.implementation.setup;
 
 import java.time.Month;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.FlexItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.LockedItemGroup;
@@ -19,12 +19,12 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 /**
  * This class holds a reference to every {@link ItemGroup}
  * found in Slimefun itself.
- * 
+ *
  * Addons should use their own {@link ItemGroup} hence why the visible of this class was now
  * changed to package-private. Only {@link SlimefunItemSetup} has access to this class.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see ItemGroup
  * @see LockedItemGroup
  * @see SeasonalItemGroup
@@ -33,36 +33,36 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 class DefaultItemGroups {
 
     // Standard Item Groups
-    protected final ItemGroup weapons = new ItemGroup(new NamespacedKey(Slimefun.instance(), "weapons"), new CustomItemStack(SlimefunItems.BLADE_OF_VAMPIRES, "&7Weapons"), 1);
-    protected final ItemGroup tools = new ItemGroup(new NamespacedKey(Slimefun.instance(), "tools"), new CustomItemStack(SlimefunItems.SMELTERS_PICKAXE, "&7Tools"), 1);
-    protected final ItemGroup usefulItems = new ItemGroup(new NamespacedKey(Slimefun.instance(), "items"), new CustomItemStack(SlimefunItems.BACKPACK_MEDIUM, "&7Useful Items"), 1);
-    protected final ItemGroup basicMachines = new ItemGroup(new NamespacedKey(Slimefun.instance(), "basic_machines"), new CustomItemStack(SlimefunItems.ENHANCED_CRAFTING_TABLE, "&7Basic Machines"), 1);
-    protected final ItemGroup food = new ItemGroup(new NamespacedKey(Slimefun.instance(), "food"), new CustomItemStack(SlimefunItems.FORTUNE_COOKIE, "&7Food"), 2);
-    protected final ItemGroup armor = new ItemGroup(new NamespacedKey(Slimefun.instance(), "armor"), new CustomItemStack(SlimefunItems.DAMASCUS_STEEL_CHESTPLATE, "&7Armor"), 2);
+    protected final ItemGroup weapons = new ItemGroup(new NamespacedKey(Slimefun.instance(), "weapons"), ItemStackUtil.withNameString(SlimefunItems.BLADE_OF_VAMPIRES,"&7Weapons"), 1);
+    protected final ItemGroup tools = new ItemGroup(new NamespacedKey(Slimefun.instance(), "tools"), ItemStackUtil.withNameString(SlimefunItems.SMELTERS_PICKAXE,"&7Tools"), 1);
+    protected final ItemGroup usefulItems = new ItemGroup(new NamespacedKey(Slimefun.instance(), "items"), ItemStackUtil.withNameString(SlimefunItems.BACKPACK_MEDIUM,"&7Useful Items"), 1);
+    protected final ItemGroup basicMachines = new ItemGroup(new NamespacedKey(Slimefun.instance(), "basic_machines"), ItemStackUtil.withNameString(SlimefunItems.ENHANCED_CRAFTING_TABLE,"&7Basic Machines"), 1);
+    protected final ItemGroup food = new ItemGroup(new NamespacedKey(Slimefun.instance(), "food"), ItemStackUtil.withNameString(SlimefunItems.FORTUNE_COOKIE,"&7Food"), 2);
+    protected final ItemGroup armor = new ItemGroup(new NamespacedKey(Slimefun.instance(), "armor"), ItemStackUtil.withNameString(SlimefunItems.DAMASCUS_STEEL_CHESTPLATE,"&7Armor"), 2);
 
     // Magical
-    protected final ItemGroup magicalResources = new ItemGroup(new NamespacedKey(Slimefun.instance(), "magical_items"), new CustomItemStack(SlimefunItems.ENDER_RUNE, "&7Magical Items"), 2);
-    protected final ItemGroup magicalGadgets = new ItemGroup(new NamespacedKey(Slimefun.instance(), "magical_gadgets"), new CustomItemStack(SlimefunItems.INFUSED_ELYTRA, "&7Magical Gadgets"), 3);
-    protected final ItemGroup magicalArmor = new ItemGroup(new NamespacedKey(Slimefun.instance(), "magical_armor"), new CustomItemStack(SlimefunItems.ENDER_HELMET, "&7Magical Armor"), 2);
+    protected final ItemGroup magicalResources = new ItemGroup(new NamespacedKey(Slimefun.instance(), "magical_items"), ItemStackUtil.withNameString(SlimefunItems.ENDER_RUNE,"&7Magical Items"), 2);
+    protected final ItemGroup magicalGadgets = new ItemGroup(new NamespacedKey(Slimefun.instance(), "magical_gadgets"), ItemStackUtil.withNameString(SlimefunItems.INFUSED_ELYTRA,"&7Magical Gadgets"), 3);
+    protected final ItemGroup magicalArmor = new ItemGroup(new NamespacedKey(Slimefun.instance(), "magical_armor"), ItemStackUtil.withNameString(SlimefunItems.ENDER_HELMET,"&7Magical Armor"), 2);
 
     // Resources and tech stuff
-    protected final ItemGroup misc = new ItemGroup(new NamespacedKey(Slimefun.instance(), "misc"), new CustomItemStack(SlimefunItems.TIN_CAN, "&7Miscellaneous"), 2);
-    protected final ItemGroup technicalComponents = new ItemGroup(new NamespacedKey(Slimefun.instance(), "tech_misc"), new CustomItemStack(SlimefunItems.HEATING_COIL, "&7Technical Components"), 2);
-    protected final ItemGroup technicalGadgets = new ItemGroup(new NamespacedKey(Slimefun.instance(), "technical_gadgets"), new CustomItemStack(SlimefunItems.STEEL_JETPACK, "&7Technical Gadgets"), 3);
-    protected final ItemGroup resources = new ItemGroup(new NamespacedKey(Slimefun.instance(), "resources"), new CustomItemStack(SlimefunItems.SYNTHETIC_SAPPHIRE, "&7Resources"), 1);
+    protected final ItemGroup misc = new ItemGroup(new NamespacedKey(Slimefun.instance(), "misc"), ItemStackUtil.withNameString(SlimefunItems.TIN_CAN,"&7Miscellaneous"), 2);
+    protected final ItemGroup technicalComponents = new ItemGroup(new NamespacedKey(Slimefun.instance(), "tech_misc"), ItemStackUtil.withNameString(SlimefunItems.HEATING_COIL,"&7Technical Components"), 2);
+    protected final ItemGroup technicalGadgets = new ItemGroup(new NamespacedKey(Slimefun.instance(), "technical_gadgets"), ItemStackUtil.withNameString(SlimefunItems.STEEL_JETPACK,"&7Technical Gadgets"), 3);
+    protected final ItemGroup resources = new ItemGroup(new NamespacedKey(Slimefun.instance(), "resources"), ItemStackUtil.withNameString(SlimefunItems.SYNTHETIC_SAPPHIRE,"&7Resources"), 1);
 
     // Locked Item Groups
-    protected final LockedItemGroup electricity = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "electricity"), new CustomItemStack(SlimefunItems.NUCLEAR_REACTOR, "&bEnergy and Electricity"), 4, basicMachines.getKey());
-    protected final LockedItemGroup androids = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "androids"), new CustomItemStack(SlimefunItems.PROGRAMMABLE_ANDROID, "&cProgrammable Androids"), 4, basicMachines.getKey());
-    protected final ItemGroup cargo = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "cargo"), new CustomItemStack(SlimefunItems.CARGO_MANAGER, "&cCargo Management"), 4, basicMachines.getKey());
-    protected final LockedItemGroup gps = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "gps"), new CustomItemStack(SlimefunItems.GPS_TRANSMITTER, "&bGPS-based Machines"), 4, basicMachines.getKey());
+    protected final LockedItemGroup electricity = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "electricity"), ItemStackUtil.withNameString(SlimefunItems.NUCLEAR_REACTOR,"&bEnergy and Electricity"), 4, basicMachines.getKey());
+    protected final LockedItemGroup androids = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "androids"), ItemStackUtil.withNameString(SlimefunItems.PROGRAMMABLE_ANDROID,"&cProgrammable Androids"), 4, basicMachines.getKey());
+    protected final ItemGroup cargo = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "cargo"), ItemStackUtil.withNameString(SlimefunItems.CARGO_MANAGER,"&cCargo Management"), 4, basicMachines.getKey());
+    protected final LockedItemGroup gps = new LockedItemGroup(new NamespacedKey(Slimefun.instance(), "gps"), ItemStackUtil.withNameString(SlimefunItems.GPS_TRANSMITTER,"&bGPS-based Machines"), 4, basicMachines.getKey());
 
     // Seasonal Item Groups
-    protected final SeasonalItemGroup christmas = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "christmas"), Month.DECEMBER, 1, new CustomItemStack(SlimefunUtils.getCustomHead("215ba31cde2671b8f176de6a9ffd008035f0590d63ee240be6e8921cd2037a45"), ChatUtils.christmas("Christmas") + " &7(December only)"));
-    protected final SeasonalItemGroup valentinesDay = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "valentines_day"), Month.FEBRUARY, 2, new CustomItemStack(SlimefunUtils.getCustomHead("55d89431d14bfef2060461b4a3565614dc51115c001fae2508e8684bc0ae6a80"), "&dValentine's Day" + " &7(14th February)"));
-    protected final SeasonalItemGroup easter = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "easter"), Month.APRIL, 2, new CustomItemStack(HeadTexture.EASTER_EGG.getAsItemStack(), "&6Easter" + " &7(April)"));
-    protected final SeasonalItemGroup birthday = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "birthday"), Month.OCTOBER, 1, new CustomItemStack(Material.FIREWORK_ROCKET, "&a&lTheBusyBiscuit's Birthday &7(26th October)"));
-    protected final SeasonalItemGroup halloween = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "halloween"), Month.OCTOBER, 1, new CustomItemStack(Material.JACK_O_LANTERN, "&6&lHalloween &7(31st October)"));
+    protected final SeasonalItemGroup christmas = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "christmas"), Month.DECEMBER, 1, ItemStackUtil.withNameString(SlimefunUtils.getCustomHead("215ba31cde2671b8f176de6a9ffd008035f0590d63ee240be6e8921cd2037a45"), ChatUtils.christmas("Christmas") + " &7(December only)"));
+    protected final SeasonalItemGroup valentinesDay = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "valentines_day"), Month.FEBRUARY, 2, ItemStackUtil.withNameString(SlimefunUtils.getCustomHead("55d89431d14bfef2060461b4a3565614dc51115c001fae2508e8684bc0ae6a80"), "&dValentine's Day" + " &7(14th February)"));
+    protected final SeasonalItemGroup easter = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "easter"), Month.APRIL, 2, ItemStackUtil.withNameString(HeadTexture.EASTER_EGG.getAsItemStack(), "&6Easter" + " &7(April)"));
+    protected final SeasonalItemGroup birthday = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "birthday"), Month.OCTOBER, 1, ItemStackUtil.withNameString(Material.FIREWORK_ROCKET, "&a&lTheBusyBiscuit's Birthday &7(26th October)"));
+    protected final SeasonalItemGroup halloween = new SeasonalItemGroup(new NamespacedKey(Slimefun.instance(), "halloween"), Month.OCTOBER, 1, ItemStackUtil.withNameString(Material.JACK_O_LANTERN, "&6&lHalloween &7(31st October)"));
 
     // Flex Item Groups
     protected final FlexItemGroup rickFlexGroup = new RickFlexGroup(new NamespacedKey(Slimefun.instance(), "rick"));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/RickFlexGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/RickFlexGroup.java
@@ -5,11 +5,11 @@ import java.time.Month;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.FlexItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideMode;
@@ -17,7 +17,7 @@ import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 
 /**
  * A super ordinary class.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -25,7 +25,7 @@ class RickFlexGroup extends FlexItemGroup {
 
     // Never instantiate more than once.
     RickFlexGroup(@Nonnull NamespacedKey key) {
-        super(key, new CustomItemStack(Material.NETHER_STAR, "&6&lSuper secret items"), 1);
+        super(key, ItemStackUtil.withNameString(Material.NETHER_STAR, "&6&lSuper secret items"), 1);
     }
 
     // Gonna override this method

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -16,7 +17,6 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.potion.PotionType;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -396,7 +396,7 @@ public final class SlimefunItemSetup {
         .register(plugin);
 
         new BasicCircuitBoard(itemGroups.technicalComponents, SlimefunItems.BASIC_CIRCUIT_BOARD, RecipeType.MOB_DROP,
-        new ItemStack[] {null, null, null, null, new CustomItemStack(SlimefunUtils.getCustomHead(HeadTexture.IRON_GOLEM.getTexture()), "&aIron Golem"), null, null, null, null})
+        new ItemStack[] {null, null, null, null, ItemStackUtil.withNameString(SlimefunUtils.getCustomHead(HeadTexture.IRON_GOLEM.getTexture()), "&aIron Golem"), null, null, null, null})
         .register(plugin);
 
         new UnplaceableBlock(itemGroups.technicalComponents, SlimefunItems.ADVANCED_CIRCUIT_BOARD, RecipeType.ENHANCED_CRAFTING_TABLE,
@@ -2661,7 +2661,7 @@ public final class SlimefunItemSetup {
         .register(plugin);
 
         new StrangeNetherGoo(itemGroups.magicalResources, SlimefunItems.STRANGE_NETHER_GOO, RecipeType.BARTER_DROP,
-        new ItemStack[] {null, null, null, null, new CustomItemStack(HeadTexture.PIGLIN_HEAD.getAsItemStack(), "&fPiglin"), null, null, null, null})
+        new ItemStack[] {null, null, null, null, ItemStackUtil.withNameString(HeadTexture.PIGLIN_HEAD.getAsItemStack(), "&fPiglin"), null, null, null, null})
         .register(plugin);
 
         if (minecraftVersion.isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChestMenuUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChestMenuUtils.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -17,7 +18,6 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
@@ -89,21 +89,17 @@ public final class ChestMenuUtils {
     }
 
     public static @Nonnull ItemStack getBackButton(@Nonnull Player p, String... lore) {
-        return new CustomItemStack(BACK_BUTTON, "&7\u21E6 " + Slimefun.getLocalization().getMessage(p, "guide.back.title"), lore);
+        return ItemStackUtil.withNameLoreString(BACK_BUTTON, "&7\u21E6 " + Slimefun.getLocalization().getMessage(p, "guide.back.title"),lore);
     }
 
     public static @Nonnull ItemStack getMenuButton(@Nonnull Player p) {
-        return new CustomItemStack(MENU_BUTTON, ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "guide.title.settings"), "", "&7\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup"));
+        return ItemStackUtil.withNameLoreString(MENU_BUTTON, ChatColor.YELLOW + Slimefun.getLocalization().getMessage(p, "guide.title.settings"), "", "&7\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.tooltips.open-itemgroup"));
     }
 
     public static @Nonnull ItemStack getSearchButton(@Nonnull Player p) {
-        return new CustomItemStack(SEARCH_BUTTON, meta -> {
-            meta.setDisplayName(ChatColors.color(Slimefun.getLocalization().getMessage(p, "guide.search.name")));
-
-            List<String> lore = Arrays.asList("", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.search.tooltip"));
-            lore.replaceAll(ChatColors::color);
-            meta.setLore(lore);
-        });
+        String displayName =Slimefun.getLocalization().getMessage(p, "guide.search.name");
+        List<String> lore = Arrays.asList("", ChatColor.GRAY + "\u21E8 " + Slimefun.getLocalization().getMessage(p, "guide.search.tooltip"));
+        return ItemStackUtil.withNameLoreString(SEARCH_BUTTON, displayName, lore);
     }
 
     public static @Nonnull ItemStack getWikiButton() {
@@ -111,31 +107,34 @@ public final class ChestMenuUtils {
     }
 
     public static @Nonnull ItemStack getPreviousButton(@Nonnull Player p, int page, int pages) {
+        ItemStack itemStack;
+        String displayName;
+        List<String> lore = Arrays.asList("", ChatColor.GRAY + "(" + page + " / " + pages + ")");
         if (pages == 1 || page == 1) {
-            return new CustomItemStack(PREV_BUTTON_INACTIVE, meta -> {
-                meta.setDisplayName(ChatColor.DARK_GRAY + "\u21E6 " + Slimefun.getLocalization().getMessage(p, "guide.pages.previous"));
-                meta.setLore(Arrays.asList("", ChatColor.GRAY + "(" + page + " / " + pages + ")"));
-            });
+            itemStack = PREV_BUTTON_INACTIVE;
+            displayName = ChatColor.DARK_GRAY + "\u21E6 " + Slimefun.getLocalization()
+                    .getMessage(p, "guide.pages.previous");
+
         } else {
-            return new CustomItemStack(PREV_BUTTON_ACTIVE, meta -> {
-                meta.setDisplayName(ChatColor.WHITE + "\u21E6 " + Slimefun.getLocalization().getMessage(p, "guide.pages.previous"));
-                meta.setLore(Arrays.asList("", ChatColor.GRAY + "(" + page + " / " + pages + ")"));
-            });
+            itemStack = PREV_BUTTON_ACTIVE;
+            displayName = ChatColor.WHITE + "\u21E6 " + Slimefun.getLocalization()
+                    .getMessage(p, "guide.pages.previous");
         }
+        return ItemStackUtil.withNameLoreString(itemStack, displayName, lore);
     }
 
     public static @Nonnull ItemStack getNextButton(@Nonnull Player p, int page, int pages) {
+        ItemStack itemStack;
+        String displayName;
+        List<String> lore = Arrays.asList("", ChatColor.GRAY + "(" + page + " / " + pages + ")");
         if (pages == 1 || page == pages) {
-            return new CustomItemStack(NEXT_BUTTON_INACTIVE, meta -> {
-                meta.setDisplayName(ChatColor.DARK_GRAY + Slimefun.getLocalization().getMessage(p, "guide.pages.next") + " \u21E8");
-                meta.setLore(Arrays.asList("", ChatColor.GRAY + "(" + page + " / " + pages + ")"));
-            });
+            itemStack = NEXT_BUTTON_INACTIVE;
+            displayName = ChatColor.DARK_GRAY + Slimefun.getLocalization().getMessage(p, "guide.pages.next") + " \u21E8";
         } else {
-            return new CustomItemStack(NEXT_BUTTON_ACTIVE, meta -> {
-                meta.setDisplayName(ChatColor.WHITE + Slimefun.getLocalization().getMessage(p, "guide.pages.next") + " \u21E8");
-                meta.setLore(Arrays.asList("", ChatColor.GRAY + "(" + page + " / " + pages + ")"));
-            });
+            itemStack = NEXT_BUTTON_ACTIVE;
+            displayName = ChatColor.WHITE + Slimefun.getLocalization().getMessage(p, "guide.pages.next") + " \u21E8";
         }
+        return ItemStackUtil.withNameLoreString(itemStack, displayName, lore);
     }
 
     public static void drawBackground(@Nonnull ChestMenu menu, int... slots) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ColoredFireworkStar.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ColoredFireworkStar.java
@@ -1,51 +1,44 @@
 package io.github.thebusybiscuit.slimefun4.utils.itemstack;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.ParametersAreNonnullByDefault;
-
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.FireworkEffect.Type;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.FireworkEffectMeta;
 
-import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
-import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedItemFlag;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
  * This simple {@link ItemStack} implementation allows us to obtain
  * a colored {@code Material.FIREWORK_STAR} {@link ItemStack} quickly.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
-public class ColoredFireworkStar extends CustomItemStack {
+public class ColoredFireworkStar extends ItemStack {
 
+    @Deprecated
     @ParametersAreNonnullByDefault
     public ColoredFireworkStar(Color color, String name, String... lore) {
-        super(Material.FIREWORK_STAR, im -> {
-            if (name != null) {
-                im.setDisplayName(ChatColors.color(name));
-            }
+        super(Material.FIREWORK_STAR);
+        itemBuilder(color, name, lore).edit(this);
+    }
 
-            ((FireworkEffectMeta) im).setEffect(FireworkEffect.builder().with(Type.BURST).withColor(color).build());
+    @ParametersAreNonnullByDefault
+    private static ItemStackEditor itemBuilder(Color color, String name, String... lore) {
+        FireworkEffect effect = FireworkEffect.builder().with(Type.BURST).withColor(color).build();
+        return new ItemStackEditor().withColor(color)
+                .withNameString(name)
+                .withLoreString(lore)
+                .withAdditionalFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP)
+                .withMetaTransform(FireworkEffectMeta.class, meta -> meta.setEffect(effect));
+    }
 
-            if (lore.length > 0) {
-                List<String> lines = new ArrayList<>();
-
-                for (String line : lore) {
-                    lines.add(ChatColors.color(line));
-                }
-
-                im.setLore(lines);
-            }
-
-            im.addItemFlags(VersionedItemFlag.HIDE_ADDITIONAL_TOOLTIP);
-        });
+    @ParametersAreNonnullByDefault
+    public static ItemStack createItem(Color color, String name, String... lore) {
+        return itemBuilder(color, name, lore).createAs(Material.FIREWORK_STAR);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ItemStackEditor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ItemStackEditor.java
@@ -1,0 +1,199 @@
+package io.github.thebusybiscuit.slimefun4.utils.itemstack;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Utility object to provide a fluent interface to edit the {@link ItemMeta} on an {@link ItemStack}
+ * The fluent methods do not return a new {@link ItemStackEditor} instance, they mutate the existing instance.
+ * <br>
+ * Unless otherwise stated, all methods will mutate this instance.
+ * This class is meant to be created, immediately used, and then effectively discarded at the call site.
+ * <br>
+ * See the following to actually apply the transformations onto {@link ItemStack}s
+ *
+ * @author md5sha256
+ * @see #edit(ItemStack)
+ * @see #editCopy(ItemStack)
+ * @see #createAs(Material)
+ */
+@ParametersAreNonnullByDefault
+public class ItemStackEditor {
+
+    private Consumer<ItemMeta> transform = meta -> {
+    };
+
+    /**
+     * Chains a consumer
+     *
+     * @param consumer The consumer to chain
+     * @return Returns this
+     */
+    public ItemStackEditor withMetaTransform(@Nonnull Consumer<ItemMeta> consumer) {
+        this.transform = this.transform.andThen(consumer);
+        return this;
+    }
+
+    /**
+     * Chains a consumer for a specific {@link ItemMeta} subtype.
+     *
+     * @param metaClass The class of the {@link ItemMeta}
+     * @param consumer  The consumer to chain
+     * @param <T>       The {@link ItemMeta} subtype
+     * @return Returns this
+     */
+    public <T extends ItemMeta> ItemStackEditor withMetaTransform(@Nonnull Class<T> metaClass, Consumer<T> consumer) {
+        Consumer<ItemMeta> wrapper = meta -> {
+            if (metaClass.isInstance(meta)) {
+                consumer.accept(metaClass.cast(meta));
+            }
+        };
+        return withMetaTransform(wrapper);
+    }
+
+    /**
+     * Set the lore as the given strings. The strings will have their color codes translated.
+     *
+     * @param lore The lore to set
+     * @return Returns this
+     */
+    public ItemStackEditor withLoreString(String... lore) {
+        return withMetaTransform(ItemStackUtil.editLoreString(lore));
+    }
+
+    /**
+     * Set the lore as the given strings. The strings will have their color codes translated.
+     *
+     * @param lore The lore to set
+     * @return Returns this
+     */
+    public ItemStackEditor withLoreString(List<String> lore) {
+        return withMetaTransform(ItemStackUtil.editLoreString(lore));
+    }
+
+    /**
+     * Set the color attribute. See {@link ItemStackUtil#editColor(Color)}
+     *
+     * @param color The color to set
+     * @return Returns this
+     */
+    public ItemStackEditor withColor(Color color) {
+        return withMetaTransform(ItemStackUtil.editColor(color));
+    }
+
+    /**
+     * Set the display name as the given string. The string will be color code translated.
+     *
+     * @param name The name to set
+     * @return Returns this
+     */
+    public ItemStackEditor withNameString(String name) {
+        return withMetaTransform(ItemStackUtil.editNameString(name));
+    }
+
+    /**
+     * Set the display name as the given {@link Component}.
+     *
+     * @param name The name to set
+     * @return Returns this
+     */
+    public ItemStackEditor withName(Component name) {
+        return withMetaTransform(ItemStackUtil.editName(name));
+    }
+
+    /**
+     * Set the lore as the given {@link Component}s
+     *
+     * @param lore The lore to set
+     * @return Returns this
+     */
+    public ItemStackEditor withLore(List<? extends Component> lore) {
+        return withMetaTransform(ItemStackUtil.editLore(lore));
+    }
+
+    /**
+     * Set the lore as the given {@link Component}s
+     *
+     * @param lore The lore to set
+     * @return Returns this
+     */
+    public ItemStackEditor withLore(Component... lore) {
+        return withMetaTransform(ItemStackUtil.editLore(lore));
+    }
+
+    /**
+     * Set the custom model data
+     *
+     * @param data The custom model data
+     * @return Returns this
+     */
+    public ItemStackEditor withCustomModel(@Nullable Integer data) {
+        return withMetaTransform(ItemStackUtil.editCustomModel(data));
+    }
+
+    /**
+     * Adds additional item flags
+     *
+     * @param flags The flags to add
+     * @return Returns this
+     */
+    public ItemStackEditor withAdditionalFlags(ItemFlag... flags) {
+        return withMetaTransform(meta -> meta.addItemFlags(flags));
+    }
+
+    /**
+     * Get the current transform which would be applied to an {@link ItemStack}
+     * This method is pure.
+     *
+     * @return {@link Consumer}
+     */
+    public Consumer<ItemMeta> getTransform() {
+        return this.transform;
+    }
+
+    /**
+     * Edits the given {@link ItemStack} with this {@link ItemStackEditor}s transform
+     * This method is pure
+     *
+     * @param itemStack The item stack to edit
+     * @return Returns the provided {@link ItemStack}
+     */
+    public ItemStack edit(ItemStack itemStack) {
+        itemStack.editMeta(this.transform);
+        return itemStack;
+    }
+
+    /**
+     * Edits a clone of the given {@link ItemStack} with this {@link ItemStackEditor}s transform.
+     * This method is pure.
+     *
+     * @param itemStack The item stack to edit
+     * @return Returns the clone of {@link ItemStack} with edits applied
+     */
+    public ItemStack editCopy(ItemStack itemStack) {
+        return edit(itemStack.clone());
+    }
+
+    /**
+     * Create a new {@link ItemStack} with the given {@link Material} and then applies the {@link ItemStackEditor}s
+     * transform onto it.
+     * This method is pure.
+     *
+     * @param material The material of the item
+     * @return Returns a new {@link ItemStack} with the given material and edits applied
+     */
+    public ItemStack createAs(Material material) {
+        return edit(new ItemStack(material));
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ItemStackUtil.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ItemStackUtil.java
@@ -1,0 +1,249 @@
+package io.github.thebusybiscuit.slimefun4.utils.itemstack;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Utility class to edit the {@link ItemMeta} on an {@link ItemStack}
+ *
+ * @author md5sha256
+ */
+@ParametersAreNonnullByDefault
+public final class ItemStackUtil {
+
+    private ItemStackUtil() {
+        throw new IllegalStateException("Static utility class cannot be instantiated");
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the display name to the given {@link Component}
+     *
+     * @param name The name to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editName(@Nonnull Component name) {
+        return (meta) -> meta.displayName(name);
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the display name to the given {@link String}.
+     * The string will have its color codes translated.
+     *
+     * @param name The name to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editNameString(@Nullable String name) {
+        return (meta) -> {
+            if (name != null) {
+                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+            }
+        };
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the lore to the given {@link String}s.
+     * The strings will have their color codes translated.
+     *
+     * @param lore The lore to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editLoreString(@Nonnull String... lore) {
+        return editLoreString(Arrays.asList(lore));
+    }
+
+
+    /**
+     * Curries a {@link Consumer} which sets the lore to the given {@link String}s.
+     * The strings will have their color codes translated.
+     *
+     * @param lore The lore to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editLoreString(@Nonnull List<String> lore) {
+        return (meta) -> {
+            if (lore.isEmpty()) {
+                meta.lore(Collections.emptyList());
+                return;
+            }
+            List<String> newLore = lore.stream()
+                    .map(line -> ChatColor.translateAlternateColorCodes('&', line))
+                    .toList();
+            meta.setLore(newLore);
+        };
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the lore to the given {@link Component}s.
+     *
+     * @param lore The lore to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editLore(@Nonnull Component... lore) {
+        return editLore(Arrays.asList(lore));
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the lore to the given {@link Component}s.
+     *
+     * @param lore The lore to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editLore(@Nonnull List<? extends Component> lore) {
+        return meta -> meta.lore(lore);
+    }
+
+    /**
+     * Curries a {@link Consumer} which calls {@link PotionMeta#setColor(Color)} or {@link LeatherArmorMeta#setColor(Color)}
+     * if the {@link ItemMeta} is an instance of either.
+     *
+     * @param color The color to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editColor(@Nonnull Color color) {
+        return (meta) -> {
+            if (meta instanceof LeatherArmorMeta leatherArmorMeta) {
+                leatherArmorMeta.setColor(color);
+            }
+            if (meta instanceof PotionMeta potionMeta) {
+                potionMeta.setColor(color);
+            }
+        };
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the custom model data to the given integer
+     *
+     * @param data The custom model data to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editCustomModel(@Nullable Integer data) {
+        return (meta) -> meta.setCustomModelData(data);
+    }
+
+    /**
+     * Sets the display name and lore on a copy of an {@link ItemStack}
+     *
+     * @param item The item
+     * @param name The name
+     * @param lore The lore
+     * @return Returns the cloned item stack with the given name and lore
+     */
+    public static ItemStack withNameLoreString(ItemStack item, String name, String... lore) {
+        Consumer<ItemMeta> consumer = editNameString(name).andThen(editLoreString(lore));
+        ItemStack itemStack = item.clone();
+        itemStack.editMeta(consumer);
+        return itemStack;
+    }
+
+    /**
+     * Sets the display name and lore on a copy of an {@link ItemStack}
+     *
+     * @param item The item
+     * @param name The name
+     * @param lore The lore
+     * @return Returns the cloned item stack with the given name and lore
+     */
+    public static ItemStack withNameLoreString(ItemStack item, String name, List<String> lore) {
+        Consumer<ItemMeta> consumer = editNameString(name).andThen(editLoreString(lore));
+        ItemStack itemStack = item.clone();
+        itemStack.editMeta(consumer);
+        return itemStack;
+    }
+
+    /**
+     * Sets the name on a newly created {@link ItemStack} with the given {@link Material}
+     *
+     * @param material The material
+     * @param name     The name
+     * @return Returns a new stack with the given name, lore, and material
+     */
+    public static ItemStack withNameString(Material material, String name) {
+        return withNameString(new ItemStack(material), name);
+    }
+
+    /**
+     * Sets the display name on a copy of an {@link ItemStack}
+     *
+     * @param item The item
+     * @param name The name
+     * @return Returns the cloned item stack with the given name
+     */
+    public static ItemStack withNameString(ItemStack item, String name) {
+        ItemStack itemStack = item.clone();
+        itemStack.editMeta(editNameString(name));
+        return itemStack;
+    }
+
+    /**
+     * Sets the lore on a copy of an {@link ItemStack}
+     *
+     * @param item The item
+     * @param lore The lore
+     * @return Returns the cloned item stack with the given lore
+     */
+    public static ItemStack withLoreString(ItemStack item, String... lore) {
+        return withLoreString(item, Arrays.asList(lore));
+    }
+
+    /**
+     * Sets the lore on a copy of an {@link ItemStack}
+     *
+     * @param item The item
+     * @param lore The lore
+     * @return Returns the cloned item stack with the given lore
+     */
+    public static ItemStack withLoreString(ItemStack item, List<String> lore) {
+        ItemStack itemStack = item.clone();
+        itemStack.editMeta(editLoreString(lore));
+        return itemStack;
+    }
+
+    /**
+     * Sets the display name and lore on a new {@link ItemStack} with the given {@link Material}
+     *
+     * @param material The material
+     * @param name     The display name
+     * @param lore     The lore
+     * @return Returns the new item stack with the given name, lore, and material
+     */
+    public static ItemStack withNameLoreString(Material material, String name, String... lore) {
+        return withNameLoreString(material, name, Arrays.asList(lore));
+    }
+
+    /**
+     * Sets the display name and lore on a new {@link ItemStack} with the given {@link Material}
+     *
+     * @param material The material
+     * @param name     The display name
+     * @param lore     The lore
+     * @return Returns the new item stack with the given name, lore, and material
+     */
+    public static ItemStack withNameLoreString(Material material, String name, List<String> lore) {
+        return withNameLoreString(new ItemStack(material), name, lore);
+    }
+
+    /**
+     * Sets the lore on a new {@link ItemStack} with the given {@link Material}
+     *
+     * @param material The material
+     * @param lore     The lore
+     * @return Returns the new item stack with the given name, lore, and material
+     */
+    public static ItemStack withLoreString(Material material, List<String> lore) {
+        return withLoreString(new ItemStack(material), lore);
+    }
+}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -16,7 +17,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.inventory.InvUtils;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
@@ -108,7 +108,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
             preset.addItem(i, ChestMenuUtils.getOutputSlotTexture(), ChestMenuUtils.getEmptyClickHandler());
         }
 
-        preset.addItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(22, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
 
         for (int i : getOutputSlots()) {
             preset.addMenuClickHandler(i, ChestMenuUtils.getDefaultOutputHandler());
@@ -118,9 +118,9 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
     /**
      * This method returns the title that is used for the {@link Inventory} of an
      * {@link AContainer} that has been opened by a Player.
-     * 
+     *
      * Override this method to set the title.
-     * 
+     *
      * @return The title of the {@link Inventory} of this {@link AContainer}
      */
     @Nonnull
@@ -131,16 +131,16 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
     /**
      * This method returns the {@link ItemStack} that this {@link AContainer} will
      * use as a progress bar.
-     * 
+     *
      * Override this method to set the progress bar.
-     * 
+     *
      * @return The {@link ItemStack} to use as the progress bar
      */
     public abstract ItemStack getProgressBar();
 
     /**
      * This method returns the max amount of electricity this machine can hold.
-     * 
+     *
      * @return The max amount of electricity this Block can store.
      */
     @Override
@@ -150,7 +150,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
 
     /**
      * This method returns the amount of energy that is consumed per operation.
-     * 
+     *
      * @return The rate of energy consumption
      */
     public int getEnergyConsumption() {
@@ -161,7 +161,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
      * This method returns the speed at which this machine will operate.
      * This can be implemented on an instantiation-level to create different tiers
      * of machines.
-     * 
+     *
      * @return The speed of this machine
      */
     public int getSpeed() {
@@ -172,10 +172,10 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
      * This sets the energy capacity for this machine.
      * This method <strong>must</strong> be called before registering the item
      * and only before registering.
-     * 
+     *
      * @param capacity
      *            The amount of energy this machine can store
-     * 
+     *
      * @return This method will return the current instance of {@link AContainer}, so that can be chained.
      */
     public final AContainer setCapacity(int capacity) {
@@ -191,10 +191,10 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
 
     /**
      * This sets the speed of this machine.
-     * 
+     *
      * @param speed
      *            The speed multiplier for this machine, must be above zero
-     * 
+     *
      * @return This method will return the current instance of {@link AContainer}, so that can be chained.
      */
     public final AContainer setProcessingSpeed(int speed) {
@@ -206,10 +206,10 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
 
     /**
      * This method sets the energy consumed by this machine per tick.
-     * 
+     *
      * @param energyConsumption
      *            The energy consumed per tick
-     * 
+     *
      * @return This method will return the current instance of {@link AContainer}, so that can be chained.
      */
     public final AContainer setEnergyConsumption(int energyConsumption) {
@@ -251,13 +251,13 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
     /**
      * This method returns an internal identifier that is used to identify this {@link AContainer}
      * and its recipes.
-     * 
+     *
      * When adding recipes to an {@link AContainer} we will use this identifier to
      * identify all instances of the same {@link AContainer}.
      * This way we can add the recipes to all instances of the same machine.
-     * 
+     *
      * <strong>This method will be deprecated and replaced in the future</strong>
-     * 
+     *
      * @return The identifier of this machine
      */
     @Nonnull
@@ -344,7 +344,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
                     processor.updateProgressBar(inv, 22, currentOperation);
                     currentOperation.addProgress(1);
                 } else {
-                    inv.replaceExistingItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "));
+                    inv.replaceExistingItem(22, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "));
 
                     for (ItemStack output : currentOperation.getResults()) {
                         inv.pushItem(output.clone(), getOutputSlots());

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -14,7 +15,6 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -122,7 +122,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
             preset.addMenuClickHandler(i, ChestMenuUtils.getDefaultOutputHandler());
         }
 
-        preset.addItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
+        preset.addItem(22, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "), ChestMenuUtils.getEmptyClickHandler());
     }
 
     @Override
@@ -164,7 +164,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
                     inv.pushItem(new ItemStack(Material.BUCKET), getOutputSlots());
                 }
 
-                inv.replaceExistingItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "));
+                inv.replaceExistingItem(22, ItemStackUtil.withNameString(Material.BLACK_STAINED_GLASS_PANE, " "));
 
                 processor.endOperation(l);
                 return 0;
@@ -209,7 +209,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
 
     /**
      * This method returns the max amount of electricity this machine can hold.
-     * 
+     *
      * @return The max amount of electricity this Block can store.
      */
     public int getCapacity() {
@@ -218,7 +218,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
 
     /**
      * This method returns the amount of energy that is consumed per operation.
-     * 
+     *
      * @return The rate of energy consumption
      */
     @Override
@@ -230,10 +230,10 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
      * This sets the energy capacity for this machine.
      * This method <strong>must</strong> be called before registering the item
      * and only before registering.
-     * 
+     *
      * @param capacity
      *            The amount of energy this machine can store
-     * 
+     *
      * @return This method will return the current instance of {@link AGenerator}, so that can be chained.
      */
     public final AGenerator setCapacity(int capacity) {
@@ -249,10 +249,10 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
 
     /**
      * This method sets the energy produced by this machine per tick.
-     * 
+     *
      * @param energyProduced
      *            The energy produced per tick
-     * 
+     *
      * @return This method will return the current instance of {@link AGenerator}, so that can be chained.
      */
     public final AGenerator setEnergyProduction(int energyProduced) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/DirtyChestMenu.java
@@ -13,7 +13,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.inventory.InvUtils;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.items.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 
@@ -33,7 +32,7 @@ public class DirtyChestMenu extends ChestMenu {
 
     /**
      * This method checks whether this {@link DirtyChestMenu} is currently viewed by a {@link Player}.
-     * 
+     *
      * @return Whether anyone is currently viewing this {@link Inventory}
      */
     public boolean hasViewer() {
@@ -136,7 +135,7 @@ public class DirtyChestMenu extends ChestMenu {
         }
 
         if (amount > 0) {
-            return new CustomItemStack(item, amount);
+            return item.asQuantity(amount);
         } else {
             return null;
         }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestDoubleRangeSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestDoubleRangeSetting.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.items.settings;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -7,7 +8,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
@@ -34,14 +34,14 @@ class TestDoubleRangeSetting {
     @Test
     @DisplayName("Test Constructor validation")
     void testConstructorValidation() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST_00", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST_00", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         Assertions.assertThrows(IllegalArgumentException.class, () -> new DoubleRangeSetting(item, "test", min, -1.0, max));
     }
 
     @Test
     @DisplayName("Test min and max getters")
     void testMinMaxGetters() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST_0", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST_0", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         DoubleRangeSetting setting = new DoubleRangeSetting(item, "test", min, 0.5, max);
 
         Assertions.assertEquals(min, setting.getMinimum());
@@ -51,7 +51,7 @@ class TestDoubleRangeSetting {
     @Test
     @DisplayName("Test illegal values")
     void testIllegalValues() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         DoubleRangeSetting setting = new DoubleRangeSetting(item, "test", min, 0.5, max);
 
         item.addItemSetting(setting);
@@ -65,7 +65,7 @@ class TestDoubleRangeSetting {
     @Test
     @DisplayName("Test allowed value")
     void testAllowedValue() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST_2", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DOUBLE_RANGE_TEST_2", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         DoubleRangeSetting setting = new DoubleRangeSetting(item, "test", min, 0.25, max);
 
         item.addItemSetting(setting);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestEnumSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestEnumSetting.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.items.settings;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -7,7 +8,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
@@ -32,7 +32,7 @@ class TestEnumSetting {
     @Test
     @DisplayName("Test Enum Getters")
     void testEnumGetters() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_0", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_0", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         EnumSetting<Material> setting = new EnumSetting<>(item, "test", Material.class, Material.DIAMOND);
         Assertions.assertArrayEquals(Material.values(), setting.getAllowedValues());
     }
@@ -40,7 +40,7 @@ class TestEnumSetting {
     @Test
     @DisplayName("Test illegal values")
     void testIllegalValues() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ENUM_SETTING_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ENUM_SETTING_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         EnumSetting<Material> setting = new EnumSetting<>(item, "test", Material.class, Material.DIAMOND);
 
         item.addItemSetting(setting);
@@ -53,7 +53,7 @@ class TestEnumSetting {
     @Test
     @DisplayName("Test allowed value")
     void testAllowedValue() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_2", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_2", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         EnumSetting<Material> setting = new EnumSetting<>(item, "test", Material.class, Material.DIAMOND);
 
         item.addItemSetting(setting);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestIntRangeSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestIntRangeSetting.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.items.settings;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -7,7 +8,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
@@ -34,14 +34,14 @@ class TestIntRangeSetting {
     @Test
     @DisplayName("Test Constructor validation")
     void testConstructorValidation() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST_00", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST_00", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         Assertions.assertThrows(IllegalArgumentException.class, () -> new IntRangeSetting(item, "test", min, -50, max));
     }
 
     @Test
     @DisplayName("Test min and max getters")
     void testMinMaxGetters() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST_0", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST_0", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         IntRangeSetting setting = new IntRangeSetting(item, "test", min, 1, max);
 
         Assertions.assertEquals(min, setting.getMinimum());
@@ -51,7 +51,7 @@ class TestIntRangeSetting {
     @Test
     @DisplayName("Test illegal values")
     void testIllegalValues() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         IntRangeSetting setting = new IntRangeSetting(item, "test", min, 1, max);
 
         item.addItemSetting(setting);
@@ -65,7 +65,7 @@ class TestIntRangeSetting {
     @Test
     @DisplayName("Test allowed value")
     void testAllowedValue() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST_2", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "INT_RANGE_TEST_2", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         IntRangeSetting setting = new IntRangeSetting(item, "test", min, 1, max);
 
         item.addItemSetting(setting);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestItemSettings.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestItemSettings.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.items.settings;
 
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -9,7 +10,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -35,7 +35,7 @@ class TestItemSettings {
     @Test
     @DisplayName("Test illegal Item Settings arguments")
     void testIllegalItemSettings() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         item.register(plugin);
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> item.addItemSetting());
@@ -46,7 +46,7 @@ class TestItemSettings {
     @Test
     @DisplayName("Test adding an Item Setting")
     void testAddItemSetting() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST_2", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST_2", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         ItemSetting<String> setting = new ItemSetting<>(item, "test", "Hello World");
 
         Assertions.assertTrue(setting.isType(String.class));
@@ -69,7 +69,7 @@ class TestItemSettings {
     @Test
     @DisplayName("Test updating an Item Settings value")
     void testUpdateItemSetting() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST_3", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST_3", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         ItemSetting<String> setting = new ItemSetting<>(item, "test", "Hello World");
 
         item.addItemSetting(setting);
@@ -86,7 +86,7 @@ class TestItemSettings {
     @Test
     @DisplayName("Test Item Settings double-registration")
     void testAlreadyExistingItemSetting() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_SETTINGS_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         ItemSetting<String> setting = new ItemSetting<>(item, "test", "Hello World");
 
         item.addItemSetting(setting);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestMaterialTagSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestMaterialTagSetting.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.junit.jupiter.api.AfterAll;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
@@ -40,7 +40,7 @@ class TestMaterialTagSetting {
     @Test
     @DisplayName("Test Constructor")
     void testConstructorValidation() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_0", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_0", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         MaterialTagSetting setting = new MaterialTagSetting(item, "test", tag);
         Assertions.assertEquals(tag, setting.getDefaultTag());
     }
@@ -48,7 +48,7 @@ class TestMaterialTagSetting {
     @Test
     @DisplayName("Test illegal values")
     void testIllegalValues() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         MaterialTagSetting setting = new MaterialTagSetting(item, "test", tag);
 
         item.addItemSetting(setting);
@@ -62,7 +62,7 @@ class TestMaterialTagSetting {
     @Test
     @DisplayName("Test allowed value")
     void testAllowedValue() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_2", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MATERIAL_SETTING_TEST_2", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         MaterialTagSetting setting = new MaterialTagSetting(item, "test", tag);
 
         item.addItemSetting(setting);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.profiles;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
@@ -88,7 +88,7 @@ class TestGuideHistory {
 
         Assertions.assertEquals(0, history.size());
 
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "HISTORIC_ITEM", new CustomItemStack(Material.DIORITE, "&4I am really running out of ideas for item names"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "HISTORIC_ITEM", ItemStackUtil.withNameString(Material.DIORITE, "&4I am really running out of ideas for item names"));
         history.add(item);
 
         Assertions.assertEquals(1, history.size());
@@ -120,7 +120,7 @@ class TestGuideHistory {
         PlayerProfile profile = TestUtilities.awaitProfile(player);
         GuideHistory history = profile.getGuideHistory();
 
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "itemgroup_guide_history"), new CustomItemStack(Material.BEDROCK, "&4Can't touch this"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "itemgroup_guide_history"), ItemStackUtil.withNameString(Material.BEDROCK, "&4Can't touch this"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> history.add((ItemGroup) null, 1));
         Assertions.assertThrows(IllegalArgumentException.class, () -> history.add(itemGroup, -20));

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
@@ -6,6 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import io.github.thebusybiscuit.slimefun4.implementation.guide.SurvivalSlimefunGuide;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
@@ -65,7 +65,7 @@ class TestGuideOpening {
     @Test
     @DisplayName("Test if an ItemGroup can be opened from the History")
     void testOpenItemGroup() throws InterruptedException {
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "history_itemgroup"), new CustomItemStack(Material.BLUE_TERRACOTTA, "&9Testy test"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "history_itemgroup"), ItemStackUtil.withNameString(Material.BLUE_TERRACOTTA, "&9Testy test"));
 
         SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);
         PlayerProfile profile = prepare(guide, history -> history.add(itemGroup, 1));
@@ -75,7 +75,7 @@ class TestGuideOpening {
     @Test
     @DisplayName("Test if a SlimefunItem can be viewed from the History")
     void testOpenSlimefunItem() throws InterruptedException {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "OPEN_SLIMEFUN_ITEM", new CustomItemStack(Material.PRISMARINE_SHARD, "&5Some Shard I guess"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "OPEN_SLIMEFUN_ITEM", ItemStackUtil.withNameString(Material.PRISMARINE_SHARD, "&5Some Shard I guess"));
 
         SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);
         PlayerProfile profile = prepare(guide, history -> history.add(item));
@@ -98,7 +98,7 @@ class TestGuideOpening {
         String normalTerm = "iron";
         String coloredTerm = ChatColor.DARK_PURPLE + "iron";
 
-        SlimefunItem testItem = TestUtilities.mockSlimefunItem(plugin, "IRON_ITEM", new CustomItemStack(Material.IRON_INGOT, "iron item"));
+        SlimefunItem testItem = TestUtilities.mockSlimefunItem(plugin, "IRON_ITEM", ItemStackUtil.withNameString(Material.IRON_INGOT, "iron item"));
         testItem.register(plugin);
 
         Player player = server.addPlayer();

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/TestMultiBlocks.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/TestMultiBlocks.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.core.multiblocks;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.junit.jupiter.api.AfterAll;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
@@ -33,7 +33,7 @@ class TestMultiBlocks {
     @Test
     @DisplayName("Test Exceptions for invalid MultiBlock constructors")
     void testInvalidConstructors() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", new CustomItemStack(Material.BRICK, "&5Multiblock Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", ItemStackUtil.withNameString(Material.BRICK, "&5Multiblock Test"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> new MultiBlock(null, null, null));
 
@@ -46,7 +46,7 @@ class TestMultiBlocks {
     @Test
     @DisplayName("Test MultiBlock constructor")
     void testValidConstructor() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", new CustomItemStack(Material.BRICK, "&5Multiblock Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", ItemStackUtil.withNameString(Material.BRICK, "&5Multiblock Test"));
         MultiBlock multiblock = new MultiBlock(item, new Material[9], BlockFace.DOWN);
 
         Assertions.assertEquals(item, multiblock.getSlimefunItem());
@@ -57,7 +57,7 @@ class TestMultiBlocks {
     @Test
     @DisplayName("Test symmetric MultiBlocks")
     void testSymmetry() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", new CustomItemStack(Material.BRICK, "&5Multiblock Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", ItemStackUtil.withNameString(Material.BRICK, "&5Multiblock Test"));
 
         MultiBlock multiblock = new MultiBlock(item, new Material[] { null, null, null, Material.DIAMOND_BLOCK, null, Material.DIAMOND_BLOCK, null, Material.DISPENSER, null }, BlockFace.DOWN);
         Assertions.assertTrue(multiblock.isSymmetric());
@@ -69,7 +69,7 @@ class TestMultiBlocks {
     @Test
     @DisplayName("Test equal MultiBlocks being equal")
     void testEqual() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", new CustomItemStack(Material.BRICK, "&5Multiblock Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", ItemStackUtil.withNameString(Material.BRICK, "&5Multiblock Test"));
 
         MultiBlock multiblock = new MultiBlock(item, new Material[] { Material.BIRCH_WOOD, Material.BIRCH_WOOD, Material.BIRCH_WOOD, null, Material.CRAFTING_TABLE, null, Material.BIRCH_WOOD, Material.DISPENSER, Material.BIRCH_WOOD }, BlockFace.DOWN);
         MultiBlock multiblock2 = new MultiBlock(item, new Material[] { Material.BIRCH_WOOD, Material.BIRCH_WOOD, Material.BIRCH_WOOD, null, Material.CRAFTING_TABLE, null, Material.BIRCH_WOOD, Material.DISPENSER, Material.BIRCH_WOOD }, BlockFace.DOWN);
@@ -80,7 +80,7 @@ class TestMultiBlocks {
     @Test
     @DisplayName("Test equal MultiBlocks with Tags but different Materials being equal")
     void testEqualWithTags() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", new CustomItemStack(Material.BRICK, "&5Multiblock Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", ItemStackUtil.withNameString(Material.BRICK, "&5Multiblock Test"));
 
         // The wooden fences are different but the structure should still match.
         MultiBlock multiblock = new MultiBlock(item, new Material[] { Material.OAK_FENCE, Material.OAK_FENCE, Material.OAK_FENCE, null, Material.CRAFTING_TABLE, null, Material.BIRCH_WOOD, Material.DISPENSER, Material.BIRCH_WOOD }, BlockFace.DOWN);
@@ -92,7 +92,7 @@ class TestMultiBlocks {
     @Test
     @DisplayName("Test MultiBlocks with moving pistons still being equal")
     void testEqualWithMovingPistons() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PISTON_MULTIBLOCK_TEST", new CustomItemStack(Material.BRICK, "&5Multiblock Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PISTON_MULTIBLOCK_TEST", ItemStackUtil.withNameString(Material.BRICK, "&5Multiblock Test"));
 
         // Some Pistons are moving but that should not interefere with the Multiblock
         MultiBlock multiblock = new MultiBlock(item, new Material[] { Material.PISTON, Material.MOVING_PISTON, Material.PISTON, null, Material.CRAFTING_TABLE, null, Material.PISTON, Material.STONE, Material.PISTON }, BlockFace.DOWN);
@@ -106,7 +106,7 @@ class TestMultiBlocks {
     @Test
     @DisplayName("Test different MultiBlocks not being equal")
     void testNotEqual() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", new CustomItemStack(Material.BRICK, "&5Multiblock Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_TEST", ItemStackUtil.withNameString(Material.BRICK, "&5Multiblock Test"));
 
         MultiBlock multiblock = new MultiBlock(item, new Material[] { Material.BIRCH_WOOD, Material.BIRCH_WOOD, Material.BIRCH_WOOD, null, Material.CRAFTING_TABLE, null, Material.BIRCH_WOOD, Material.DISPENSER, Material.BIRCH_WOOD }, BlockFace.DOWN);
         MultiBlock multiblock2 = new MultiBlock(item, new Material[] { Material.BIRCH_WOOD, Material.BIRCH_WOOD, Material.BIRCH_WOOD, null, Material.EMERALD_BLOCK, null, Material.BIRCH_WOOD, Material.DISPENSER, Material.BIRCH_WOOD }, BlockFace.DOWN);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearches.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.core.researching;
 
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerPreResearchEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
@@ -78,7 +78,7 @@ class TestResearches {
     void testResearchRegistration() {
         NamespacedKey key = new NamespacedKey(plugin, "test_research");
         Research research = new Research(key, 1, "Test", 100);
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", new CustomItemStack(Material.TORCH, "&bResearch Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", ItemStackUtil.withNameString(Material.TORCH, "&bResearch Test"));
         research.addItems(item, null);
         research.register();
 
@@ -98,7 +98,7 @@ class TestResearches {
     void testDisabledResearch() {
         NamespacedKey key = new NamespacedKey(plugin, "disabled_research");
         Research research = new Research(key, 2, "Test", 100);
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", new CustomItemStack(Material.TORCH, "&bResearch Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", ItemStackUtil.withNameString(Material.TORCH, "&bResearch Test"));
         research.addItems(item);
 
         Slimefun.getRegistry().setResearchingEnabled(true);
@@ -127,7 +127,7 @@ class TestResearches {
     void testAddItems() {
         NamespacedKey key = new NamespacedKey(plugin, "add_items_to_research");
         Research research = new Research(key, 17, "Test", 100);
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_ITEMS_TEST", new CustomItemStack(Material.LAPIS_LAZULI, "&9Adding items is fun"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_ITEMS_TEST", ItemStackUtil.withNameString(Material.LAPIS_LAZULI, "&9Adding items is fun"));
         item.register(plugin);
 
         research.addItems(item.getItem(), null);
@@ -199,7 +199,7 @@ class TestResearches {
         SlimefunGuideImplementation guide = Mockito.mock(SlimefunGuideImplementation.class);
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
-        SlimefunItem sfItem = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", new CustomItemStack(Material.TORCH, "&bResearch Test"));
+        SlimefunItem sfItem = TestUtilities.mockSlimefunItem(plugin, "RESEARCH_TEST", ItemStackUtil.withNameString(Material.TORCH, "&bResearch Test"));
 
         research.unlockFromGuide(guide, player, profile, sfItem, sfItem.getItemGroup(), 0);
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestPermissionsService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestPermissionsService.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.core.services;
 import java.util.Arrays;
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permission;
@@ -15,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
@@ -44,7 +44,7 @@ class TestPermissionsService {
     @ValueSource(booleans = { false, true })
     void testDefaultPermission(boolean registered) {
         PermissionsService service = new PermissionsService(plugin);
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", new CustomItemStack(Material.EMERALD, "&bBad omen"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", ItemStackUtil.withNameString(Material.EMERALD, "&bBad omen"));
 
         if (registered) {
             service.register(Arrays.asList(item), false);
@@ -58,7 +58,7 @@ class TestPermissionsService {
     @DisplayName("Test if a permission node can be set")
     void testSetPermission() {
         PermissionsService service = new PermissionsService(plugin);
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", new CustomItemStack(Material.EMERALD, "&bBad omen"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", ItemStackUtil.withNameString(Material.EMERALD, "&bBad omen"));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> service.setPermission(null, null));
 
@@ -80,7 +80,7 @@ class TestPermissionsService {
     void testHasPermissionTrue() {
         PermissionsService service = new PermissionsService(plugin);
         Player player = server.addPlayer();
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", new CustomItemStack(Material.EMERALD, "&bBad omen"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", ItemStackUtil.withNameString(Material.EMERALD, "&bBad omen"));
 
         Assertions.assertTrue(service.hasPermission(player, null));
         Assertions.assertTrue(service.hasPermission(player, item));
@@ -94,7 +94,7 @@ class TestPermissionsService {
     void testHasPermissionFalse() {
         PermissionsService service = new PermissionsService(plugin);
         Player player = server.addPlayer();
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", new CustomItemStack(Material.EMERALD, "&bBad omen"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", ItemStackUtil.withNameString(Material.EMERALD, "&bBad omen"));
 
         service.setPermission(item, "slimefun.tests");
         Assertions.assertFalse(service.hasPermission(player, item));
@@ -106,7 +106,7 @@ class TestPermissionsService {
         PermissionsService service = new PermissionsService(plugin);
         Player player = server.addPlayer();
         player.setOp(true);
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", new CustomItemStack(Material.EMERALD, "&bBad omen"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", ItemStackUtil.withNameString(Material.EMERALD, "&bBad omen"));
 
         Permission permission = new Permission("slimefun.unit.tests.op", PermissionDefault.OP);
 
@@ -119,7 +119,7 @@ class TestPermissionsService {
     void testHasPermissionSet() {
         PermissionsService service = new PermissionsService(plugin);
         Player player = server.addPlayer();
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", new CustomItemStack(Material.EMERALD, "&bBad omen"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PERMISSIONS_TEST", ItemStackUtil.withNameString(Material.EMERALD, "&bBad omen"));
 
         String permission = "slimefun.unit.tests.permission";
         player.addAttachment(plugin, permission, true);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items;
 
 import java.util.Optional;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterAll;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.UnregisteredItemException;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.WrongItemStackException;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -39,7 +39,7 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test wiki pages getting assigned correctly")
     void testWikiPages() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "WIKI_ITEM", new CustomItemStack(Material.BOOK, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "WIKI_ITEM", ItemStackUtil.withNameString(Material.BOOK, "&cTest"));
         item.register(plugin);
 
         Assertions.assertFalse(item.getWikipage().isPresent());
@@ -57,7 +57,7 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test SlimefunItem registering Recipes properly")
     void testRecipe() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RECIPE_TEST", new CustomItemStack(Material.DIAMOND, "&dAnother one bites the test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RECIPE_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&dAnother one bites the test"));
 
         ItemStack[] recipe = { null, new ItemStack(Material.DIAMOND), null, null, new ItemStack(Material.DIAMOND), null, null, new ItemStack(Material.DIAMOND), null };
         item.setRecipe(recipe);
@@ -73,7 +73,7 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test Recipe outputs being handled correctly")
     void testRecipeOutput() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RECIPE_OUTPUT_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RECIPE_OUTPUT_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         item.register(plugin);
 
         Assertions.assertEquals(item.getItem(), item.getRecipeOutput());
@@ -89,7 +89,7 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test Recipe Types being handled properly")
     void testRecipeType() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RECIPE_TYPE_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "RECIPE_TYPE_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         item.register(plugin);
 
         Assertions.assertNotNull(item.getRecipeType());
@@ -106,18 +106,18 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test SlimefunItem#isItem(...)")
     void testIsItem() {
-        ItemStack item = new CustomItemStack(Material.BEACON, "&cItem Test");
+        ItemStack item = ItemStackUtil.withNameString(Material.BEACON, "&cItem Test");
         String id = "IS_ITEM_TEST";
-        SlimefunItem sfItem = TestUtilities.mockSlimefunItem(plugin, id, new CustomItemStack(Material.BEACON, "&cItem Test"));
+        SlimefunItem sfItem = TestUtilities.mockSlimefunItem(plugin, id, ItemStackUtil.withNameString(Material.BEACON, "&cItem Test"));
         sfItem.register(plugin);
 
         Assertions.assertTrue(sfItem.isItem(sfItem.getItem()));
 
         Assertions.assertFalse(sfItem.isItem(null));
         Assertions.assertFalse(sfItem.isItem(new ItemStack(Material.BEACON)));
-        Assertions.assertFalse(sfItem.isItem(new CustomItemStack(Material.REDSTONE, "&cTest")));
+        Assertions.assertFalse(sfItem.isItem(ItemStackUtil.withNameString(Material.REDSTONE, "&cTest")));
         Assertions.assertFalse(sfItem.isItem(item));
-        Assertions.assertFalse(sfItem.isItem(new CustomItemStack(Material.BEACON, "&cItem Test")));
+        Assertions.assertFalse(sfItem.isItem(ItemStackUtil.withNameString(Material.BEACON, "&cItem Test")));
 
         Assertions.assertEquals(sfItem, SlimefunItem.getByItem(new SlimefunItemStack(sfItem.getId(), item)));
     }
@@ -125,7 +125,7 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test WrongItemStackException")
     void testWrongItemStackException() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "WRONG_ITEMSTACK_EXCEPTION", new CustomItemStack(Material.NETHER_STAR, "&4Do not modify me"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "WRONG_ITEMSTACK_EXCEPTION", ItemStackUtil.withNameString(Material.NETHER_STAR, "&4Do not modify me"));
         item.register(plugin);
         item.load();
 
@@ -136,16 +136,16 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test UnregisteredItemException")
     void testUnregisteredItemException() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "UNREGISTERED_ITEM_EXCEPTION", new CustomItemStack(Material.NETHER_STAR, "&4Do not modify me"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "UNREGISTERED_ITEM_EXCEPTION", ItemStackUtil.withNameString(Material.NETHER_STAR, "&4Do not modify me"));
         Assertions.assertThrows(UnregisteredItemException.class, () -> item.getAddon());
     }
 
     @Test
     @DisplayName("Test SlimefunItem#equals(...)")
     void testEquals() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", new CustomItemStack(Material.LANTERN, "&6We are equal"));
-        SlimefunItem item2 = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", new CustomItemStack(Material.LANTERN, "&6We are equal"));
-        SlimefunItem differentItem = TestUtilities.mockSlimefunItem(plugin, "I_AM_DIFFERENT", new CustomItemStack(Material.LANTERN, "&6We are equal"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", ItemStackUtil.withNameString(Material.LANTERN, "&6We are equal"));
+        SlimefunItem item2 = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", ItemStackUtil.withNameString(Material.LANTERN, "&6We are equal"));
+        SlimefunItem differentItem = TestUtilities.mockSlimefunItem(plugin, "I_AM_DIFFERENT", ItemStackUtil.withNameString(Material.LANTERN, "&6We are equal"));
 
         Assertions.assertEquals(item, item2);
         Assertions.assertNotEquals(item, differentItem);
@@ -155,9 +155,9 @@ class TestSlimefunItem {
     @Test
     @DisplayName("Test SlimefunItem#hashCode()")
     void testHashCode() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", new CustomItemStack(Material.LANTERN, "&6We are equal"));
-        SlimefunItem item2 = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", new CustomItemStack(Material.LANTERN, "&6We are equal"));
-        SlimefunItem differentItem = TestUtilities.mockSlimefunItem(plugin, "I_AM_DIFFERENT", new CustomItemStack(Material.LANTERN, "&6We are equal"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", ItemStackUtil.withNameString(Material.LANTERN, "&6We are equal"));
+        SlimefunItem item2 = TestUtilities.mockSlimefunItem(plugin, "EQUALS_TEST", ItemStackUtil.withNameString(Material.LANTERN, "&6We are equal"));
+        SlimefunItem differentItem = TestUtilities.mockSlimefunItem(plugin, "I_AM_DIFFERENT", ItemStackUtil.withNameString(Material.LANTERN, "&6We are equal"));
 
         Assertions.assertEquals(item.hashCode(), item2.hashCode());
         Assertions.assertNotEquals(item.hashCode(), differentItem.hashCode());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAbstractRecipe.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAbstractRecipe.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
@@ -42,7 +42,7 @@ class TestAbstractRecipe {
     @DisplayName("Test ShapelessRecipe as AbstractRecipe")
     void testShapelessRecipe() {
         NamespacedKey key = new NamespacedKey(plugin, "shapeless_recipe_test");
-        ItemStack result = new CustomItemStack(Material.DIAMOND, "&6Special Diamond :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.DIAMOND, "&6Special Diamond :o");
 
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
         recipe.addIngredient(new MaterialChoice(Material.IRON_NUGGET, Material.GOLD_NUGGET));
@@ -59,7 +59,7 @@ class TestAbstractRecipe {
     @DisplayName("Test ShapedRecipe as AbstractRecipe")
     void testShapedRecipe() {
         NamespacedKey key = new NamespacedKey(plugin, "shaped_recipe_test");
-        ItemStack result = new CustomItemStack(Material.EMERALD, "&6Special Emerald :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.EMERALD, "&6Special Emerald :o");
 
         ShapedRecipe recipe = new ShapedRecipe(key, result);
         recipe.shape("OXO", " X ", "OXO");
@@ -80,7 +80,7 @@ class TestAbstractRecipe {
     @DisplayName("Test invalid recipes as AbstractRecipe")
     void testInvalidRecipes() {
         NamespacedKey key = new NamespacedKey(plugin, "furnace_recipe_test");
-        ItemStack result = new CustomItemStack(Material.COAL, "&6Special Coal :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.COAL, "&6Special Coal :o");
         FurnaceRecipe recipe = new FurnaceRecipe(key, result, Material.COAL, 1, 1);
 
         Assertions.assertNull(AbstractRecipe.of(recipe));

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAutoCrafter.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAutoCrafter.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters;
 
 import javax.annotation.Nonnull;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -44,7 +44,7 @@ class TestAutoCrafter {
     @DisplayName("Test crafting a valid ShapelessRecipe")
     void testValidShapelessRecipe() {
         NamespacedKey key = new NamespacedKey(plugin, "shapeless_recipe_test");
-        ItemStack result = new CustomItemStack(Material.DIAMOND, "&6Special Diamond :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.DIAMOND, "&6Special Diamond :o");
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
         recipe.addIngredient(new MaterialChoice(Material.IRON_NUGGET, Material.GOLD_NUGGET));
 
@@ -71,7 +71,7 @@ class TestAutoCrafter {
     @DisplayName("Test crafting a valid ShapelessRecipe")
     void testDisabledRecipe() {
         NamespacedKey key = new NamespacedKey(plugin, "disabled_recipe_test");
-        ItemStack result = new CustomItemStack(Material.DIAMOND, "&bAmazing Diamond :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.DIAMOND, "&bAmazing Diamond :o");
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
         recipe.addIngredient(new MaterialChoice(Material.GOLD_NUGGET));
 
@@ -100,7 +100,7 @@ class TestAutoCrafter {
     @DisplayName("Test resource leftovers when crafting")
     void testResourceLeftovers() {
         NamespacedKey key = new NamespacedKey(plugin, "resource_leftovers_test");
-        ItemStack result = new CustomItemStack(Material.DIAMOND, "&9Diamond. Nuff said.");
+        ItemStack result = ItemStackUtil.withNameString(Material.DIAMOND, "&9Diamond. Nuff said.");
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
         recipe.addIngredient(new MaterialChoice(Material.HONEY_BOTTLE));
         recipe.addIngredient(new MaterialChoice(Material.HONEY_BOTTLE));
@@ -123,7 +123,7 @@ class TestAutoCrafter {
     @DisplayName("Test crafting an invalid ShapelessRecipe")
     void testInvalidShapelessRecipe() {
         NamespacedKey key = new NamespacedKey(plugin, "shapeless_recipe_test");
-        ItemStack result = new CustomItemStack(Material.DIAMOND, "&6Special Diamond :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.DIAMOND, "&6Special Diamond :o");
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
         recipe.addIngredient(Material.IRON_NUGGET);
 
@@ -142,7 +142,7 @@ class TestAutoCrafter {
     @DisplayName("Test crafting a ShapelessRecipe with a SlimefunItem")
     void ShapelessRecipeWithSlimefunItem() {
         NamespacedKey key = new NamespacedKey(plugin, "shapeless_recipe_test");
-        ItemStack result = new CustomItemStack(Material.DIAMOND, "&6Special Diamond :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.DIAMOND, "&6Special Diamond :o");
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
         recipe.addIngredient(Material.BAMBOO);
 
@@ -173,7 +173,7 @@ class TestAutoCrafter {
     @DisplayName("Test crafting with a full Inventory")
     void testFullInventory() {
         NamespacedKey key = new NamespacedKey(plugin, "shapeless_recipe_test");
-        ItemStack result = new CustomItemStack(Material.DIAMOND, "&6Special Diamond :o");
+        ItemStack result = ItemStackUtil.withNameString(Material.DIAMOND, "&6Special Diamond :o");
         ShapelessRecipe recipe = new ShapelessRecipe(key, result);
         recipe.addIngredient(Material.IRON_NUGGET);
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestAnvilListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestAnvilListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
@@ -62,7 +62,7 @@ class TestAnvilListener {
 
     @Test
     void testAnvilWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCKED_IRON_SWORD", new CustomItemStack(Material.IRON_SWORD, "&6Mock"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCKED_IRON_SWORD", ItemStackUtil.withNameString(Material.IRON_SWORD, "&6Mock"));
         item.register(plugin);
 
         InventoryClickEvent event = mockAnvilEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBackpackListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBackpackListener.java
@@ -3,7 +3,6 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.TagMisconfigurationException;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -14,6 +13,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.mocks.InventoryViewWrapper;
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -84,7 +84,7 @@ class TestBackpackListener {
         PlayerBackpack backpack = profile.createBackpack(size);
         listener.setBackpackId(player, item, 2, backpack.getId());
 
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test_backpacks"), new CustomItemStack(Material.CHEST, "&4Test Backpacks"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test_backpacks"), ItemStackUtil.withNameString(Material.CHEST, "&4Test Backpacks"));
         SlimefunBackpack slimefunBackpack = new SlimefunBackpack(size, itemGroup, item, RecipeType.NULL, new ItemStack[9]);
         slimefunBackpack.register(plugin);
 
@@ -100,15 +100,15 @@ class TestBackpackListener {
         Assertions.assertThrows(IllegalArgumentException.class, () -> listener.setBackpackId(null, null, 1, 1));
         Assertions.assertThrows(IllegalArgumentException.class, () -> listener.setBackpackId(player, null, 1, 1));
         Assertions.assertThrows(IllegalArgumentException.class, () -> listener.setBackpackId(player, new ItemStack(Material.REDSTONE), 1, 1));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> listener.setBackpackId(player, new CustomItemStack(Material.REDSTONE, "Hi", "lore"), 1, 1));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> listener.setBackpackId(player, new CustomItemStack(Material.REDSTONE, "Hi", "lore", "no id"), 1, 1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> listener.setBackpackId(player, ItemStackUtil.withNameLoreString(Material.REDSTONE, "Hi", "lore"), 1, 1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> listener.setBackpackId(player, ItemStackUtil.withNameLoreString(Material.REDSTONE, "Hi", "lore", "no id"), 1, 1));
     }
 
     @Test
     @DisplayName("Test if backpack id is properly applied to the lore")
     void testSetId() throws InterruptedException {
         Player player = server.addPlayer();
-        ItemStack item = new CustomItemStack(Material.CHEST, "&cA mocked Backpack", "", "&7Size: &e" + BACKPACK_SIZE, "&7ID: <ID>", "", "&7&eRight Click&7 to open");
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.CHEST, "&cA mocked Backpack", "", "&7Size: &e" + BACKPACK_SIZE, "&7ID: <ID>", "", "&7&eRight Click&7 to open");
 
         PlayerProfile profile = TestUtilities.awaitProfile(player);
         int id = profile.createBackpack(BACKPACK_SIZE).getId();

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBrewingStandListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBrewingStandListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.block.BrewingStand;
 import org.bukkit.entity.Player;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
@@ -67,7 +67,7 @@ class TestBrewingStandListener {
 
     @Test
     void testBrewingWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCK_POWDER", new CustomItemStack(Material.BLAZE_POWDER, "&6Magic Mock Powder"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCK_POWDER", ItemStackUtil.withNameString(Material.BLAZE_POWDER, "&6Magic Mock Powder"));
         item.register(plugin);
 
         InventoryClickEvent event = mockBrewingEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -15,7 +16,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
@@ -68,7 +68,7 @@ class TestCargoNodeListener {
         Block against = b.getRelative(BlockFace.DOWN);
 
         ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "cargo_test");
-        SlimefunItemStack item = new SlimefunItemStack("MOCK_CARGO_NODE", new CustomItemStack(Material.PLAYER_HEAD, "&4Cargo node!"));
+        SlimefunItemStack item = new SlimefunItemStack("MOCK_CARGO_NODE", ItemStackUtil.withNameString(Material.PLAYER_HEAD, "&4Cargo node!"));
         CargoInputNode node = new CargoInputNode(itemGroup, item, RecipeType.NULL, new ItemStack[9], null);
         node.register(plugin);
 
@@ -87,7 +87,7 @@ class TestCargoNodeListener {
         b.setType(Material.GRASS_BLOCK);
 
         ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "cargo_test");
-        SlimefunItemStack item = new SlimefunItemStack("MOCK_CARGO_NODE_2", new CustomItemStack(Material.PLAYER_HEAD, "&4Cargo node!"));
+        SlimefunItemStack item = new SlimefunItemStack("MOCK_CARGO_NODE_2", ItemStackUtil.withNameString(Material.PLAYER_HEAD, "&4Cargo node!"));
         CargoInputNode node = new CargoInputNode(itemGroup, item, RecipeType.NULL, new ItemStack[9], null);
         node.register(plugin);
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCartographyTableListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCartographyTableListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
@@ -56,7 +56,7 @@ class TestCartographyTableListener {
 
     @Test
     void testCartographyTableWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCKED_PAPER", new CustomItemStack(Material.PAPER, "&6Mock"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCKED_PAPER", ItemStackUtil.withNameString(Material.PAPER, "&6Mock"));
         item.register(plugin);
 
         InventoryClickEvent event = mockCartographyTableEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCauldronListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCauldronListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -15,7 +16,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
@@ -77,7 +77,7 @@ class TestCauldronListener {
     @Test
     @DisplayName("Test Cauldron working as normal with non-leather slimefun items")
     void testCauldronWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CAULDRON_TEST_MOCK", new CustomItemStack(Material.GOLDEN_APPLE, "&6Mock"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CAULDRON_TEST_MOCK", ItemStackUtil.withNameString(Material.GOLDEN_APPLE, "&6Mock"));
         item.register(plugin);
 
         PlayerInteractEvent event = mockCauldronEvent(item.getItem());
@@ -87,7 +87,7 @@ class TestCauldronListener {
     @Test
     @DisplayName("Test Cauldron being cancelled with slimefun leather armor")
     void testCauldronWithSlimefunLeatherArmor() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CAULDRON_TEST_MOCK_LEATHER", new CustomItemStack(Material.LEATHER_BOOTS, "&6Mock Leather Armor"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CAULDRON_TEST_MOCK_LEATHER", ItemStackUtil.withNameString(Material.LEATHER_BOOTS, "&6Mock Leather Armor"));
         item.register(plugin);
 
         PlayerInteractEvent event = mockCauldronEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCoolerListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCoolerListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.CoolerFeedPlayerEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -41,7 +41,7 @@ class TestCoolerListener {
         server = MockBukkit.mock();
         Slimefun plugin = MockBukkit.load(Slimefun.class);
 
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "cooler_test"), new CustomItemStack(Material.SNOWBALL, "Mr. Freeze"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "cooler_test"), ItemStackUtil.withNameString(Material.SNOWBALL, "Mr. Freeze"));
         SlimefunItemStack item = new SlimefunItemStack("TEST_COOLER", Material.SNOWBALL, "&6Test Cooler", "", "&7ID: <ID>");
         cooler = new Cooler(18, itemGroup, item, RecipeType.NULL, new ItemStack[9]);
         cooler.register(plugin);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCraftingTableListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCraftingTableListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang.mutable.MutableObject;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -21,7 +22,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
@@ -93,7 +93,7 @@ class TestCraftingTableListener {
 
     @Test
     void testCraftEventWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCK_DIAMOND", new CustomItemStack(Material.DIAMOND, "&cMock Diamond"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCK_DIAMOND", ItemStackUtil.withNameString(Material.DIAMOND, "&cMock Diamond"));
         item.register(plugin);
 
         CraftItemEvent event = mockCraftingEvent(item.getItem());
@@ -102,7 +102,7 @@ class TestCraftingTableListener {
 
     @Test
     void testCraftEventWithChangingSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CHANGING_ITEM", new CustomItemStack(Material.DIAMOND, "&dChanging Diamond"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "CHANGING_ITEM", ItemStackUtil.withNameString(Material.DIAMOND, "&dChanging Diamond"));
         item.register(plugin);
 
         item.setUseableInWorkbench(true);
@@ -131,7 +131,7 @@ class TestCraftingTableListener {
 
     @Test
     void testPreCraftEventWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCK_DIAMOND2", new CustomItemStack(Material.DIAMOND, "&cMock Diamond"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCK_DIAMOND2", ItemStackUtil.withNameString(Material.DIAMOND, "&cMock Diamond"));
         item.register(plugin);
 
         PrepareItemCraftEvent event = mockPreCraftingEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestGrindstoneListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestGrindstoneListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideMode;
@@ -66,7 +66,7 @@ class TestGrindstoneListener {
 
     @Test
     void testGrindStoneWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ENCHANTED_MOCK_BOOK", new CustomItemStack(Material.ENCHANTED_BOOK, "&6Mock"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ENCHANTED_MOCK_BOOK", ItemStackUtil.withNameString(Material.ENCHANTED_BOOK, "&6Mock"));
         item.register(plugin);
 
         InventoryClickEvent event = mockGrindStoneEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestIronGolemListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestIronGolemListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.IronGolem;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
@@ -78,7 +78,7 @@ class TestIronGolemListener {
     @Test
     @DisplayName("Test Iron Golem Healing with Slimefun Items being cancelled")
     void testWithSlimefunIron() {
-        SlimefunItem slimefunItem = TestUtilities.mockSlimefunItem(plugin, "SLIMEFUN_IRON", new CustomItemStack(Material.IRON_INGOT, "&cSlimefun Iron"));
+        SlimefunItem slimefunItem = TestUtilities.mockSlimefunItem(plugin, "SLIMEFUN_IRON", ItemStackUtil.withNameString(Material.IRON_INGOT, "&cSlimefun Iron"));
         slimefunItem.register(plugin);
 
         // The Event should be cancelled, we do not wanna use Slimefun Items for this

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestItemPickupListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestItemPickupListener.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientPedestal;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
@@ -83,9 +83,9 @@ class TestItemPickupListener {
         ItemStack stack;
 
         if (flag) {
-            stack = new CustomItemStack(Material.DIAMOND, AncientPedestal.ITEM_PREFIX + System.nanoTime());
+            stack = ItemStackUtil.withNameString(Material.DIAMOND, AncientPedestal.ITEM_PREFIX + System.nanoTime());
         } else {
-            stack = new CustomItemStack(Material.DIAMOND, "&5Just a normal named diamond");
+            stack = ItemStackUtil.withNameString(Material.DIAMOND, "&5Just a normal named diamond");
         }
 
         AtomicBoolean removed = new AtomicBoolean(false);
@@ -111,9 +111,9 @@ class TestItemPickupListener {
         ItemStack stack;
 
         if (flag) {
-            stack = new CustomItemStack(Material.DIAMOND, AncientPedestal.ITEM_PREFIX + System.nanoTime());
+            stack = ItemStackUtil.withNameString(Material.DIAMOND, AncientPedestal.ITEM_PREFIX + System.nanoTime());
         } else {
-            stack = new CustomItemStack(Material.DIAMOND, "&5Just a normal named diamond");
+            stack = ItemStackUtil.withNameString(Material.DIAMOND, "&5Just a normal named diamond");
         }
 
         AtomicBoolean removed = new AtomicBoolean(false);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestMultiblockListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestMultiblockListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -15,7 +16,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.MultiBlockInteractEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlock;
@@ -37,7 +37,7 @@ class TestMultiblockListener {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(Slimefun.class);
         listener = new MultiBlockListener(plugin);
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_LISTENER_TEST", new CustomItemStack(Material.DIAMOND, "&9Some multiblock item"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MULTIBLOCK_LISTENER_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&9Some multiblock item"));
         multiblock = new MultiBlock(item, new Material[] { null, Material.EMERALD_BLOCK, null, null, Material.DIAMOND_BLOCK, null, null, Material.LAPIS_BLOCK, null }, BlockFace.SELF);
         Slimefun.getRegistry().getMultiBlocks().add(multiblock);
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestPiglinListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestPiglinListener.java
@@ -2,6 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
 import java.util.UUID;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
@@ -19,7 +20,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.PiglinListener;
@@ -81,7 +81,7 @@ class TestPiglinListener {
 
     @Test
     void testPiglinPickupWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PIGLIN_PICKUP_MOCK", new CustomItemStack(Material.GOLD_INGOT, "&6Piglin Bait"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PIGLIN_PICKUP_MOCK", ItemStackUtil.withNameString(Material.GOLD_INGOT, "&6Piglin Bait"));
         item.register(plugin);
 
         EntityPickupItemEvent event = createPickupEvent(item.getItem());
@@ -100,7 +100,7 @@ class TestPiglinListener {
     @ParameterizedTest
     @EnumSource(value = EquipmentSlot.class, names = { "HAND", "OFF_HAND" })
     void testPiglinInteractWithSlimefunItem(EquipmentSlot hand) {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PIGLIN_GIVE_" + hand.name(), new CustomItemStack(Material.GOLD_INGOT, "&6Piglin Bait"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "PIGLIN_GIVE_" + hand.name(), ItemStackUtil.withNameString(Material.GOLD_INGOT, "&6Piglin Bait"));
         item.register(plugin);
 
         PlayerInteractEntityEvent event = createInteractEvent(hand, item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSmithingTableListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSmithingTableListener.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
@@ -46,9 +46,9 @@ class TestSmithingTableListener {
         Slimefun plugin = MockBukkit.load(Slimefun.class);
         listener = new SmithingTableListener(plugin);
 
-        slimefunTool = TestUtilities.mockSlimefunItem(plugin, "MOCK_DIAMOND_SWORD", new CustomItemStack(Material.DIAMOND_SWORD, "&6Mock"));
-        slimefunIngot = TestUtilities.mockSlimefunItem(plugin, "MOCK_NETHERITE_INGOT", new CustomItemStack(Material.NETHERITE_INGOT, "&6Mock"));
-        usableSlimefunIngot = TestUtilities.mockSlimefunItem(plugin, "MOCK_NETHERITE_INGOT_USABLE", new CustomItemStack(Material.NETHERITE_INGOT, "&6Mock"));
+        slimefunTool = TestUtilities.mockSlimefunItem(plugin, "MOCK_DIAMOND_SWORD", ItemStackUtil.withNameString(Material.DIAMOND_SWORD, "&6Mock"));
+        slimefunIngot = TestUtilities.mockSlimefunItem(plugin, "MOCK_NETHERITE_INGOT", ItemStackUtil.withNameString(Material.NETHERITE_INGOT, "&6Mock"));
+        usableSlimefunIngot = TestUtilities.mockSlimefunItem(plugin, "MOCK_NETHERITE_INGOT_USABLE", ItemStackUtil.withNameString(Material.NETHERITE_INGOT, "&6Mock"));
         usableSlimefunIngot.setUseableInWorkbench(true);
 
         vanillaTool = TestUtilities.mockVanillaItem(plugin, Material.DIAMOND_SWORD, true);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSoulboundListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSoulboundListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -44,7 +44,7 @@ class TestSoulboundListener {
     @DisplayName("Test if the soulbound item is dropped or not")
     void testItemDrop(boolean soulbound) {
         PlayerMock player = server.addPlayer();
-        ItemStack item = new CustomItemStack(Material.DIAMOND_SWORD, "&4Cool Sword");
+        ItemStack item = ItemStackUtil.withNameString(Material.DIAMOND_SWORD, "&4Cool Sword");
         SlimefunUtils.setSoulbound(item, soulbound);
         player.getInventory().setItem(6, item);
         player.setHealth(0);
@@ -83,7 +83,7 @@ class TestSoulboundListener {
     @DisplayName("Test if soulbound item is returned to player")
     void testItemRecover(boolean soulbound) {
         PlayerMock player = server.addPlayer();
-        ItemStack item = new CustomItemStack(Material.DIAMOND_SWORD, "&4Cool Sword");
+        ItemStack item = ItemStackUtil.withNameString(Material.DIAMOND_SWORD, "&4Cool Sword");
         SlimefunUtils.setSoulbound(item, soulbound);
         player.getInventory().setItem(6, item);
         player.setHealth(0);

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestVillagerTradingListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestVillagerTradingListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -68,7 +68,7 @@ class TestVillagerTradingListener {
 
     @Test
     void testTradingWithSlimefunItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCKED_FAKE_EMERALD", new CustomItemStack(Material.EMERALD, "&aFake Emerald"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "MOCKED_FAKE_EMERALD", ItemStackUtil.withNameString(Material.EMERALD, "&aFake Emerald"));
         item.register(plugin);
 
         InventoryClickEvent event = mockClickEvent(item.getItem());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.registration;
 import java.time.LocalDate;
 import java.time.Month;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -49,7 +49,7 @@ class TestItemGroups {
     @Test
     @DisplayName("Test the Getters for ItemGroup")
     void testItemGroupGetters() {
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "getter_test"), new CustomItemStack(Material.DIAMOND_AXE, "&6Testing"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "getter_test"), ItemStackUtil.withNameString(Material.DIAMOND_AXE, "&6Testing"));
 
         Assertions.assertEquals(3, itemGroup.getTier());
         Assertions.assertEquals(new NamespacedKey(Slimefun.instance(), "getter_test"), itemGroup.getKey());
@@ -64,8 +64,8 @@ class TestItemGroups {
     @Test
     @DisplayName("Test adding an item to a ItemGroup")
     void testAddItem() {
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "items_test"), new CustomItemStack(Material.DIAMOND_AXE, "&6Testing"));
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_GROUPS_TEST_ITEM", new CustomItemStack(Material.BAMBOO, "&6Test Bamboo"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "items_test"), ItemStackUtil.withNameString(Material.DIAMOND_AXE, "&6Testing"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_GROUPS_TEST_ITEM", ItemStackUtil.withNameString(Material.BAMBOO, "&6Test Bamboo"));
         item.setItemGroup(itemGroup);
         item.register(plugin);
         item.load();
@@ -89,7 +89,7 @@ class TestItemGroups {
         // Empty Item Groups are also hidden
         Assertions.assertFalse(group.isVisible(player));
 
-        SlimefunItem disabledItem = TestUtilities.mockSlimefunItem(plugin, "DISABLED_ITEM_GROUP_ITEM", new CustomItemStack(Material.BEETROOT, "&4Disabled"));
+        SlimefunItem disabledItem = TestUtilities.mockSlimefunItem(plugin, "DISABLED_ITEM_GROUP_ITEM", ItemStackUtil.withNameString(Material.BEETROOT, "&4Disabled"));
         Slimefun.getItemCfg().setValue("DISABLED_ITEM_GROUP_ITEM.enabled", false);
         disabledItem.setItemGroup(group);
         disabledItem.register(plugin);
@@ -98,7 +98,7 @@ class TestItemGroups {
         // A disabled Item should also make the ItemGroup hide
         Assertions.assertFalse(group.isVisible(player));
 
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_GROUP_HIDDEN_TEST", new CustomItemStack(Material.BAMBOO, "&6Test Bamboo"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_GROUP_HIDDEN_TEST", ItemStackUtil.withNameString(Material.BAMBOO, "&6Test Bamboo"));
         item.setItemGroup(group);
         item.setHidden(true);
         item.register(plugin);
@@ -114,7 +114,7 @@ class TestItemGroups {
     @Test
     @DisplayName("Test ItemGroup#contains")
     void testContains() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_GROUP_TEST_ITEM_2", new CustomItemStack(Material.BOW, "&6Test Bow"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_GROUP_TEST_ITEM_2", ItemStackUtil.withNameString(Material.BOW, "&6Test Bow"));
         item.register(plugin);
         item.load();
 
@@ -130,14 +130,14 @@ class TestItemGroups {
     @Test
     @DisplayName("Test LockedItemGroup parental locking")
     void testLockedItemGroupsParents() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new LockedItemGroup(new NamespacedKey(plugin, "locked"), new CustomItemStack(Material.GOLD_NUGGET, "&6Locked Test"), (NamespacedKey) null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LockedItemGroup(new NamespacedKey(plugin, "locked"), ItemStackUtil.withNameString(Material.GOLD_NUGGET, "&6Locked Test"), (NamespacedKey) null));
 
-        ItemGroup group = new ItemGroup(new NamespacedKey(plugin, "unlocked"), new CustomItemStack(Material.EMERALD, "&5I am SHERlocked"));
+        ItemGroup group = new ItemGroup(new NamespacedKey(plugin, "unlocked"), ItemStackUtil.withNameString(Material.EMERALD, "&5I am SHERlocked"));
         group.register(plugin);
 
-        ItemGroup unregistered = new ItemGroup(new NamespacedKey(plugin, "unregistered"), new CustomItemStack(Material.EMERALD, "&5I am unregistered"));
+        ItemGroup unregistered = new ItemGroup(new NamespacedKey(plugin, "unregistered"), ItemStackUtil.withNameString(Material.EMERALD, "&5I am unregistered"));
 
-        LockedItemGroup locked = new LockedItemGroup(new NamespacedKey(plugin, "locked"), new CustomItemStack(Material.GOLD_NUGGET, "&6Locked Test"), group.getKey(), unregistered.getKey());
+        LockedItemGroup locked = new LockedItemGroup(new NamespacedKey(plugin, "locked"), ItemStackUtil.withNameString(Material.GOLD_NUGGET, "&6Locked Test"), group.getKey(), unregistered.getKey());
         locked.register(plugin);
 
         Assertions.assertTrue(locked.getParents().contains(group));
@@ -159,18 +159,18 @@ class TestItemGroups {
         Player player = server.addPlayer();
         PlayerProfile profile = TestUtilities.awaitProfile(player);
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new LockedItemGroup(new NamespacedKey(plugin, "locked"), new CustomItemStack(Material.GOLD_NUGGET, "&6Locked Test"), (NamespacedKey) null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LockedItemGroup(new NamespacedKey(plugin, "locked"), ItemStackUtil.withNameString(Material.GOLD_NUGGET, "&6Locked Test"), (NamespacedKey) null));
 
-        ItemGroup group = new ItemGroup(new NamespacedKey(plugin, "parent"), new CustomItemStack(Material.EMERALD, "&5I am SHERlocked"));
+        ItemGroup group = new ItemGroup(new NamespacedKey(plugin, "parent"), ItemStackUtil.withNameString(Material.EMERALD, "&5I am SHERlocked"));
         group.register(plugin);
 
-        LockedItemGroup locked = new LockedItemGroup(new NamespacedKey(plugin, "locked2"), new CustomItemStack(Material.GOLD_NUGGET, "&6Locked Test"), group.getKey());
+        LockedItemGroup locked = new LockedItemGroup(new NamespacedKey(plugin, "locked2"), ItemStackUtil.withNameString(Material.GOLD_NUGGET, "&6Locked Test"), group.getKey());
         locked.register(plugin);
 
         // No Items, so it should be unlocked
         Assertions.assertTrue(locked.hasUnlocked(player, profile));
 
-        SlimefunItem item = new SlimefunItem(group, new SlimefunItemStack("LOCKED_ITEMGROUP_TEST", new CustomItemStack(Material.LANTERN, "&6Test Item for locked categories")), RecipeType.NULL, new ItemStack[9]);
+        SlimefunItem item = new SlimefunItem(group, new SlimefunItemStack("LOCKED_ITEMGROUP_TEST", ItemStackUtil.withNameString(Material.LANTERN, "&6Test Item for locked categories")), RecipeType.NULL, new ItemStack[9]);
         item.register(plugin);
         item.load();
 
@@ -192,8 +192,8 @@ class TestItemGroups {
     void ItemGroups() {
         // ItemGroup with current Month
         Month month = LocalDate.now().getMonth();
-        SeasonalItemGroup group = new SeasonalItemGroup(new NamespacedKey(plugin, "seasonal"), month, 1, new CustomItemStack(Material.NETHER_STAR, "&cSeasonal Test"));
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "SEASONAL_ITEM", new CustomItemStack(Material.NETHER_STAR, "&dSeasonal Test Star"));
+        SeasonalItemGroup group = new SeasonalItemGroup(new NamespacedKey(plugin, "seasonal"), month, 1, ItemStackUtil.withNameString(Material.NETHER_STAR, "&cSeasonal Test"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "SEASONAL_ITEM", ItemStackUtil.withNameString(Material.NETHER_STAR, "&dSeasonal Test Star"));
         item.setItemGroup(group);
         item.register(plugin);
         item.load();
@@ -204,14 +204,14 @@ class TestItemGroups {
         Assertions.assertTrue(group.isVisible(player));
 
         // ItemGroup with future Month
-        SeasonalItemGroup itemGroup2 = new SeasonalItemGroup(group.getKey(), month.plus(6), 1, new CustomItemStack(Material.MILK_BUCKET, "&dSeasonal Test"));
+        SeasonalItemGroup itemGroup2 = new SeasonalItemGroup(group.getKey(), month.plus(6), 1, ItemStackUtil.withNameString(Material.MILK_BUCKET, "&dSeasonal Test"));
         Assertions.assertFalse(itemGroup2.isVisible(player));
     }
 
     @Test
     @DisplayName("Test the FlexItemGroup")
     void testFlexItemGroup() {
-        FlexItemGroup group = new FlexItemGroup(new NamespacedKey(plugin, "flex"), new CustomItemStack(Material.REDSTONE, "&4Weird flex but ok")) {
+        FlexItemGroup group = new FlexItemGroup(new NamespacedKey(plugin, "flex"), ItemStackUtil.withNameString(Material.REDSTONE, "&4Weird flex but ok")) {
 
             @Override
             public void open(Player p, PlayerProfile profile, SlimefunGuideMode layout) {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemHandlers.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemHandlers.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.registration;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.IncompatibleItemHandlerException;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BowShootHandler;
@@ -39,7 +39,7 @@ class TestItemHandlers {
     @Test
     @DisplayName("Test validation for Item Handlers")
     void testIllegalItemHandlers() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_HANDLER_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_HANDLER_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         item.register(plugin);
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> item.addItemHandler());
@@ -50,7 +50,7 @@ class TestItemHandlers {
     @Test
     @DisplayName("Test calling an ItemHandler")
     void testItemHandler() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_HANDLER_TEST_2", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEM_HANDLER_TEST_2", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
 
         MockItemHandler handler = new MockItemHandler();
         item.addItemHandler(handler);
@@ -72,12 +72,12 @@ class TestItemHandlers {
     @DisplayName("Test validation for BowShootHandler")
     void testBowShootHandler() {
         BowShootHandler handler = (e, n) -> {};
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "NOT_A_BOW", new CustomItemStack(Material.KELP, "&bNot a bow!"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "NOT_A_BOW", ItemStackUtil.withNameString(Material.KELP, "&bNot a bow!"));
 
         Optional<IncompatibleItemHandlerException> exception = handler.validate(item);
         Assertions.assertTrue(exception.isPresent());
 
-        SlimefunItem bow = TestUtilities.mockSlimefunItem(plugin, "A_BOW", new CustomItemStack(Material.BOW, "&bA bow!"));
+        SlimefunItem bow = TestUtilities.mockSlimefunItem(plugin, "A_BOW", ItemStackUtil.withNameString(Material.BOW, "&bA bow!"));
         Optional<IncompatibleItemHandlerException> exception2 = handler.validate(bow);
         Assertions.assertFalse(exception2.isPresent());
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRechargeableItems.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRechargeableItems.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.registration;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterAll;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import io.github.bakedlibs.dough.common.ChatColors;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -55,7 +55,7 @@ class TestRechargeableItems {
     @Test
     void testSetItemCharge() {
         Rechargeable rechargeable = mock("CHARGING_TEST", 10);
-        ItemStack item = new CustomItemStack(Material.REDSTONE_ORE, "&4Chargeable Item", "", LoreBuilder.powerCharged(0, 10));
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.REDSTONE_ORE, "&4Chargeable Item", "", LoreBuilder.powerCharged(0, 10));
 
         Assertions.assertEquals(0, rechargeable.getItemCharge(item));
 
@@ -69,7 +69,7 @@ class TestRechargeableItems {
     @Test
     void testItemChargeBounds() {
         Rechargeable rechargeable = mock("CHARGING_BOUNDS_TEST", 10);
-        ItemStack item = new CustomItemStack(Material.REDSTONE_BLOCK, "&4Chargeable Item with bounds", "", LoreBuilder.powerCharged(0, 10));
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.REDSTONE_BLOCK, "&4Chargeable Item with bounds", "", LoreBuilder.powerCharged(0, 10));
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> rechargeable.setItemCharge(item, -1));
         Assertions.assertThrows(IllegalArgumentException.class, () -> rechargeable.setItemCharge(item, -0.01F));
@@ -83,7 +83,7 @@ class TestRechargeableItems {
     @Test
     void testAddItemCharge() {
         Rechargeable rechargeable = mock("CHARGING_BOUNDS_TEST", 10);
-        ItemStack item = new CustomItemStack(Material.REDSTONE_BLOCK, "&4Chargeable Item with additions", "", LoreBuilder.powerCharged(0, 10));
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.REDSTONE_BLOCK, "&4Chargeable Item with additions", "", LoreBuilder.powerCharged(0, 10));
 
         Assertions.assertTrue(rechargeable.addItemCharge(item, 10));
         Assertions.assertEquals(10, rechargeable.getItemCharge(item));
@@ -94,7 +94,7 @@ class TestRechargeableItems {
     @Test
     void testAddItemChargeWithoutLore() {
         Rechargeable rechargeable = mock("CHARGING_NO_LORE_TEST", 10);
-        ItemStack item = new CustomItemStack(Material.REDSTONE_BLOCK, "&4Chargeable Item with no lore");
+        ItemStack item = ItemStackUtil.withNameString(Material.REDSTONE_BLOCK, "&4Chargeable Item with no lore");
 
         Assertions.assertEquals(0, rechargeable.getItemCharge(item));
 
@@ -108,7 +108,7 @@ class TestRechargeableItems {
     @Test
     void testRemoveItemCharge() {
         Rechargeable rechargeable = mock("CHARGING_BOUNDS_TEST", 10);
-        ItemStack item = new CustomItemStack(Material.REDSTONE_BLOCK, "&4Chargeable Item with removal", "", LoreBuilder.powerCharged(0, 10));
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.REDSTONE_BLOCK, "&4Chargeable Item with removal", "", LoreBuilder.powerCharged(0, 10));
 
         Assertions.assertFalse(rechargeable.removeItemCharge(item, 1));
 
@@ -122,7 +122,7 @@ class TestRechargeableItems {
 
     private RechargeableMock mock(String id, float capacity) {
         ItemGroup itemGroup = TestUtilities.getItemGroup(plugin, "rechargeable");
-        return new RechargeableMock(itemGroup, new SlimefunItemStack(id, new CustomItemStack(Material.REDSTONE_LAMP, "&3" + id)), capacity);
+        return new RechargeableMock(itemGroup, new SlimefunItemStack(id, ItemStackUtil.withNameString(Material.REDSTONE_LAMP, "&3" + id)), capacity);
     }
 
     private class RechargeableMock extends SlimefunItem implements Rechargeable {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.registration;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.AfterAll;
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.IdConflictException;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemState;
@@ -38,7 +38,7 @@ class TestSlimefunItemRegistration {
     @DisplayName("Test SlimefunItem registering properly")
     void testSuccessfulRegistration() {
         String id = "TEST_ITEM";
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, id, new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, id, ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
 
         Assertions.assertEquals(ItemState.UNREGISTERED, item.getState());
 
@@ -53,7 +53,7 @@ class TestSlimefunItemRegistration {
     @Test
     @DisplayName("Test disabled SlimefunItem being disabled")
     void testDisabledItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DISABLED_ITEM", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DISABLED_ITEM", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         Slimefun.getItemCfg().setValue("DISABLED_ITEM.enabled", false);
         item.register(plugin);
 
@@ -75,10 +75,10 @@ class TestSlimefunItemRegistration {
     @Test
     @DisplayName("Test id conflicts being handled with an exception")
     void testIdConflict() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DUPLICATE_ID", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "DUPLICATE_ID", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         item.register(plugin);
 
-        SlimefunItem item2 = TestUtilities.mockSlimefunItem(plugin, "DUPLICATE_ID", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item2 = TestUtilities.mockSlimefunItem(plugin, "DUPLICATE_ID", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         Assertions.assertThrows(IdConflictException.class, () -> item2.register(plugin));
 
         Assertions.assertEquals(ItemState.ENABLED, item.getState());
@@ -88,7 +88,7 @@ class TestSlimefunItemRegistration {
     @Test
     @DisplayName("Test ItemGroup registration when registering an item")
     void testItemGroupRegistration() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEMGROUP_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "ITEMGROUP_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         item.register(plugin);
         item.load();
 
@@ -96,7 +96,7 @@ class TestSlimefunItemRegistration {
         Assertions.assertThrows(IllegalArgumentException.class, () -> item.setItemGroup(null));
 
         ItemGroup itemGroup = item.getItemGroup();
-        ItemGroup itemGroup2 = new ItemGroup(new NamespacedKey(plugin, "test2"), new CustomItemStack(Material.OBSIDIAN, "&6Test 2"));
+        ItemGroup itemGroup2 = new ItemGroup(new NamespacedKey(plugin, "test2"), ItemStackUtil.withNameString(Material.OBSIDIAN, "&6Test 2"));
 
         Assertions.assertTrue(itemGroup.contains(item));
         Assertions.assertFalse(itemGroup2.contains(item));
@@ -111,7 +111,7 @@ class TestSlimefunItemRegistration {
     @Test
     @DisplayName("Test hidden items being hidden")
     void testHiddenItem() {
-        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "HIDDEN_TEST", new CustomItemStack(Material.DIAMOND, "&cTest"));
+        SlimefunItem item = TestUtilities.mockSlimefunItem(plugin, "HIDDEN_TEST", ItemStackUtil.withNameString(Material.DIAMOND, "&cTest"));
         item.setHidden(true);
         item.register(plugin);
         item.load();

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -28,7 +29,6 @@ import org.mockito.Mockito;
 
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.block.BlockMock;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunBlockPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -57,19 +57,19 @@ public final class TestUtilities {
 
     @ParametersAreNonnullByDefault
     public static @Nonnull ItemGroup getItemGroup(Plugin plugin, String name) {
-        return new ItemGroup(new NamespacedKey(plugin, name), new CustomItemStack(Material.NETHER_STAR, "&4Test ItemGroup"));
+        return new ItemGroup(new NamespacedKey(plugin, name), ItemStackUtil.withNameString(Material.NETHER_STAR, "&4Test ItemGroup"));
     }
 
     @ParametersAreNonnullByDefault
     public static @Nonnull SlimefunItem mockSlimefunItem(Plugin plugin, String id, ItemStack item) {
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test"), new CustomItemStack(Material.EMERALD, "&4Test ItemGroup"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test"), ItemStackUtil.withNameString(Material.EMERALD, "&4Test ItemGroup"));
 
         return new MockSlimefunItem(itemGroup, item, id);
     }
 
     @ParametersAreNonnullByDefault
     public static @Nonnull VanillaItem mockVanillaItem(Plugin plugin, Material type, boolean enabled) {
-        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test"), new CustomItemStack(Material.EMERALD, "&4Test ItemGroup"));
+        ItemGroup itemGroup = new ItemGroup(new NamespacedKey(plugin, "test"), ItemStackUtil.withNameString(Material.EMERALD, "&4Test ItemGroup"));
         VanillaItem item = new VanillaItem(itemGroup, new ItemStack(type), type.name(), RecipeType.NULL, new ItemStack[9]);
         Slimefun.getItemCfg().setValue(type.name() + ".enabled", enabled);
         return item;
@@ -105,7 +105,7 @@ public final class TestUtilities {
         Slimefun.getRegistry().getWorlds().put(world.getName(), new BlockStorage(world));
         return world;
     }
-    
+
     public static Block placeSlimefunBlock(ServerMock server, ItemStack item, World world, Player player) {
         int x = TestUtilities.randomInt();
         int z = TestUtilities.randomInt();

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestItemStackWrapper.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestItemStackWrapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterAll;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 
@@ -35,7 +35,7 @@ class TestItemStackWrapper {
     @Test
     @DisplayName("Test if an ItemStackWrappers can be compared properly (With ItemMeta)")
     void testEqualityWithItemMeta() {
-        ItemStack item = new CustomItemStack(Material.LAVA_BUCKET, "&4SuperHot.exe", "", "&6Hello");
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.LAVA_BUCKET, "&4SuperHot.exe", "", "&6Hello");
         ItemStackWrapper wrapper = ItemStackWrapper.wrap(item);
 
         Assertions.assertEquals(item.getType(), wrapper.getType());
@@ -59,7 +59,7 @@ class TestItemStackWrapper {
     @Test
     @DisplayName("Test if an ItemStackWrapper is immutable")
     void testImmutability() {
-        ItemStack item = new CustomItemStack(Material.LAVA_BUCKET, "&4SuperHot.exe", "", "&6Hello");
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.LAVA_BUCKET, "&4SuperHot.exe", "", "&6Hello");
         ItemStackWrapper wrapper = ItemStackWrapper.wrap(item);
 
         Assertions.assertThrows(UnsupportedOperationException.class, () -> wrapper.setType(Material.BEDROCK));
@@ -76,7 +76,7 @@ class TestItemStackWrapper {
     void testWrapperChecking() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> ItemStackWrapper.wrap(null));
         Assertions.assertThrows(IllegalArgumentException.class, () -> ItemStackWrapper.forceWrap(null));
-        ItemStack item = new CustomItemStack(Material.IRON_INGOT, "A Name", "line 1", "line2");
+        ItemStack item = ItemStackUtil.withNameLoreString(Material.IRON_INGOT, "A Name", "line 1", "line2");
         ItemStackWrapper wrapper = ItemStackWrapper.wrap(item);
         ItemStackWrapper secondWrap = ItemStackWrapper.wrap(wrapper);
         // We want to check that the wrapper returned is of reference equality
@@ -90,7 +90,7 @@ class TestItemStackWrapper {
     @Test
     @DisplayName("Test wrapping an ItemStack Array")
     void testWrapArray() {
-        ItemStack[] items = { new ItemStack(Material.DIAMOND), null, new ItemStack(Material.EMERALD), new CustomItemStack(Material.REDSTONE, "&4Firey thing", "with lore :o") };
+        ItemStack[] items = { new ItemStack(Material.DIAMOND), null, new ItemStack(Material.EMERALD), ItemStackUtil.withNameLoreString(Material.REDSTONE, "&4Firey thing", "with lore :o") };
         ItemStackWrapper[] wrappers = ItemStackWrapper.wrapArray(items);
 
         Assertions.assertEquals(items.length, wrappers.length);
@@ -111,7 +111,7 @@ class TestItemStackWrapper {
     @Test
     @DisplayName("Test wrapping an ItemStack List")
     void testWrapList() {
-        List<ItemStack> items = Arrays.asList(new ItemStack(Material.DIAMOND), null, new ItemStack(Material.EMERALD), new CustomItemStack(Material.REDSTONE, "&4Firey thing", "with lore :o"));
+        List<ItemStack> items = Arrays.asList(new ItemStack(Material.DIAMOND), null, new ItemStack(Material.EMERALD), ItemStackUtil.withNameLoreString(Material.REDSTONE, "&4Firey thing", "with lore :o"));
         List<? extends ItemStack> wrappers = ItemStackWrapper.wrapList(items);
 
         Assertions.assertEquals(items.size(), wrappers.size());

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.utils;
 
+import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -9,7 +10,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -49,7 +49,7 @@ class TestSoulboundItem {
     @Test
     @DisplayName("Test whether an Item can be marked as soulbound")
     void testSetSoulbound() {
-        ItemStack item = new CustomItemStack(Material.DIAMOND, "&cI wanna be soulbound!");
+        ItemStack item = ItemStackUtil.withNameString(Material.DIAMOND, "&cI wanna be soulbound!");
 
         Assertions.assertFalse(SlimefunUtils.isSoulbound(item));
 
@@ -65,7 +65,7 @@ class TestSoulboundItem {
     @Test
     @DisplayName("Make sure that marking an item as soulbound twice has no effect")
     void testDoubleCalls() {
-        ItemStack item = new CustomItemStack(Material.DIAMOND, "&cI wanna be soulbound!");
+        ItemStack item = ItemStackUtil.withNameString(Material.DIAMOND, "&cI wanna be soulbound!");
 
         SlimefunUtils.setSoulbound(item, true);
         SlimefunUtils.setSoulbound(item, true);
@@ -83,7 +83,7 @@ class TestSoulboundItem {
     @Test
     @DisplayName("Test that soulbound Slimefun Items are soulbound")
     void testSoulboundSlimefunItem() {
-        SlimefunItem item = new SoulboundMock(new ItemGroup(new NamespacedKey(plugin, "soulbound_itemgroup"), new CustomItemStack(Material.REDSTONE, "&4Walshrus forever")));
+        SlimefunItem item = new SoulboundMock(new ItemGroup(new NamespacedKey(plugin, "soulbound_itemgroup"), ItemStackUtil.withNameString(Material.REDSTONE, "&4Walshrus forever")));
         item.register(plugin);
 
         Assertions.assertTrue(SlimefunUtils.isSoulbound(item.getItem()));


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
I can't make this a draft PR but treat this as such. 
Adds a paper-dependent replacement for CustomItemStack. 
Fixes issues with "class cast exception ... is not a CraftItemStack" due to usages of CustomItemStack.

This should be refactored into dough but i've made a PR here just to see the damage. 
A suggested solution by @Intybyte is to keep the existing CustomItemStack constructors and then add some sort of `.getDelegate` or `build()` method. In any case, all existing usages will cause compile errors. 

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
