### PR TITLE
Add permission check to SF Search in cheat mode

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -370,10 +370,10 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
                         if (isSurvivalMode()) {
                             displayItem(profile, slimefunItem, true);
                         } else if (pl.hasPermission("slimefun.cheat.items")) {
-                            if (sfitem instanceof MultiBlockMachine) {
+                            if (slimefunItem instanceof MultiBlockMachine) {
                                 Slimefun.getLocalization().sendMessage(pl, "guide.cheat.no-multiblocks");
                             } else {
-                                ItemStack clonedItem = sfitem.getItem().clone();
+                                ItemStack clonedItem = slimefunItem.getItem().clone();
 
                                 if (action.isShiftClicked()) {
                                     clonedItem.setAmount(clonedItem.getMaxStackSize());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -367,10 +367,27 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
                 menu.addItem(index, itemstack);
                 menu.addMenuClickHandler(index, (pl, slot, itm, action) -> {
                     try {
-                        if (!isSurvivalMode()) {
-                            pl.getInventory().addItem(slimefunItem.getItem().clone());
-                        } else {
+                        if (isSurvivalMode()) {
                             displayItem(profile, slimefunItem, true);
+                        } else if (pl.hasPermission("slimefun.cheat.items")) {
+                            if (sfitem instanceof MultiBlockMachine) {
+                                Slimefun.getLocalization().sendMessage(pl, "guide.cheat.no-multiblocks");
+                            } else {
+                                ItemStack clonedItem = sfitem.getItem().clone();
+
+                                if (action.isShiftClicked()) {
+                                    clonedItem.setAmount(clonedItem.getMaxStackSize());
+                                }
+
+                                pl.getInventory().addItem(clonedItem);
+                            }
+                        } else {
+                            /*
+                             * Fixes #3548 - If for whatever reason,
+                             * an unpermitted players gets access to this guide,
+                             * this will be our last line of defense to prevent any exploit.
+                             */
+                            Slimefun.getLocalization().sendMessage(pl, "messages.no-permission", true);
                         }
                     } catch (Exception | LinkageError x) {
                         printErrorMessage(pl, slimefunItem, x);


### PR DESCRIPTION
## Description
In the unlikely event someone manages to get a cheat sheet they can cheat in items with the search feature, we don’t want that.

## Proposed changes
Change the logic for search items to match the logic for normal items when clicked. (Have a permission check for cheating, cheat in stack when shifting)

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
