### PR TITLE
Replace copper ingot with copper from original Minecraft.

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -456,7 +456,6 @@ public final class SlimefunItems {
     public static final SlimefunItemStack RAINBOW_GLAZED_TERRACOTTA_HALLOWEEN = new SlimefunItemStack("RAINBOW_GLAZED_TERRACOTTA_HALLOWEEN", Material.ORANGE_GLAZED_TERRACOTTA, "&5Rainbow Glazed Terracotta &7(Halloween)", "", HALLOWEEN);
 
     /* Ingots */
-    public static final SlimefunItemStack COPPER_INGOT = new SlimefunItemStack("COPPER_INGOT", Material.BRICK, "&bCopper Ingot");
     public static final SlimefunItemStack TIN_INGOT = new SlimefunItemStack("TIN_INGOT", Material.IRON_INGOT, "&bTin Ingot");
     public static final SlimefunItemStack SILVER_INGOT = new SlimefunItemStack("SILVER_INGOT", Material.IRON_INGOT, "&bSilver Ingot");
     public static final SlimefunItemStack ALUMINUM_INGOT = new SlimefunItemStack("ALUMINUM_INGOT", Material.IRON_INGOT, "&bAluminum Ingot");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricPress.java
@@ -44,7 +44,7 @@ public class ElectricPress extends AContainer implements RecipeDisplayItem {
         addRecipe(3, new ItemStack(Material.CLAY_BALL, 4), new ItemStack(Material.CLAY));
         addRecipe(3, new ItemStack(Material.BRICK, 4), new ItemStack(Material.BRICKS));
 
-        addRecipe(6, SlimefunItems.COPPER_INGOT.item(), CustomItemStack.create(SlimefunItems.COPPER_WIRE.item(), 3));
+        addRecipe(6, new ItemStack(Material.COPPER_INGOT), CustomItemStack.create(SlimefunItems.COPPER_WIRE.item(), 3));
         addRecipe(16, new SlimefunItemStack(SlimefunItems.STEEL_INGOT, 8), SlimefunItems.STEEL_PLATE);
         addRecipe(18, new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 8), SlimefunItems.REINFORCED_PLATE);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
@@ -59,6 +59,8 @@ public class Smeltery extends AbstractSmeltery {
     protected void registerDefaultRecipes(@Nonnull List<ItemStack> recipes) {
         recipes.add(SlimefunItems.IRON_DUST.item());
         recipes.add(new ItemStack(Material.IRON_INGOT));
+        recipes.add(SlimefunItems.COPPER_DUST.item());
+        recipes.add(new ItemStack(Material.COPPER_INGOT));
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/ResearchSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/ResearchSetup.java
@@ -67,7 +67,7 @@ public final class ResearchSetup {
         register("cactus_armor", 31, "Cactus Suit", 5, SlimefunItems.CACTUS_BOOTS, SlimefunItems.CACTUS_CHESTPLATE, SlimefunItems.CACTUS_HELMET, SlimefunItems.CACTUS_LEGGINGS);
         register("gold_pan", 32, "Gold Pan", 5, SlimefunItems.GOLD_PAN);
         register("magical_book_cover", 33, "Magical Book Binding", 5, SlimefunItems.MAGICAL_BOOK_COVER);
-        register("slimefun_metals", 34, "New Metals", 6, SlimefunItems.COPPER_INGOT, SlimefunItems.TIN_INGOT, SlimefunItems.SILVER_INGOT, SlimefunItems.LEAD_INGOT, SlimefunItems.ALUMINUM_INGOT, SlimefunItems.ZINC_INGOT, SlimefunItems.MAGNESIUM_INGOT);
+        register("slimefun_metals", 34, "New Metals", 6, SlimefunItems.TIN_INGOT, SlimefunItems.SILVER_INGOT, SlimefunItems.LEAD_INGOT, SlimefunItems.ALUMINUM_INGOT, SlimefunItems.ZINC_INGOT, SlimefunItems.MAGNESIUM_INGOT);
         register("ore_crusher", 35, "Ore Doubling", 6, SlimefunItems.ORE_CRUSHER);
         register("bronze", 36, "Bronze Creation", 8, SlimefunItems.BRONZE_INGOT);
         register("alloys", 37, "Advanced Alloys", 12, SlimefunItems.BILLON_INGOT, SlimefunItems.DURALUMIN_INGOT, SlimefunItems.ALUMINUM_BRASS_INGOT, SlimefunItems.ALUMINUM_BRONZE_INGOT, SlimefunItems.SOLDER_INGOT, SlimefunItems.CORINTHIAN_BRONZE_INGOT, SlimefunItems.BRASS_INGOT);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -555,6 +555,11 @@ public final class SlimefunItemSetup {
                 new ItemStack[] {new ItemStack(Material.IRON_ORE), null, null, null, null, null, null, null, null},
                 new SlimefunItemStack(SlimefunItems.IRON_DUST, oreCrusher.isOreDoublingEnabled() ? 2 : 1).item())
                 .register(plugin);
+        
+        new SlimefunItem(itemGroups.resources, SlimefunItems.COPPER_DUST, RecipeType.ORE_CRUSHER,
+                new ItemStack[] {new ItemStack(Material.COPPER_ORE), null, null, null, null, null, null, null, null},
+                new SlimefunItemStack(SlimefunItems.COPPER_DUST, oreCrusher.isOreDoublingEnabled() ? 2 : 1).item())
+                .register(plugin);
 
         new SlimefunItem(itemGroups.resources, SlimefunItems.GOLD_DUST, RecipeType.ORE_CRUSHER,
                 new ItemStack[] {new ItemStack(Material.GOLD_ORE), null, null, null, null, null, null, null, null},
@@ -587,10 +592,6 @@ public final class SlimefunItemSetup {
 
         new SlimefunItem(itemGroups.resources, SlimefunItems.MAGNESIUM_DUST, RecipeType.ORE_WASHER,
                 new ItemStack[] {SlimefunItems.SIFTED_ORE.item(), null, null, null, null, null, null, null, null})
-                .register(plugin);
-
-        new SlimefunItem(itemGroups.resources, new ItemStack(Material.COPPER_INGOT), RecipeType.SMELTERY,
-                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), null, null, null, null, null, null, null, null})
                 .register(plugin);
 
         new SlimefunItem(itemGroups.resources, SlimefunItems.TIN_INGOT, RecipeType.SMELTERY,

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -566,10 +566,6 @@ public final class SlimefunItemSetup {
                 new SlimefunItemStack(SlimefunItems.GOLD_DUST, oreCrusher.isOreDoublingEnabled() ? 2 : 1).item())
                 .register(plugin);
 
-        new SlimefunItem(itemGroups.resources, SlimefunItems.COPPER_DUST, RecipeType.ORE_WASHER,
-                new ItemStack[] {SlimefunItems.SIFTED_ORE.item(), null, null, null, null, null, null, null, null})
-                .register(plugin);
-
         new SlimefunItem(itemGroups.resources, SlimefunItems.TIN_DUST, RecipeType.ORE_WASHER,
                 new ItemStack[] {SlimefunItems.SIFTED_ORE.item(), null, null, null, null, null, null, null, null})
                 .register(plugin);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -425,7 +425,7 @@ public final class SlimefunItemSetup {
         new PressureChamber(itemGroups.basicMachines, SlimefunItems.PRESSURE_CHAMBER).register(plugin);
 
         new UnplaceableBlock(itemGroups.technicalComponents, SlimefunItems.BATTERY, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, new ItemStack(Material.REDSTONE), null, SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), new ItemStack(Material.COPPER_INGOT).item(), SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), new ItemStack(Material.COPPER_INGOT).item()})
+                new ItemStack[] {null, new ItemStack(Material.REDSTONE), null, SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), new ItemStack(Material.COPPER_INGOT), SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), new ItemStack(Material.COPPER_INGOT)})
                 .register(plugin);
 
         registerArmorSet(itemGroups.magicalArmor, new ItemStack(Material.GLOWSTONE), new ItemStack[] {SlimefunItems.GLOWSTONE_HELMET.item(), SlimefunItems.GLOWSTONE_CHESTPLATE.item(), SlimefunItems.GLOWSTONE_LEGGINGS.item(), SlimefunItems.GLOWSTONE_BOOTS.item()}, "GLOWSTONE", false,
@@ -490,7 +490,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.BRONZE_INGOT,
-                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.TIN_DUST.item(), new ItemStack(Material.COPPER_INGOT).item(), null, null, null, null, null, null})
+                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.TIN_DUST.item(), new ItemStack(Material.COPPER_INGOT), null, null, null, null, null, null})
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.DURALUMIN_INGOT,
@@ -502,7 +502,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.BRASS_INGOT,
-                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.ZINC_DUST.item(), new ItemStack(Material.COPPER_INGOT).item(), null, null, null, null, null, null})
+                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.ZINC_DUST.item(), new ItemStack(Material.COPPER_INGOT), null, null, null, null, null, null})
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.ALUMINUM_BRASS_INGOT,
@@ -1389,7 +1389,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new UnplaceableBlock(itemGroups.technicalComponents, SlimefunItems.COPPER_WIRE, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, null, null, new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item(), null, null, null},
+                new ItemStack[] {null, null, null, new ItemStack(Material.COPPER_INGOT), new ItemStack(Material.COPPER_INGOT), new ItemStack(Material.COPPER_INGOT), null, null, null},
                 new SlimefunItemStack(SlimefunItems.COPPER_WIRE, 8).item())
                 .register(plugin);
 
