### PR TITLE
fix Bug #4037

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -122,9 +122,13 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
         ExplosiveToolBreakBlocksEvent event = new ExplosiveToolBreakBlocksEvent(p, b, blocksToDestroy, item, this);
         Bukkit.getServer().getPluginManager().callEvent(event);
 
+        blocksToDestroy.sort((b1, b2) -> Integer.compare(b2.getY(), b1.getY()));
+
         if (!event.isCancelled()) {
             for (Block block : blocksToDestroy) {
-                breakBlock(e, p, item, block, drops);
+                if (block.getType() != Material.AIR) {
+                    breakBlock(e, p, item, block, drops);
+                }
             }
         }
     }
@@ -195,7 +199,9 @@ public class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements
                 BlockStorage.clearBlockInfo(b);
             }
         } else {
-            b.breakNaturally(item);
+            if (b.getType() != Material.AIR) {
+                b.breakNaturally(item);
+            }
         }
 
         damageItem(p, item);


### PR DESCRIPTION
## Description
This PR addresses a critical item duplication exploit involving **Explosive Tools** (e.g., Explosive Pickaxe) and blocks that rely on a support block (e.g., **Elevator Plates**, Rails, Torches, Carpets).

**The Issue:**
Previously, when an Explosive Tool was used on a cluster of blocks, the order of destruction was not determined by height. If the tool destroyed the **supporting block** (floor) before the **attached block** (Elevator Plate):
1. The support block breaks.
2. Minecraft physics detects the attached block is floating and breaks it, dropping an item (Drop 1).
3. The Explosive Tool continues its iteration and tries to break the attached block again, dropping the item a second time (Drop 2).

This resulted in infinite duplication of Elevator Plates and similar items.

## Proposed changes
Modified `ExplosiveTool.java` to implement a sorting mechanism for the destruction list.

1.  **Y-Level Sorting:** The list of blocks to be destroyed (`blocksToDestroy`) is now sorted by Y-level in **descending order** (Top to Bottom).
    * Logic: `blocksToDestroy.sort((b1, b2) -> Integer.compare(b2.getY(), b1.getY()));`
    * This ensures that attached blocks (Top) are broken by the tool *before* their support blocks (Bottom) are removed.

2.  **Safety Check:** Added a validation check `if (block.getType() != Material.AIR)` before breaking to ensure the tool does not attempt to break a block that has already been removed by other means/plugins.

This change completely resolves the duplication glitch while maintaining the intended behavior of the Explosive Tool.

## Related Issues (if applicable)
Resolves #4037

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.