### PR TITLE
Walshy/mc 1.21 bundles

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/SlimefunBackpack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/SlimefunBackpack.java
@@ -69,6 +69,11 @@ public class SlimefunBackpack extends SimpleSlimefunItem<ItemUseHandler> impleme
             return false;
         }
 
+        // Bundles aren't allowed either
+        if (SlimefunTag.BUNDLES.isTagged(item.getType())) {
+            return false;
+        }
+
         return !(itemAsSlimefunItem instanceof SlimefunBackpack);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
@@ -277,7 +277,9 @@ public enum SlimefunTag implements Tag<Material> {
     /**
      * All tile entities.
      */
-    TILE_ENTITIES;
+    TILE_ENTITIES,
+
+    BUNDLES;
 
     /**
      * Lookup table for tag names.

--- a/src/main/resources/tags/bundles.json
+++ b/src/main/resources/tags/bundles.json
@@ -1,0 +1,72 @@
+{
+  "values" : [
+    {
+      "id" : "minecraft:bundle",
+      "required" : false
+    },
+    {
+    "id" : "minecraft:white_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:orange_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:magenta_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:light_blue_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:yellow_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:lime_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:pink_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:gray_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:light_gray_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:cyan_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:purple_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:blue_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:brown_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:green_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:red_bundle",
+    "required" : false
+    },
+    {
+    "id" : "minecraft:black_bundle",
+    "required" : false
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Bundles in 1.21.3+ will create some problems with backpacks that need to be addressed

## Issues
- Players can put bundles into backpack (Minor problem, maybe worth considering a config option for this)
- Players can put backpacks into bundles (Major problem)

## Proposed changes
- [x] Make a tag similar to shulker boxes in order to stop people from putting bundles inside backpacks
- [ ] Block people from bundling up a lot of backpacks (Major problem)

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
