### PR TITLE
fix: remove bartering drop order bias by shuffling candidates (#4326)

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nonnull;
 
@@ -38,7 +39,6 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlock;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.guide.CheatSheetSlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.implementation.guide.SurvivalSlimefunGuide;
-
 import me.mrCookieSlime.Slimefun.api.BlockInfoConfig;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
@@ -280,6 +280,19 @@ public final class SlimefunRegistry {
     @Nonnull
     public Set<ItemStack> getBarteringDrops() {
         return barterDrops;
+    }
+
+    /**
+     * Returns a shuffled snapshot of the current bartering drops to avoid
+     * iteration order bias when evaluating random chances.
+     *
+     * @return A shuffled List of bartering drops
+     */
+    @Nonnull
+    public List<ItemStack> getRandomizedBarteringDrops() {
+        List<ItemStack> list = new ArrayList<>(barterDrops);
+        Collections.shuffle(list, ThreadLocalRandom.current());
+        return list;
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/PiglinListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/entity/PiglinListener.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners.entity;
 
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nonnull;
@@ -78,21 +78,12 @@ public class PiglinListener implements Listener {
     @EventHandler
     public void onPiglinDropItem(EntityDropItemEvent e) {
         if (e.getEntity() instanceof Piglin) {
-            Set<ItemStack> drops = Slimefun.getRegistry().getBarteringDrops();
-
-            /*
-             * NOTE: Getting a new random number each iteration because multiple items could have the same
-             * % chance to drop, and if one fails all items with that number will fail.
-             * Getting a new random number will allow multiple items with the same % chance to drop.
-             */
-
+            List<ItemStack> drops = Slimefun.getRegistry().getRandomizedBarteringDrops();
+            
             for (ItemStack is : drops) {
                 SlimefunItem sfi = SlimefunItem.getByItem(is);
-                // Check the getBarteringLootChance and compare against a random number 0-100,
-                // if the random number is greater then replace the item.
                 if (sfi instanceof PiglinBarterDrop piglinBarterDrop) {
                     int chance = piglinBarterDrop.getBarteringLootChance();
-
                     if (chance < 1 || chance >= 100) {
                         sfi.warn("The Piglin Bartering chance must be between 1-99% on item: " + sfi.getId());
                     } else if (chance > ThreadLocalRandom.current().nextInt(100)) {


### PR DESCRIPTION
## Description
This PR fixes the issue where the piglin barter drop uses a `HashSet` for iteration, which results in a deterministic order after the set is finalized.

## Proposed changes
- Added a new method in `SlimefunRegistry` called `getRandomizedBarteringDrops()`, which copies the `barterDrops` into a `List` and shuffles it with `ThreadLocalRandom`.  
- Updated the piglin drop event listener to use the randomized list instead of iterating over the original `HashSet`. 

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->
Resolves #4326 

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [x] I added sufficient Unit Tests to cover my code.