### PR TITLE
Remove EnumMap and EnumSet usages

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -47,7 +47,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.UniversalBlockMenu;
 /**
  * This class houses a lot of instances of {@link Map} and {@link List} that hold
  * various mappings and collections related to {@link SlimefunItem}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  */
@@ -87,7 +87,7 @@ public final class SlimefunRegistry {
     private final Map<String, BlockStorage> worlds = new ConcurrentHashMap<>();
     private final Map<String, BlockInfoConfig> chunks = new HashMap<>();
     private final Map<SlimefunGuideMode, SlimefunGuideImplementation> guides = new EnumMap<>(SlimefunGuideMode.class);
-    private final Map<EntityType, Set<ItemStack>> mobDrops = new EnumMap<>(EntityType.class);
+    private final Map<EntityType, Set<ItemStack>> mobDrops = new HashMap<>();
 
     private final Map<String, BlockMenuPreset> blockMenuPresets = new HashMap<>();
     private final Map<String, UniversalBlockMenu> universalInventories = new HashMap<>();
@@ -120,7 +120,7 @@ public final class SlimefunRegistry {
      * Auto-Loading will automatically call {@link SlimefunItem#load()} when the item is registered.
      * Normally that method is called after the {@link Server} finished starting up.
      * But in the unusual scenario if a {@link SlimefunItem} is registered after that, this is gonna cover that.
-     * 
+     *
      * @return Whether auto-loading is enabled
      */
     public boolean isAutoLoadingEnabled() {
@@ -132,7 +132,7 @@ public final class SlimefunRegistry {
      * call {@link SlimefunItem#load()}.
      * Normally this method call is delayed but when the {@link Server} is already running,
      * the method can be called instantaneously.
-     * 
+     *
      * @param mode
      *            Whether auto-loading should be enabled
      */
@@ -142,7 +142,7 @@ public final class SlimefunRegistry {
 
     /**
      * This returns a {@link List} containing every enabled {@link ItemGroup}.
-     * 
+     *
      * @return {@link List} containing every enabled {@link ItemGroup}
      */
     public @Nonnull List<ItemGroup> getAllItemGroups() {
@@ -151,7 +151,7 @@ public final class SlimefunRegistry {
 
     /**
      * This {@link List} contains every {@link SlimefunItem}, even disabled items.
-     * 
+     *
      * @return A {@link List} containing every {@link SlimefunItem}
      */
     public @Nonnull List<SlimefunItem> getAllSlimefunItems() {
@@ -160,7 +160,7 @@ public final class SlimefunRegistry {
 
     /**
      * This {@link List} contains every <strong>enabled</strong> {@link SlimefunItem}.
-     * 
+     *
      * @return A {@link List} containing every enabled {@link SlimefunItem}
      */
     @Nonnull
@@ -170,7 +170,7 @@ public final class SlimefunRegistry {
 
     /**
      * This returns a {@link List} containing every enabled {@link Research}.
-     * 
+     *
      * @return A {@link List} containing every enabled {@link Research}
      */
     @Nonnull
@@ -181,7 +181,7 @@ public final class SlimefunRegistry {
     /**
      * This method returns a {@link Set} containing the {@link UUID} of every
      * {@link Player} who is currently unlocking a {@link Research}.
-     * 
+     *
      * @return A {@link Set} holding the {@link UUID} from every {@link Player}
      *         who is currently unlocking a {@link Research}
      */
@@ -226,7 +226,7 @@ public final class SlimefunRegistry {
 
     /**
      * This method returns a {@link List} of every enabled {@link MultiBlock}.
-     * 
+     *
      * @return A {@link List} containing every enabled {@link MultiBlock}
      */
     @Nonnull
@@ -241,10 +241,10 @@ public final class SlimefunRegistry {
      * This mainly only exists for internal purposes, if you want to open a certain section
      * using the {@link SlimefunGuide}, then please use the static methods provided in the
      * {@link SlimefunGuide} class.
-     * 
+     *
      * @param mode
      *            The {@link SlimefunGuideMode}
-     * 
+     *
      * @return The corresponding {@link SlimefunGuideImplementation}
      */
     @Nonnull
@@ -263,7 +263,7 @@ public final class SlimefunRegistry {
     /**
      * This returns a {@link Map} connecting the {@link EntityType} with a {@link Set}
      * of {@link ItemStack ItemStacks} which would be dropped when an {@link Entity} of that type was killed.
-     * 
+     *
      * @return The {@link Map} of custom mob drops
      */
     @Nonnull
@@ -274,7 +274,7 @@ public final class SlimefunRegistry {
     /**
      * This returns a {@link Set} of {@link ItemStack ItemStacks} which can be obtained by bartering
      * with {@link Piglin Piglins}.
-     * 
+     *
      * @return A {@link Set} of bartering drops
      */
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines;
 
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -33,8 +33,8 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
  */
 public class AutoBrewer extends AContainer implements NotHopperable {
 
-    private static final Map<Material, PotionType> potionRecipes = new EnumMap<>(Material.class);
-    private static final Map<PotionType, PotionType> fermentations = new EnumMap<>(PotionType.class);
+    private static final Map<Material, PotionType> potionRecipes = new HashMap<>();
+    private static final Map<PotionType, PotionType> fermentations = new HashMap<>();
 
     static {
         potionRecipes.put(Material.SUGAR, VersionedPotionType.SWIFTNESS);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/EnchantmentRune.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/runes/EnchantmentRune.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.magical.runes;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +43,7 @@ import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedParticle;
 public class EnchantmentRune extends SimpleSlimefunItem<ItemDropHandler> {
 
     private static final double RANGE = 1.5;
-    private final Map<Material, List<Enchantment>> applicableEnchantments = new EnumMap<>(Material.class);
+    private final Map<Material, List<Enchantment>> applicableEnchantments = new HashMap<>();
 
     @ParametersAreNonnullByDefault
     public EnchantmentRune(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ClimbingPick.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ClimbingPick.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +62,7 @@ public class ClimbingPick extends SimpleSlimefunItem<ItemUseHandler> implements 
     private final ItemSetting<Boolean> dualWielding = new ItemSetting<>(this, "dual-wielding", true);
     private final ItemSetting<Boolean> damageOnUse = new ItemSetting<>(this, "damage-on-use", true);
 
-    private final Map<Material, ClimbableSurface> surfaces = new EnumMap<>(Material.class);
+    private final Map<Material, ClimbableSurface> surfaces = new HashMap<>();
     private final Set<UUID> users = new HashSet<>();
 
     @ParametersAreNonnullByDefault
@@ -97,7 +97,7 @@ public class ClimbingPick extends SimpleSlimefunItem<ItemUseHandler> implements 
     /**
      * This returns whether the {@link ClimbingPick} needs to be held in both
      * arms to work.
-     * 
+     *
      * @return Whether dual wielding is enabled
      */
     public boolean isDualWieldingEnabled() {
@@ -107,7 +107,7 @@ public class ClimbingPick extends SimpleSlimefunItem<ItemUseHandler> implements 
     /**
      * This method returns a {@link Collection} of every {@link ClimbableSurface} the
      * {@link ClimbingPick} can climb.
-     * 
+     *
      * @return A {@link Collection} of every {@link ClimbableSurface}
      */
     @Nonnull
@@ -117,10 +117,10 @@ public class ClimbingPick extends SimpleSlimefunItem<ItemUseHandler> implements 
 
     /**
      * This returns the climbing speed for a given {@link Material}.
-     * 
+     *
      * @param type
      *            The {@link Material}
-     * 
+     *
      * @return The climbing speed for this {@link Material} or 0.
      */
     public double getClimbingSpeed(@Nonnull Material type) {
@@ -136,12 +136,12 @@ public class ClimbingPick extends SimpleSlimefunItem<ItemUseHandler> implements 
 
     /**
      * This returns the climbing speed for a given {@link Material} and the used {@link ItemStack}.
-     * 
+     *
      * @param item
      *            the {@link ClimbingPick}'s {@link ItemStack}
      * @param type
      *            The {@link Material}
-     * 
+     *
      * @return The climbing speed or 0.
      */
     public double getClimbingSpeed(@Nonnull ItemStack item, @Nonnull Material type) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
@@ -4,7 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -34,7 +34,7 @@ import org.bukkit.plugin.java.JavaPlugin;
  * The most common type is {@link Integer}, if you are using complex objects and try to read
  * your {@link BiomeMap} from a {@link JsonElement}, make sure to provide an adequate
  * {@link BiomeDataConverter} to convert the raw json data.
- * 
+ *
  * @author TheBusyBiscuit
  *
  * @param <T>
@@ -43,9 +43,9 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class BiomeMap<T> implements Keyed {
 
     /**
-     * Our internal {@link EnumMap} holding all the data.
+     * Our internal {@link HashMap} holding all the data.
      */
-    private final Map<Biome, T> dataMap = new EnumMap<>(Biome.class);
+    private final Map<Biome, T> dataMap = new HashMap<>();
 
     /**
      * The {@link NamespacedKey} to identify this {@link BiomeMap}.
@@ -54,7 +54,7 @@ public class BiomeMap<T> implements Keyed {
 
     /**
      * This constructs a new {@link BiomeMap} with the given {@link NamespacedKey}.
-     * 
+     *
      * @param namespacedKey
      *            The {@link NamespacedKey} for this {@link BiomeMap}
      */
@@ -92,7 +92,7 @@ public class BiomeMap<T> implements Keyed {
     /**
      * This returns whether this {@link BiomeMap} is empty.
      * An empty {@link BiomeMap} contains no biomes or values.
-     * 
+     *
      * @return Whether this {@link BiomeMap} is empty.
      */
     public boolean isEmpty() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMapParser.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMapParser.java
@@ -1,7 +1,8 @@
 package io.github.thebusybiscuit.slimefun4.utils.biomes;
 
-import java.util.EnumMap;
-import java.util.EnumSet;
+
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -25,12 +26,12 @@ import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
 
 /**
  * The {@link BiomeMapParser} allows you to parse json data into a {@link BiomeMap}.
- * 
+ *
  * @author TheBusyBiscuit
  *
  * @param <T>
  *            The data type of the resulting {@link BiomeMap}
- * 
+ *
  * @see BiomeMap
  */
 public class BiomeMapParser<T> {
@@ -40,7 +41,7 @@ public class BiomeMapParser<T> {
 
     private final NamespacedKey key;
     private final BiomeDataConverter<T> valueConverter;
-    private final Map<Biome, T> map = new EnumMap<>(Biome.class);
+    private final Map<Biome, T> map = new HashMap<>();
 
     /**
      * This flag specifies whether the parsing is "lenient" or not.
@@ -54,7 +55,7 @@ public class BiomeMapParser<T> {
      * This constructs a new {@link BiomeMapParser}.
      * <p>
      * To parse data, use the {@link #read(JsonArray)} or {@link #read(String)} method.
-     * 
+     *
      * @param key
      *            The {@link NamespacedKey} for the resulting {@link BiomeMap}
      * @param valueConverter
@@ -75,7 +76,7 @@ public class BiomeMapParser<T> {
      * A lenient parser will not throw a {@link BiomeMapException} if the {@link Biome}
      * could not be found.
      * The default value is false.
-     * 
+     *
      * @param isLenient
      *            Whether this parser should be lenient or not.
      */
@@ -89,7 +90,7 @@ public class BiomeMapParser<T> {
      * A lenient parser will not throw a {@link BiomeMapException} if the {@link Biome}
      * could not be found.
      * The default value is false.
-     * 
+     *
      * @return Whether this parser is lenient or not.
      */
     public boolean isLenient() {
@@ -159,7 +160,7 @@ public class BiomeMapParser<T> {
 
     private @Nonnull Set<Biome> readBiomes(@Nonnull JsonArray array) throws BiomeMapException {
         Validate.notNull(array, "The JSON array should not be null!");
-        Set<Biome> biomes = EnumSet.noneOf(Biome.class);
+        Set<Biome> biomes = new HashSet<>();
 
         for (JsonElement element : array) {
             if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
@@ -196,7 +197,7 @@ public class BiomeMapParser<T> {
      * <p>
      * Make sure to parse data via {@link #read(JsonArray)} or {@link #read(String)}
      * before calling this method! Otherwise the resulting {@link BiomeMap} will be empty.
-     * 
+     *
      * @return The resulting {@link BiomeMap}
      */
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
@@ -1,7 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.utils.tags;
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
@@ -298,7 +297,7 @@ public enum SlimefunTag implements Tag<Material> {
     }
 
     private final NamespacedKey key;
-    private final Set<Material> includedMaterials = EnumSet.noneOf(Material.class);
+    private final Set<Material> includedMaterials = new HashSet<>();
     private final Set<Tag<Material>> additionalTags = new HashSet<>();
 
     /**
@@ -370,8 +369,7 @@ public enum SlimefunTag implements Tag<Material> {
         if (additionalTags.isEmpty()) {
             return Collections.unmodifiableSet(includedMaterials);
         } else {
-            Set<Material> materials = EnumSet.noneOf(Material.class);
-            materials.addAll(includedMaterials);
+            Set<Material> materials = new HashSet<>(includedMaterials);
 
             for (Tag<Material> tag : additionalTags) {
                 materials.addAll(tag.getValues());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/TagParser.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/TagParser.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -35,9 +34,9 @@ import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
 
 /**
  * The {@link TagParser} is responsible for parsing a JSON input into a {@link SlimefunTag}.
- * 
+ *
  * @author TheBusyBiscuit
- * 
+ *
  * @see SlimefunTag
  *
  */
@@ -51,7 +50,7 @@ public class TagParser implements Keyed {
 
     /**
      * This constructs a new {@link TagParser}.
-     * 
+     *
      * @param key
      *            The {@link NamespacedKey} of the resulting {@link SlimefunTag}
      */
@@ -61,7 +60,7 @@ public class TagParser implements Keyed {
 
     /**
      * This constructs a new {@link TagParser} for the given {@link SlimefunTag}
-     * 
+     *
      * @param tag
      *            The {@link SlimefunTag} to parse inputs for
      */
@@ -82,12 +81,12 @@ public class TagParser implements Keyed {
     /**
      * This will parse the given JSON {@link String} and run the provided callback with {@link Set Sets} of
      * matched {@link Material Materials} and {@link Tag Tags}.
-     * 
+     *
      * @param json
      *            The JSON {@link String} to parse
      * @param callback
      *            A callback to run after successfully parsing the input
-     * 
+     *
      * @throws TagMisconfigurationException
      *             This is thrown whenever the given input is malformed or no adequate
      *             {@link Material} or {@link Tag} could be found
@@ -96,7 +95,7 @@ public class TagParser implements Keyed {
         Validate.notNull(json, "Cannot parse a null String");
 
         try {
-            Set<Material> materials = EnumSet.noneOf(Material.class);
+            Set<Material> materials = new HashSet<>();
             Set<Tag<Material>> tags = new HashSet<>();
 
             JsonObject root = JsonUtils.parseString(json).getAsJsonObject();


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Removes usages of `EnumMap` and `EnumSet` on types which implement `Keyed`

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
