### PR TITLE
[Api] Give & Pick Slimefun Item api

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -233,7 +233,7 @@ public class SlimefunItem implements Placeable {
      *
      * @return The {@link ItemStack} that is given to the {@link Player}
      * */
-    public @Nonnull ItemStack getGiveItemResult(Player player) {
+    public @Nonnull ItemStack getGiveItemResult(@Nonnull Player player) {
         return getItem();
     }
 
@@ -248,7 +248,7 @@ public class SlimefunItem implements Placeable {
      *
      * @return The {@link ItemStack} that is picked when middle-clicking this {@link SlimefunItem}
      */
-    public @Nonnull ItemStack getPickBlockResult(Player player, Block block) {
+    public @Nonnull ItemStack getPickBlockResult(@Nonnull Player player, @Nonnull Block block) {
         return getItem();
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -17,6 +17,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -39,6 +40,7 @@ import io.github.thebusybiscuit.slimefun4.core.SlimefunRegistry;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotConfigurable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Placeable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactive;
+import io.github.thebusybiscuit.slimefun4.core.commands.subcommands.GiveCommand;
 import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.core.handlers.GlobalItemHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -220,6 +222,34 @@ public class SlimefunItem implements Placeable {
      */
     public @Nonnull ItemStack getItem() {
         return itemStackTemplate;
+    }
+
+    /**
+     * This returns the {@link ItemStack} result when a {@link Player}
+     * is given this item via the {@link GiveCommand}.
+     *
+     * @param player
+     *            The {@link Player} who will receive the item
+     *
+     * @return The {@link ItemStack} that is given to the {@link Player}
+     * */
+    public @Nonnull ItemStack getGiveItemResult(Player player) {
+        return getItem();
+    }
+
+    /**
+     * This returns the {@link ItemStack} result when a {@link Player}
+     * in creative mode middle-clicks this {@link SlimefunItem}'s {@link Block}.
+     *
+     * @param player
+     *            The {@link Player} who middle-clicked this {@link SlimefunItem}
+     * @param block
+     *            The {@link Block} middle-clicked
+     *
+     * @return The {@link ItemStack} that is picked when middle-clicking this {@link SlimefunItem}
+     */
+    public @Nonnull ItemStack getPickBlockResult(Player player, Block block) {
+        return getItem();
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/GiveCommand.java
@@ -19,7 +19,7 @@ import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-class GiveCommand extends SubCommand {
+public class GiveCommand extends SubCommand {
 
     private static final String PLACEHOLDER_PLAYER = "%player%";
     private static final String PLACEHOLDER_ITEM = "%item%";
@@ -65,7 +65,7 @@ class GiveCommand extends SubCommand {
 
             if (amount > 0) {
                 Slimefun.getLocalization().sendMessage(p, "messages.given-item", true, msg -> msg.replace(PLACEHOLDER_ITEM, sfItem.getItemName()).replace(PLACEHOLDER_AMOUNT, String.valueOf(amount)));
-                Map<Integer, ItemStack> excess = p.getInventory().addItem(new CustomItemStack(sfItem.getItem(), amount));
+                Map<Integer, ItemStack> excess = p.getInventory().addItem(new CustomItemStack(sfItem.getGiveItemResult(p), amount));
                 if (Slimefun.getCfg().getBoolean("options.drop-excess-sf-give-items") && !excess.isEmpty()) {
                     for (ItemStack is : excess.values()) {
                         p.getWorld().dropItem(p.getLocation(), is);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/MiddleClickListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/MiddleClickListener.java
@@ -42,7 +42,10 @@ public class MiddleClickListener implements Listener {
          * ClickType is not MIDDLE but CREATIVE (because this ClickType covers
          * multiple cases, we have to filter out more later on)
          */
-        if (e.getClick() == ClickType.CREATIVE && e.getSlotType() == SlotType.QUICKBAR && e.getWhoClicked() instanceof Player player) {
+        if (e.getClick() == ClickType.CREATIVE
+        	&& e.getSlotType() == SlotType.QUICKBAR
+        	&& e.getWhoClicked() instanceof Player player
+        ) {
             // get the block the player is looking at for later
             Block b = player.getTargetBlockExact(5);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/MiddleClickListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/MiddleClickListener.java
@@ -6,6 +6,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
@@ -41,8 +42,7 @@ public class MiddleClickListener implements Listener {
          * ClickType is not MIDDLE but CREATIVE (because this ClickType covers
          * multiple cases, we have to filter out more later on)
          */
-        if (e.getClick() == ClickType.CREATIVE && e.getSlotType() == SlotType.QUICKBAR) {
-            HumanEntity player = e.getWhoClicked();
+        if (e.getClick() == ClickType.CREATIVE && e.getSlotType() == SlotType.QUICKBAR && e.getWhoClicked() instanceof Player player) {
             // get the block the player is looking at for later
             Block b = player.getTargetBlockExact(5);
 
@@ -74,7 +74,7 @@ public class MiddleClickListener implements Listener {
             }
 
             // Give the item, doing it like this will not alter any other cases.
-            e.setCursor(sfItem.getItem().clone());
+            e.setCursor(sfItem.getPickBlockResult(player, b).clone());
         }
     }
 


### PR DESCRIPTION
## Description
Addons with complex SlimefunItem's that can have data different for the same slimefun item often have problems with the middle click & give item command, as they may lack some data that would be there when attained in survival, this PR adds 2 methods to help solve that problem.

## Proposed changes
- Added `SlimefunItem#getGiveItemResult(Player)`
  - Defaults to `getItem` and is called in `GiveCommand` in place of `getItem`
- Added `SlimefunItem#getPickBlockResult(Player, Block)`
  - Also defaults to `getItem` and is called in `MiddleClickListener` in place of `getItem`
    - Also adds an instanceof to `MiddleClickListener` as the event returns `HumanEntity` not `Player` and I didn't want it to be inconsistent, testing is needed to make sure it still works

## Related Issues (if applicable)
N/A

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
