### PR TITLE
fix: make research placeholder use same math logic as stats

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -280,7 +280,7 @@ public class PlayerProfile {
         return Optional.empty();
     }
 
-    private int countNonEmptyResearches(@Nonnull Collection<Research> researches) {
+    public int countNonEmptyResearches(@Nonnull Collection<Research> researches) {
         int count = 0;
         for (Research research : researches) {
             if (research.hasEnabledItems()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/PlaceholderAPIIntegration.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/integrations/PlaceholderAPIIntegration.java
@@ -106,8 +106,9 @@ class PlaceholderAPIIntegration extends PlaceholderExpansion {
             Optional<PlayerProfile> profile = PlayerProfile.find(p);
 
             if (profile.isPresent()) {
-                Set<Research> set = profile.get().getResearches();
-                return String.valueOf(Math.round(((set.size() * 100.0F) / Slimefun.getRegistry().getResearches().size()) * 100.0F) / 100.0F);
+                int unlockedResearches = profile.get().countNonEmptyResearches(profile.get().getResearches());
+                int allResearches = profile.get().countNonEmptyResearches(Slimefun.getRegistry().getResearches());
+                return String.valueOf(Math.round(((unlockedResearches * 100.0F) / allResearches) * 100.0F) / 100.0F);
             } else if (p instanceof Player player) {
                 return getProfilePlaceholder(player);
             }


### PR DESCRIPTION
## Description
The data displayed by the placeholder %slimefun_researches_percentage_researches_unlocked% displays data from all slimefun items (including the disabled ones) while the /sf stats displays data from all slimefun items (except the disabled ones).


## Proposed changes
I'm not sure about style guide or how you wanted parity to happen, so I went with the more logical approach. Adjusted the placeholder calculation to remove disabled researches from the calculation, which matches what the /stats command does.

Made the countNonEmptyResearches public to access it from placeholder with our provided profile instance.

## Related Issues (if applicable)
#4277 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
