### PR TITLE
Fix: handle lore on AncientPedestal

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -158,6 +158,11 @@ public class AncientPedestal extends SimpleSlimefunItem<BlockDispenseHandler> im
         ItemStack hand = p.getInventory().getItemInMainHand();
         String displayName = ITEM_PREFIX + System.nanoTime();
         ItemStack displayItem = CustomItemStack.create(hand, displayName);
+        if (hand.hasItemMeta() && hand.getItemMeta().hasLore()) {
+            ItemMeta meta = displayItem.getItemMeta();
+            meta.setLore(hand.getItemMeta().getLore());
+            displayItem.setItemMeta(meta);
+        }
         displayItem.setAmount(1);
 
         // Get the display name of the original Item in the Player's hand


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
This pull request fixes a bug related to lore handling on the AncientPedestal when using the experimental branch.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added a check and proper handling of lore in AncientPedestal.

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->


## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
