### PR TITLE
Fix the recipe: makes Synthesic Sapphire's material data is Lapis Lazuli, fixing #3955

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -530,7 +530,7 @@ public final class SlimefunItems {
     /* Gems */
     public static final SlimefunItemStack SYNTHETIC_DIAMOND = new SlimefunItemStack("SYNTHETIC_DIAMOND", Material.DIAMOND, "&bSynthetic Diamond", "", "&fThis item can be used in a", "&fworkbench and acts like a normal Diamond");
     public static final SlimefunItemStack SYNTHETIC_EMERALD = new SlimefunItemStack("SYNTHETIC_EMERALD", Material.EMERALD, "&bSynthetic Emerald", "", "&fThis item can be used to", "&ftrade with Villagers");
-    public static final SlimefunItemStack SYNTHETIC_SAPPHIRE = new SlimefunItemStack("SYNTHETIC_SAPPHIRE", HeadTexture.SAPPHIRE, "&bSynthetic Sapphire", "", "&fThis item can be used in a", "&fworkbench and acts like Lapis Lazuli");
+    public static final SlimefunItemStack SYNTHETIC_SAPPHIRE = new SlimefunItemStack("SYNTHETIC_SAPPHIRE", Material.LAPIS_LAZULI, "&bSynthetic Sapphire", "", "&fThis item can be used in a", "&fworkbench and acts like Lapis Lazuli");
     public static final SlimefunItemStack CARBONADO = new SlimefunItemStack("CARBONADO", HeadTexture.CARBONADO, "&b&lCarbonado", "", "&7&o\"Black Diamond\"");
     public static final SlimefunItemStack RAW_CARBONADO = new SlimefunItemStack("RAW_CARBONADO", HeadTexture.RAW_CARBONADO, "&bRaw Carbonado");
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -522,7 +522,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new SlimefunItem(itemGroups.resources, SlimefunItems.SYNTHETIC_SAPPHIRE, RecipeType.SMELTERY,
-                new ItemStack[] {SlimefunItems.ALUMINUM_DUST.item(), new ItemStack(Material.GLASS), new ItemStack(Material.GLASS_PANE), SlimefunItems.ALUMINUM_INGOT.item(), SlimefunItems.SALT.item(), SlimefunItems.SULFATE.item(), ItemStack(Material.CALCITE), null, null})
+                new ItemStack[] {SlimefunItems.ALUMINUM_DUST.item(), new ItemStack(Material.GLASS), new ItemStack(Material.GLASS_PANE), SlimefunItems.ALUMINUM_INGOT.item(), SlimefunItems.SALT.item(), SlimefunItems.SULFATE.item(), new ItemStack(Material.CALCITE), null, null})
                 .setUseableInWorkbench(true)
                 .register(plugin);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -522,7 +522,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new SlimefunItem(itemGroups.resources, SlimefunItems.SYNTHETIC_SAPPHIRE, RecipeType.SMELTERY,
-                new ItemStack[] {SlimefunItems.ALUMINUM_DUST.item(), new ItemStack(Material.GLASS), new ItemStack(Material.GLASS_PANE), SlimefunItems.ALUMINUM_INGOT.item(), new ItemStack(Material.LAPIS_LAZULI), null, null, null, null})
+                new ItemStack[] {SlimefunItems.ALUMINUM_DUST.item(), new ItemStack(Material.GLASS), new ItemStack(Material.GLASS_PANE), SlimefunItems.ALUMINUM_INGOT.item(), SlimefunItems.SALT.item(), SlimefunItems.Sulfate.item(), ItemStack(Material.CALCITE), null, null})
                 .setUseableInWorkbench(true)
                 .register(plugin);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -522,7 +522,7 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new SlimefunItem(itemGroups.resources, SlimefunItems.SYNTHETIC_SAPPHIRE, RecipeType.SMELTERY,
-                new ItemStack[] {SlimefunItems.ALUMINUM_DUST.item(), new ItemStack(Material.GLASS), new ItemStack(Material.GLASS_PANE), SlimefunItems.ALUMINUM_INGOT.item(), SlimefunItems.SALT.item(), SlimefunItems.Sulfate.item(), ItemStack(Material.CALCITE), null, null})
+                new ItemStack[] {SlimefunItems.ALUMINUM_DUST.item(), new ItemStack(Material.GLASS), new ItemStack(Material.GLASS_PANE), SlimefunItems.ALUMINUM_INGOT.item(), SlimefunItems.SALT.item(), SlimefunItems.SULFATE.item(), ItemStack(Material.CALCITE), null, null})
                 .setUseableInWorkbench(true)
                 .register(plugin);
 


### PR DESCRIPTION
## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->
i fixed the synthesic sapphire issue, which cannot be used in workbench.
while researching the solution i found the Lapis's chemical formula. so i used it as a recipe.

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->
Added Calcite, Salt, Sulfate to it.
Changed the material to Minecraft's Lapis Lazuli.
## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #3955.

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] ~~I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).~~ due to the big difference, calcite is not included in 1.17. so it only works on 1.17.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
