### PR TITLE
Fix/machine inventory drop

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/MachineBlockBreakHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/MachineBlockBreakHandler.java
@@ -1,0 +1,92 @@
+package io.github.thebusybiscuit.slimefun4.implementation.handlers;
+
+import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
+import io.github.thebusybiscuit.slimefun4.core.machines.MachineProcessor;
+import io.github.thebusybiscuit.slimefun4.implementation.operations.CraftingOperation;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link SimpleBlockBreakHandler} given the processor and the slots to drop of a machine.
+ *  Uses the machine's {@link MachineProcessor} to drop the items that didn't finish processing for crafting recipes
+ *  The slots field is used to drop items in those slots of block's inventory.
+ *
+ * @author Vaan1310/Intybyte
+ *
+ */
+public class MachineBlockBreakHandler extends SimpleBlockBreakHandler {
+    private final MachineProcessor<? extends MachineOperation> processor;
+    private final int[][] slots;
+
+    public MachineBlockBreakHandler(MachineProcessor<? extends MachineOperation> processor, int[]... slots) {
+        this.processor = processor;
+        this.slots = slots;
+    }
+
+    public MachineBlockBreakHandler(int[]... slots) {
+        this(null, slots);
+    }
+
+    protected void beforeBreak(@Nonnull Block b) {
+
+    }
+
+    @Override
+    public final void onBlockBreak(@Nonnull Block b) {
+        beforeBreak(b);
+        BlockMenu inv = BlockStorage.getInventory(b);
+        Location loc = b.getLocation();
+
+        // Check if the world where we might want to drop stuff is valid
+        World world = loc.getWorld();
+        if (world == null) {
+            if (processor != null) {
+                processor.endOperation(b);
+            }
+            afterBreak(b);
+            return;
+        }
+
+        if (inv != null) {
+            for (int[] slotArray : slots) {
+                inv.dropItems(loc, slotArray);
+            }
+        }
+
+        if (processor == null) {
+            afterBreak(b);
+            return;
+        }
+
+        var operation = processor.getOperation(b);
+        if (operation == null) {
+            afterBreak(b);
+            return;
+        }
+
+        // if the processed operation is a crafting recipe give back recipe ingredients, Fixes #4268
+        if (!(operation instanceof CraftingOperation craftingOperation)) {
+            processor.endOperation(b);
+            afterBreak(b);
+            return;
+        }
+
+        ItemStack[] ingredients = craftingOperation.getIngredients();
+        for (ItemStack ingredient : ingredients) {
+            world.dropItemNaturally(loc, ingredient);
+        }
+
+        processor.endOperation(b);
+        afterBreak(b);
+    }
+
+    protected void afterBreak(@Nonnull Block b) {
+
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/SimpleBlockBreakHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/SimpleBlockBreakHandler.java
@@ -3,15 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.handlers;
 import java.util.List;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
-import io.github.thebusybiscuit.slimefun4.core.machines.MachineProcessor;
-import io.github.thebusybiscuit.slimefun4.implementation.operations.CraftingOperation;
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
-import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -27,7 +19,6 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.androids.MinerAnd
  * By default, both androids and explosions are allowed.
  * 
  * @author TheBusyBiscuit
- * @author Vaan1310/Intybyte
  * 
  * @see BlockBreakHandler
  *
@@ -65,49 +56,4 @@ public abstract class SimpleBlockBreakHandler extends BlockBreakHandler {
         onBlockBreak(b);
     }
 
-    /**
-     * Creates a {@link SimpleBlockBreakHandler} given the processor and the slots to drop of a machine.
-     *
-     * @param processor the machine's {@link MachineProcessor}, used to drop the items that didn't finish processing for crafting recipes
-     * @param slots which slots of the inventory to drop on block break
-     */
-    public static SimpleBlockBreakHandler of(@Nullable MachineProcessor<? extends MachineOperation> processor, int[]... slots) {
-        return new SimpleBlockBreakHandler() {
-            @Override
-            public void onBlockBreak(@Nonnull Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-                Location loc = b.getLocation();
-                if (inv != null) {
-                    for (int[] slotArray : slots) {
-                        inv.dropItems(loc, slotArray);
-                    }
-                }
-
-                if (processor == null) {
-                    return;
-                }
-
-                var operation = processor.getOperation(b);
-                if (operation == null) {
-                    return;
-                }
-
-                if (operation instanceof CraftingOperation craftingOperation) {
-                    var ingredients = craftingOperation.getIngredients();
-                    World world = loc.getWorld();
-
-                    if (world == null) {
-                        processor.endOperation(b);
-                        return;
-                    }
-
-                    for (ItemStack ingredient : ingredients) {
-                        world.dropItemNaturally(loc, ingredient);
-                    }
-                }
-
-                processor.endOperation(b);
-            }
-        };
-    }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractFilterNode.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -52,17 +53,7 @@ abstract class AbstractFilterNode extends AbstractCargoNode {
 
     @Nonnull
     private BlockBreakHandler onBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(@Nonnull Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), SLOTS);
-                }
-            }
-        };
+        return new MachineBlockBreakHandler(SLOTS);
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -117,19 +118,7 @@ public class ReactorAccessPort extends SlimefunItem {
 
     @Nonnull
     private BlockBreakHandler onBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(@Nonnull Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getFuelSlots());
-                    inv.dropItems(b.getLocation(), getCoolantSlots());
-                    inv.dropItems(b.getLocation(), getOutputSlots());
-                }
-            }
-        };
+        return new MachineBlockBreakHandler(getFuelSlots(), getCoolantSlots(), getOutputSlots());
     }
 
     private void constructMenu(@Nonnull BlockMenuPreset preset) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -70,18 +71,7 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
 
     @Nonnull
     private BlockBreakHandler onBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getInputSlots());