@@ -1660,7 +1660,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new ElectricDustWasher(itemGroups.electricity, SlimefunItems.ELECTRIC_DUST_WASHER, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, new ItemStack(Material.WATER_BUCKET), null, SlimefunItems.ELECTRO_MAGNET.item(), SlimefunItems.ELECTRIC_GOLD_PAN.item(), SlimefunItems.ELECTRO_MAGNET.item(), new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item()})
+                new ItemStack[] {null, new ItemStack(Material.WATER_BUCKET), null, SlimefunItems.ELECTRO_MAGNET.item(), SlimefunItems.ELECTRIC_GOLD_PAN.item(), SlimefunItems.ELECTRO_MAGNET.item(), new ItemStack(Material.COPPER_INGOT), new ItemStack(Material.COPPER_INGOT), new ItemStack(Material.COPPER_INGOT)})
                 .setCapacity(128)
                 .setEnergyConsumption(3)
                 .setProcessingSpeed(1)
@@ -1870,7 +1870,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new Multimeter(itemGroups.technicalGadgets, SlimefunItems.MULTIMETER, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {new ItemStack(Material.COPPER_INGOT).item(), null, new ItemStack(Material.COPPER_INGOT).item(), null, SlimefunItems.REDSTONE_ALLOY.item(), null, null, SlimefunItems.GOLD_6K.item(), null})
+                new ItemStack[] {new ItemStack(Material.COPPER_INGOT), null, new ItemStack(Material.COPPER_INGOT), null, SlimefunItems.REDSTONE_ALLOY.item(), null, null, SlimefunItems.GOLD_6K.item(), null})
                 .register(plugin);
 
         new SlimefunItem(itemGroups.technicalComponents, SlimefunItems.PLASTIC_SHEET, RecipeType.HEATED_PRESSURE_CHAMBER,

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -425,7 +425,7 @@ public final class SlimefunItemSetup {
         new PressureChamber(itemGroups.basicMachines, SlimefunItems.PRESSURE_CHAMBER).register(plugin);
 
         new UnplaceableBlock(itemGroups.technicalComponents, SlimefunItems.BATTERY, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, new ItemStack(Material.REDSTONE), null, SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), SlimefunItems.COPPER_INGOT.item(), SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), SlimefunItems.COPPER_INGOT.item()})
