### PR TITLE
fix: block tickers task error #4276

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -138,7 +138,7 @@ public class TickerTask implements Runnable {
         try {
             // Only continue if the Chunk is actually loaded
             if (chunk.isLoaded()) {
-                for (Location l : locations) {
+                for (Location l : new HashSet<>(locations)) {
                     tickLocation(tickers, l);
                 }
             }


### PR DESCRIPTION
## Description
```
12/22 3:14:56 PM [Error] : [Slimefun] An Exception was caught while ticking the Block Tickers Task for Slimefun vDev - 1157
12/22 3:14:56 PM [Error] java.util.ConcurrentModificationException: null
12/22 3:14:56 PM [Error] at java.util.HashMap$HashIterator.nextNode(HashMap.java:1605) ~[?:?]
12/22 3:14:56 PM [Error] at java.util.HashMap$KeyIterator.next(HashMap.java:1628) ~[?:?]
```

Being made as we iterate over the value set 

## Proposed changes
Update tickChunk to iterate over a copy of the set to avoid concurrent modification for protection

## Related Issues (if applicable)
#4276 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
