### PR TITLE
feat: onExplode customization on EnergyNetProvider

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetProvider.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetProvider.java
@@ -3,9 +3,11 @@ package io.github.thebusybiscuit.slimefun4.core.attributes;
 import javax.annotation.Nonnull;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNet;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.AbstractEnergyProvider;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.reactors.Reactor;
 
@@ -61,6 +63,23 @@ public interface EnergyNetProvider extends EnergyNetComponent {
      */
     default boolean willExplode(@Nonnull Location l, @Nonnull Config data) {
         return false;
+    }
+
+    /**
+     * This method determines what happens when the {@link Location} of
+     * this {@link EnergyNetProvider} is going to explode.
+     * <br>
+     * Note: This method is called async.
+     * The actual block is still there but the Slimefun block data is removed.
+     *
+     * @param l
+     *              The {@link Location} of this {@link EnergyNetProvider}
+     */
+    default void onExplode(@Nonnull Location l) {
+        Slimefun.runSync(() -> {
+            l.getBlock().setType(Material.LAVA);
+            l.getWorld().createExplosion(l, 0F, false);
+        });
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -254,10 +254,7 @@ public class EnergyNet extends Network implements HologramOwner {
                     explodedBlocks.add(loc);
                     BlockStorage.clearBlockInfo(loc);
 
-                    Slimefun.runSync(() -> {
-                        loc.getBlock().setType(Material.LAVA);
-                        loc.getWorld().createExplosion(loc, 0F, false);
-                    });
+                    provider.onExplode(loc);
                 } else {
                     supply = NumberUtils.flowSafeAddition(supply, energy);
                 }


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
Currently, the behavior of a block that should explode is hard-coded, which is becoming lava and creating a small explosion.
This PR would allow addon developers to use `willExplode` with `onExplode` to implement some tremendous ideas.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added `onExplode(Location)` to `EnergyNetProvider`, default to the current explosion behavior.
Changed `EnergyNet` to use `onExplode` from provider.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Just an idea came after I saw a chat.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