+                new ItemStack[] {null, new ItemStack(Material.REDSTONE), null, SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), new ItemStack(Material.COPPER_INGOT).item(), SlimefunItems.ZINC_INGOT.item(), SlimefunItems.SULFATE.item(), new ItemStack(Material.COPPER_INGOT).item()})
                 .register(plugin);
 
         registerArmorSet(itemGroups.magicalArmor, new ItemStack(Material.GLOWSTONE), new ItemStack[] {SlimefunItems.GLOWSTONE_HELMET.item(), SlimefunItems.GLOWSTONE_CHESTPLATE.item(), SlimefunItems.GLOWSTONE_LEGGINGS.item(), SlimefunItems.GLOWSTONE_BOOTS.item()}, "GLOWSTONE", false,
@@ -490,7 +490,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.BRONZE_INGOT,
-                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.TIN_DUST.item(), SlimefunItems.COPPER_INGOT.item(), null, null, null, null, null, null})
+                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.TIN_DUST.item(), new ItemStack(Material.COPPER_INGOT).item(), null, null, null, null, null, null})
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.DURALUMIN_INGOT,
@@ -502,7 +502,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.BRASS_INGOT,
-                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.ZINC_DUST.item(), SlimefunItems.COPPER_INGOT.item(), null, null, null, null, null, null})
+                new ItemStack[] {SlimefunItems.COPPER_DUST.item(), SlimefunItems.ZINC_DUST.item(), new ItemStack(Material.COPPER_INGOT).item(), null, null, null, null, null, null})
                 .register(plugin);
 
         new AlloyIngot(itemGroups.resources, SlimefunItems.ALUMINUM_BRASS_INGOT,
@@ -589,7 +589,7 @@ public final class SlimefunItemSetup {
                 new ItemStack[] {SlimefunItems.SIFTED_ORE.item(), null, null, null, null, null, null, null, null})
                 .register(plugin);
 
-        new SlimefunItem(itemGroups.resources, SlimefunItems.COPPER_INGOT, RecipeType.SMELTERY,
+        new SlimefunItem(itemGroups.resources, new ItemStack(Material.COPPER_INGOT), RecipeType.SMELTERY,
                 new ItemStack[] {SlimefunItems.COPPER_DUST.item(), null, null, null, null, null, null, null, null})
                 .register(plugin);
 
@@ -1389,7 +1389,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new UnplaceableBlock(itemGroups.technicalComponents, SlimefunItems.COPPER_WIRE, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, null, null, SlimefunItems.COPPER_INGOT.item(), SlimefunItems.COPPER_INGOT.item(), SlimefunItems.COPPER_INGOT.item(), null, null, null},
+                new ItemStack[] {null, null, null, new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item(), null, null, null},
                 new SlimefunItemStack(SlimefunItems.COPPER_WIRE, 8).item())
                 .register(plugin);
 
@@ -1660,7 +1660,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new ElectricDustWasher(itemGroups.electricity, SlimefunItems.ELECTRIC_DUST_WASHER, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, new ItemStack(Material.WATER_BUCKET), null, SlimefunItems.ELECTRO_MAGNET.item(), SlimefunItems.ELECTRIC_GOLD_PAN.item(), SlimefunItems.ELECTRO_MAGNET.item(), SlimefunItems.COPPER_INGOT.item(), SlimefunItems.COPPER_INGOT.item(), SlimefunItems.COPPER_INGOT.item()})
+                new ItemStack[] {null, new ItemStack(Material.WATER_BUCKET), null, SlimefunItems.ELECTRO_MAGNET.item(), SlimefunItems.ELECTRIC_GOLD_PAN.item(), SlimefunItems.ELECTRO_MAGNET.item(), new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item(), new ItemStack(Material.COPPER_INGOT).item()})
                 .setCapacity(128)
                 .setEnergyConsumption(3)
                 .setProcessingSpeed(1)
