### PR TITLE
fix Bug #4304

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.blocks.Vein;
-import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
@@ -48,13 +47,13 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<ToolUseHandler> {
         return (e, tool, fortune, drops) -> {
             if (SlimefunTag.PICKAXE_OF_VEIN_MINING_BLOCKS.isTagged(e.getBlock().getType())) {
                 List<Block> blocks = Vein.find(e.getBlock(), maxBlocks.getValue(), b -> SlimefunTag.PICKAXE_OF_VEIN_MINING_BLOCKS.isTagged(b.getType()));
-                breakBlocks(e.getPlayer(), blocks, fortune, tool);
+                breakBlocks(e.getPlayer(), blocks, tool);
             }
         };
     }
 
     @ParametersAreNonnullByDefault
-    private void breakBlocks(Player p, List<Block> blocks, int fortune, ItemStack tool) {
+    private void breakBlocks(Player p, List<Block> blocks, ItemStack tool) {
         for (Block b : blocks) {
             if (Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.BREAK_BLOCK)) {
                 b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
@@ -63,7 +62,7 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<ToolUseHandler> {
                     b.getWorld().dropItemNaturally(b.getLocation(), new ItemStack(b.getType()));
                 } else {
                     for (ItemStack drop : b.getDrops(tool)) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), drop.getType().isBlock() ? drop : CustomItemStack.create(drop, fortune));
+                        b.getWorld().dropItemNaturally(b.getLocation(), drop);
                     }
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
@@ -23,6 +23,7 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 
 /**
  * The {@link PickaxeOfVeinMining} is a powerful tool which allows you to mine an entire vein of ores
@@ -55,6 +56,10 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<ToolUseHandler> {
     @ParametersAreNonnullByDefault
     private void breakBlocks(Player p, List<Block> blocks, ItemStack tool) {
         for (Block b : blocks) {
+            if (BlockStorage.check(b.getLocation()) != null) {
+                continue;
+            }
+
             if (Slimefun.getProtectionManager().hasPermission(p, b.getLocation(), Interaction.BREAK_BLOCK)) {
                 b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 


### PR DESCRIPTION
## Description
This PR fixes a bug regarding the **Pickaxe of the Vein Mining**. Previously, when this tool was enchanted with **Fortune**, the drops were not calculated correctly (the Fortune effect was ignored or inconsistent) during the vein mining operation.

## Proposed changes
I have updated the logic for the Pickaxe of the Vein Mining to ensure that the **Fortune enchantment** is correctly applied to the drops.
Now, when using the Vein Mining ability, the drops will correctly reflect the Fortune level on the pickaxe, matching the expected behavior.

**Before Fix**
https://jumpshare.com/s/mQ2ijJOYAO8CfugdvTHV

**After Fix**
https://jumpshare.com/s/fIlEzieY2bKTu1z8aPB6

## Related Issues (if applicable)
Resolves #4304

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.