-                    inv.dropItems(b.getLocation(), getOutputSlots());
-                }
-            }
-        };
+        return new MachineBlockBreakHandler(getOutputSlots(), getOutputSlots());
     }
 
     private void constructMenu(@Nonnull BlockMenuPreset preset) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AbstractGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/accelerators/AbstractGrowthAccelerator.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machine
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
@@ -39,17 +40,7 @@ public abstract class AbstractGrowthAccelerator extends SlimefunItem implements 
 
     @Nonnull
     private BlockBreakHandler onBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getInputSlots());
-                }
-            }
-        };
+        return new MachineBlockBreakHandler(getInputSlots());
     }
 
     private void constructMenu(BlockMenuPreset preset) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AutoBreeder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AutoBreeder.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machine
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
@@ -50,17 +51,7 @@ public class AutoBreeder extends SlimefunItem implements InventoryBlock, EnergyN
 
     @Nonnull
     private ItemHandler onBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getInputSlots());
-                }
-            }
-        };
+        return new MachineBlockBreakHandler(getInputSlots());
     }
 
     protected void constructMenu(BlockMenuPreset preset) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ExpCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ExpCollector.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -77,17 +78,7 @@ public class ExpCollector extends SlimefunItem implements InventoryBlock, Energy
     }
 
     private @Nonnull ItemHandler onBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(@Nonnull Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getOutputSlots());
-                }
-            }
-        };
+        return new MachineBlockBreakHandler(getOutputSlots());
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -122,19 +123,9 @@ public abstract class Reactor extends AbstractEnergyProvider implements Hologram
 
     @Nonnull
     private BlockBreakHandler onBreak() {
-        return new SimpleBlockBreakHandler() {
-
+        return new MachineBlockBreakHandler(processor, getFuelSlots(), getCoolantSlots(), getOutputSlots()) {
             @Override
-            public void onBlockBreak(@Nonnull Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getFuelSlots());
-                    inv.dropItems(b.getLocation(), getCoolantSlots());
-                    inv.dropItems(b.getLocation(), getOutputSlots());
-                }
-
-                processor.endOperation(b);
+            public void afterBreak(@Nonnull Block b) {
                 removeHologram(b);
             }
         };

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
@@ -7,6 +7,7 @@ import java.util.OptionalInt;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.apache.commons.lang.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -197,18 +198,10 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
 
     @Nonnull
     private BlockBreakHandler onBlockBreak() {
-        return new SimpleBlockBreakHandler() {
-
+        return new MachineBlockBreakHandler(OUTPUT_SLOTS) {
             @Override
-            public void onBlockBreak(@Nonnull Block b) {
+            protected void beforeBreak(@Nonnull Block b) {
                 removeHologram(b);
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), OUTPUT_SLOTS);
-                }
-
-                processor.endOperation(b);
             }
         };
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -67,21 +68,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
 
     @Nonnull
     protected BlockBreakHandler onBlockBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getInputSlots());
-                    inv.dropItems(b.getLocation(), getOutputSlots());
-                }
-
-                processor.endOperation(b);
-            }
-
-        };
+        return new MachineBlockBreakHandler(processor, getOutputSlots(), getInputSlots());
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.thebusybiscuit.slimefun4.implementation.handlers.MachineBlockBreakHandler;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -89,20 +90,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
 
     @Nonnull
     protected BlockBreakHandler onBlockBreak() {
-        return new SimpleBlockBreakHandler() {
-
-            @Override
-            public void onBlockBreak(Block b) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    inv.dropItems(b.getLocation(), getInputSlots());
-                    inv.dropItems(b.getLocation(), getOutputSlots());
-                }
-
-                processor.endOperation(b);
-            }
-        };
+        return new MachineBlockBreakHandler(processor, getInputSlots(), getOutputSlots());
     }
 
     private void constructMenu(BlockMenuPreset preset) {


### PR DESCRIPTION
## Proposed changes
Create a class extending SimpleBlockBreakHandler that handles inventories and MachineProcesoors (MachineBlockBreakHandler).
If the MachineProcessor is of CraftingOperation type and the process isn't completed, then the ingredients will be dropped.

## Related Issues (if applicable)
Resolves #4268

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
