### PR TITLE
Fix: Send message when hologram projector no longer exists

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -106,7 +106,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
                 // Fixes #3445 - Make sure the projector is not broken
                 if (!BlockStorage.check(projector, getId())) {
                     // Hologram projector no longer exists.
-                    // TODO: Add a chat message informing the player that their message was ignored.
+                    Slimefun.getLocalization().sendMessage(pl, "machines.HOLOGRAM_PROJECTOR.ignored", true);
                     return;
                 }
 

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -316,6 +316,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Please enter your desired Hologram Text into your Chat. &r(Color Codes are supported!)'
     inventory-title: 'Hologram Editor'
+    ignored: '&cYour input was ignored because the Hologram Projector no longer exists.'
 
   ELEVATOR:
     no-destinations: '&4No destinations found'

--- a/src/main/resources/languages/zh-CN/messages.yml
+++ b/src/main/resources/languages/zh-CN/messages.yml
@@ -276,6 +276,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7请写下想显示在全息文本上的话. &r(支持颜色代码)'
     inventory-title: '全息图像编辑器'
+    ignored: '&c输入已被忽略，因为全息投影仪已不存在.'
   ELEVATOR:
     no-destinations: '&4找不到上下楼'
     pick-a-floor: '&3- 选择一个楼层 -'


### PR DESCRIPTION
## Description

This PR fixes the issue where players would not receive any feedback when their input was ignored due to the Hologram Projector being destroyed or removed while editing.

## Proposed changes

Added a message to inform the player that their input was ignored when the Hologram Projector no longer exists
Added the corresponding localization key `machines.HOLOGRAM_PROJECTOR.ignored` in English and Chinese

## Related Issues 

Resolves #3445