@@ -1870,7 +1870,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new Multimeter(itemGroups.technicalGadgets, SlimefunItems.MULTIMETER, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {SlimefunItems.COPPER_INGOT.item(), null, SlimefunItems.COPPER_INGOT.item(), null, SlimefunItems.REDSTONE_ALLOY.item(), null, null, SlimefunItems.GOLD_6K.item(), null})
+                new ItemStack[] {new ItemStack(Material.COPPER_INGOT).item(), null, new ItemStack(Material.COPPER_INGOT).item(), null, SlimefunItems.REDSTONE_ALLOY.item(), null, null, SlimefunItems.GOLD_6K.item(), null})
                 .register(plugin);
 
         new SlimefunItem(itemGroups.technicalComponents, SlimefunItems.PLASTIC_SHEET, RecipeType.HEATED_PRESSURE_CHAMBER,

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -551,14 +551,14 @@ public final class SlimefunItemSetup {
                 new ItemStack[] {new ItemStack(Material.IRON_INGOT), SlimefunItems.IRON_DUST.item(), SlimefunItems.SILICON.item(), null, null, null, null, null, null})
                 .register(plugin);
 
-        new SlimefunItem(itemGroups.resources, SlimefunItems.IRON_DUST, RecipeType.ORE_CRUSHER,
-                new ItemStack[] {new ItemStack(Material.IRON_ORE), null, null, null, null, null, null, null, null},
-                new SlimefunItemStack(SlimefunItems.IRON_DUST, oreCrusher.isOreDoublingEnabled() ? 2 : 1).item())
-                .register(plugin);
-        
         new SlimefunItem(itemGroups.resources, SlimefunItems.COPPER_DUST, RecipeType.ORE_CRUSHER,
                 new ItemStack[] {new ItemStack(Material.COPPER_ORE), null, null, null, null, null, null, null, null},
                 new SlimefunItemStack(SlimefunItems.COPPER_DUST, oreCrusher.isOreDoublingEnabled() ? 2 : 1).item())
+                .register(plugin);
+        
+        new SlimefunItem(itemGroups.resources, SlimefunItems.IRON_DUST, RecipeType.ORE_CRUSHER,
+                new ItemStack[] {new ItemStack(Material.IRON_ORE), null, null, null, null, null, null, null, null},
+                new SlimefunItemStack(SlimefunItems.IRON_DUST, oreCrusher.isOreDoublingEnabled() ? 2 : 1).item())
                 .register(plugin);
 
         new SlimefunItem(itemGroups.resources, SlimefunItems.GOLD_DUST, RecipeType.ORE_CRUSHER,


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
on 1.17, the copper was added,
however, slimefun didnt removed it yet. causing the copper ingot(sf) still remaining.
this commit replaces Copper Ingot(SF) in favor of Copper ingot from vanilla minecraft.

all users making a new addon
should replace all usage of SlimefunItems.COPPER_INGOT to new ItemStack(Material.COPPER_INGOT).
## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Remove SlimefunItems.COPPER_INGOT and replace with new ItemStack(Material.COPPER_INGOT)
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
