### PR TITLE
fix: allow redirects for metrics download

### DIFF
--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -46,7 +46,7 @@ jobs:
           apiToken: ${{ secrets.BLOB_BUILDS_API_TOKEN }}
           file: './target/Slimefun v4.9-UNOFFICIAL.jar'
           releaseNotes: ${{ github.event.head_commit.message }}
-    
+
       - name: Upload Experimental build
         uses: WalshyDev/blob-builds/gh-action@ea9ecd9266c902c6627f884e657560d0fa6b61dd
         if: github.ref == 'refs/heads/experimental'

--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
         </dependency>
         <!-- This needs to be before Spigot because MockBukkit will fail otherwise. -->
         <dependency>
-            <groupId>com.github.MockBukkit</groupId>
+            <groupId>com.github.mockbukkit</groupId>
             <artifactId>MockBukkit</artifactId>
             <version>c7cc678834</version>
             <scope>test</scope>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MetricsService.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
@@ -75,7 +76,7 @@ public class MetricsService {
     private final Slimefun plugin;
     private final File parentFolder;
     private final File metricsModuleFile;
-    private final HttpClient client = HttpClient.newHttpClient();
+    private final HttpClient client = HttpClient.newBuilder().followRedirects(Redirect.NORMAL).build();
 
     private URLClassLoader moduleClassLoader;
     private String metricVersion = null;


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
The HttpClient in metrics service does not allow redirects by default, which will fail to download module all the time.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
- Set the redirect policy to normal (allow redirects except HTTPS to HTTP)

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
N/A

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
