### PR TITLE
refactor: replace commons-lang Validate with Guava Preconditions (#3586)

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Server;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -233,7 +233,7 @@ public enum MinecraftVersion {
      * @return Whether this {@link MinecraftVersion} is newer or equal to the given {@link MinecraftVersion}
      */
     public boolean isAtLeast(@Nonnull MinecraftVersion version) {
-        Validate.notNull(version, "A Minecraft version cannot be null!");
+        Preconditions.checkNotNull(version, "A Minecraft version cannot be null!");
 
         if (this == UNKNOWN) {
             return false;
@@ -268,7 +268,7 @@ public enum MinecraftVersion {
      * @return Whether this {@link MinecraftVersion} is older than the given one
      */
     public boolean isBefore(@Nonnull MinecraftVersion version) {
-        Validate.notNull(version, "A Minecraft version cannot be null!");
+        Preconditions.checkNotNull(version, "A Minecraft version cannot be null!");
 
         if (this == UNKNOWN) {
             return true;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunAddon.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunAddon.java
@@ -5,7 +5,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -86,7 +86,7 @@ public interface SlimefunAddon {
      * @return Whether this {@link SlimefunAddon} depends on the given {@link Plugin}
      */
     default boolean hasDependency(@Nonnull String dependency) {
-        Validate.notNull(dependency, "The dependency cannot be null");
+        Preconditions.checkNotNull(dependency, "The dependency cannot be null");
 
         // Well... it cannot depend on itself but you get the idea.
         if (getJavaPlugin().getName().equalsIgnoreCase(dependency)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunBranch.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/SlimefunBranch.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import io.github.bakedlibs.dough.common.CommonPatterns;
 
@@ -45,7 +45,7 @@ public enum SlimefunBranch {
     private final boolean official;
 
     SlimefunBranch(@Nonnull String name, boolean official) {
-        Validate.notNull(name, "The branch name cannot be null");
+        Preconditions.checkNotNull(name, "The branch name cannot be null");
 
         this.name = name;
         this.official = official;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoEnchanterProcessEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncAutoEnchanterProcessEvent.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -31,9 +31,9 @@ public class AsyncAutoEnchanterProcessEvent extends Event implements Cancellable
     public AsyncAutoEnchanterProcessEvent(@Nonnull ItemStack item, @Nonnull ItemStack enchantedBook, @Nonnull BlockMenu menu) {
         super(true);
 
-        Validate.notNull(item, "The item to enchant cannot be null!");
-        Validate.notNull(enchantedBook, "The enchanted book to enchant cannot be null!");
-        Validate.notNull(menu, "The menu of auto-enchanter cannot be null!");
+        Preconditions.checkNotNull(item, "The item to enchant cannot be null!");
+        Preconditions.checkNotNull(enchantedBook, "The enchanted book to enchant cannot be null!");
+        Preconditions.checkNotNull(menu, "The menu of auto-enchanter cannot be null!");
 
         this.item = item;
         this.enchantedBook = enchantedBook;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncProfileLoadEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AsyncProfileLoadEvent.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -32,7 +32,7 @@ public class AsyncProfileLoadEvent extends Event {
     public AsyncProfileLoadEvent(@Nonnull PlayerProfile profile) {
         super(true);
 
-        Validate.notNull(profile, "The Profile cannot be null");
+        Preconditions.checkNotNull(profile, "The Profile cannot be null");
 
         this.uniqueId = profile.getUUID();
         this.profile = profile;
@@ -56,8 +56,8 @@ public class AsyncProfileLoadEvent extends Event {
      *            The {@link PlayerProfile}
      */
     public void setProfile(@Nonnull PlayerProfile profile) {
-        Validate.notNull(profile, "The PlayerProfile cannot be null!");
-        Validate.isTrue(profile.getUUID().equals(uniqueId), "Cannot inject a PlayerProfile with a different UUID");
+        Preconditions.checkNotNull(profile, "The PlayerProfile cannot be null!");
+        Preconditions.checkArgument(profile.getUUID().equals(uniqueId), "Cannot inject a PlayerProfile with a different UUID");
 
         this.profile = profile;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/BlockPlacerPlaceEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/BlockPlacerPlaceEvent.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.block.Block;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -75,7 +75,7 @@ public class BlockPlacerPlaceEvent extends BlockEvent implements Cancellable {
      *            The {@link ItemStack} to be placed
      */
     public void setItemStack(@Nonnull ItemStack item) {
-        Validate.notNull(item, "The ItemStack must not be null!");
+        Preconditions.checkNotNull(item, "The ItemStack must not be null!");
 
         if (!locked) {
             this.placedItem = item;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ClimbingPickLaunchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ClimbingPickLaunchEvent.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -63,7 +63,7 @@ public class ClimbingPickLaunchEvent extends PlayerEvent implements Cancellable 
      *            The {@link Vector} velocity to apply
      */
     public void setVelocity(@Nonnull Vector velocity) {
-        Validate.notNull(velocity);
+        Preconditions.checkNotNull(velocity);
         this.velocity = velocity;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/CoolerFeedPlayerEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/CoolerFeedPlayerEvent.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -84,8 +84,8 @@ public class CoolerFeedPlayerEvent extends PlayerEvent implements Cancellable {
      *            The new {@link ItemStack}
      */
     public void setConsumedItem(@Nonnull ItemStack item) {
-        Validate.notNull(item, "The consumed Item cannot be null!");
-        Validate.isTrue(item.getItemMeta() instanceof PotionMeta, "The item must be a potion!");
+        Preconditions.checkNotNull(item, "The consumed Item cannot be null!");
+        Preconditions.checkArgument(item.getItemMeta() instanceof PotionMeta, "The item must be a potion!");
 
         this.consumedItem = item;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlocksEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ExplosiveToolBreakBlocksEvent.java
@@ -5,7 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -38,10 +38,10 @@ public class ExplosiveToolBreakBlocksEvent extends PlayerEvent implements Cancel
     public ExplosiveToolBreakBlocksEvent(Player player, Block block, List<Block> blocks, ItemStack item, ExplosiveTool explosiveTool) {
         super(player);
 
-        Validate.notNull(block, "The center block cannot be null!");
-        Validate.notNull(blocks, "Blocks cannot be null");
-        Validate.notNull(item, "Item cannot be null");
-        Validate.notNull(explosiveTool, "ExplosiveTool cannot be null");
+        Preconditions.checkNotNull(block, "The center block cannot be null!");
+        Preconditions.checkNotNull(blocks, "Blocks cannot be null");
+        Preconditions.checkNotNull(item, "Item cannot be null");
+        Preconditions.checkNotNull(explosiveTool, "ExplosiveTool cannot be null");
 
         this.mainBlock = block;
         this.additionalBlocks = blocks;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerPreResearchEvent.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -35,9 +35,9 @@ public class PlayerPreResearchEvent extends Event implements Cancellable {
 
     @ParametersAreNonnullByDefault
     public PlayerPreResearchEvent(Player p, Research research, SlimefunItem slimefunItem) {
-        Validate.notNull(p, "The Player cannot be null");
-        Validate.notNull(research, "Research cannot be null");
-        Validate.notNull(slimefunItem, "SlimefunItem cannot be null");
+        Preconditions.checkNotNull(p, "The Player cannot be null");
+        Preconditions.checkNotNull(research, "Research cannot be null");
+        Preconditions.checkNotNull(slimefunItem, "SlimefunItem cannot be null");
 
         this.player = p;
         this.research = research;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerRightClickEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerRightClickEvent.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -168,12 +168,12 @@ public class PlayerRightClickEvent extends PlayerEvent {
     }
 
     public void setUseItem(@Nonnull Result result) {
-        Validate.notNull(result, "Result cannot be null");
+        Preconditions.checkNotNull(result, "Result cannot be null");
         itemResult = result;
     }
 
     public void setUseBlock(@Nonnull Result result) {
-        Validate.notNull(result, "Result cannot be null");
+        Preconditions.checkNotNull(result, "Result cannot be null");
         blockResult = result;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ReactorExplodeEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ReactorExplodeEvent.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -24,8 +24,8 @@ public class ReactorExplodeEvent extends Event {
     private final Reactor reactor;
 
     public ReactorExplodeEvent(@Nonnull Location l, @Nonnull Reactor reactor) {
-        Validate.notNull(l, "A Location must be provided");
-        Validate.notNull(reactor, "A Reactor cannot be null");
+        Preconditions.checkNotNull(l, "A Location must be provided");
+        Preconditions.checkNotNull(reactor, "A Reactor cannot be null");
 
         this.location = l;
         this.reactor = reactor;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ResearchUnlockEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ResearchUnlockEvent.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -30,8 +30,8 @@ public class ResearchUnlockEvent extends Event implements Cancellable {
     public ResearchUnlockEvent(@Nonnull Player p, @Nonnull Research research) {
         super(!Bukkit.isPrimaryThread());
 
-        Validate.notNull(p, "The Player cannot be null");
-        Validate.notNull(research, "Research cannot be null");
+        Preconditions.checkNotNull(p, "The Player cannot be null");
+        Preconditions.checkNotNull(research, "Research cannot be null");
 
         this.player = p;
         this.research = research;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunGuideOpenEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunGuideOpenEvent.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -28,9 +28,9 @@ public class SlimefunGuideOpenEvent extends Event implements Cancellable {
     private boolean cancelled;
 
     public SlimefunGuideOpenEvent(@Nonnull Player p, @Nonnull ItemStack guide, @Nonnull SlimefunGuideMode layout) {
-        Validate.notNull(p, "The Player cannot be null");
-        Validate.notNull(guide, "Guide cannot be null");
-        Validate.notNull(layout, "Layout cannot be null");
+        Preconditions.checkNotNull(p, "The Player cannot be null");
+        Preconditions.checkNotNull(guide, "Guide cannot be null");
+        Preconditions.checkNotNull(layout, "Layout cannot be null");
         this.player = p;
         this.guide = guide;
         this.layout = layout;
@@ -76,7 +76,7 @@ public class SlimefunGuideOpenEvent extends Event implements Cancellable {
      *            The new {@link SlimefunGuideMode}
      */
     public void setGuideLayout(@Nonnull SlimefunGuideMode layout) {
-        Validate.notNull(layout, "You must specify a layout that is not-null!");
+        Preconditions.checkNotNull(layout, "You must specify a layout that is not-null!");
         this.layout = layout;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemSpawnEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/SlimefunItemSpawnEvent.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -83,7 +83,7 @@ public class SlimefunItemSpawnEvent extends Event implements Cancellable {
      *            The {@link Location} where to drop the {@link ItemStack}
      */
     public void setLocation(@Nonnull Location location) {
-        Validate.notNull(location, "The Location cannot be null!");
+        Preconditions.checkNotNull(location, "The Location cannot be null!");
 
         this.location = location;
     }
@@ -104,8 +104,8 @@ public class SlimefunItemSpawnEvent extends Event implements Cancellable {
      *            The {@link ItemStack} to drop
      */
     public void setItemStack(@Nonnull ItemStack itemStack) {
-        Validate.notNull(itemStack, "Cannot drop null.");
-        Validate.isTrue(!itemStack.getType().isAir(), "Cannot drop air.");
+        Preconditions.checkNotNull(itemStack, "Cannot drop null.");
+        Preconditions.checkArgument(!itemStack.getType().isAir(), "Cannot drop air.");
 
         this.itemStack = itemStack;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/WaypointCreateEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/WaypointCreateEvent.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -37,8 +37,8 @@ public class WaypointCreateEvent extends PlayerEvent implements Cancellable {
     public WaypointCreateEvent(@Nonnull Player player, @Nonnull String name, @Nonnull Location location) {
         super(player);
 
-        Validate.notNull(location, "Location must not be null!");
-        Validate.notNull(name, "Name must not be null!");
+        Preconditions.checkNotNull(location, "Location must not be null!");
+        Preconditions.checkNotNull(name, "Name must not be null!");
 
         this.location = location;
         this.name = name;
@@ -63,7 +63,7 @@ public class WaypointCreateEvent extends PlayerEvent implements Cancellable {
      *            The {@link Location} to set
      */
     public void setLocation(@Nonnull Location loc) {
-        Validate.notNull(loc, "Cannot set the Location to null!");
+        Preconditions.checkNotNull(loc, "Cannot set the Location to null!");
         this.location = loc;
     }
 
@@ -84,7 +84,7 @@ public class WaypointCreateEvent extends PlayerEvent implements Cancellable {
      *            The name for this waypoint
      */
     public void setName(@Nonnull String name) {
-        Validate.notEmpty(name, "The name of a waypoint must not be empty!");
+        Preconditions.checkArgument(!name, "The name of a waypoint must not be empty!");
         this.name = name;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/WaypointCreateEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/WaypointCreateEvent.java
@@ -84,7 +84,7 @@ public class WaypointCreateEvent extends PlayerEvent implements Cancellable {
      *            The name for this waypoint
      */
     public void setName(@Nonnull String name) {
-        Preconditions.checkArgument(!name, "The name of a waypoint must not be empty!");
+        Preconditions.checkArgument(name != null && !name.isEmpty(), "The name of a waypoint must not be empty!");
         this.name = name;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
@@ -69,8 +69,8 @@ public class ResourceManager {
      *            The {@link GEOResource} to register
      */
     void register(@Nonnull GEOResource resource) {
-        Validate.notNull(resource, "Cannot register null as a GEO-Resource");
-        Validate.notNull(resource.getKey(), "GEO-Resources must have a NamespacedKey which is not null");
+        Preconditions.checkNotNull(resource, "Cannot register null as a GEO-Resource");
+        Preconditions.checkNotNull(resource.getKey(), "GEO-Resources must have a NamespacedKey which is not null");
 
         // Resources may only be registered once
         if (Slimefun.getRegistry().getGEOResources().containsKey(resource.getKey())) {
@@ -106,8 +106,8 @@ public class ResourceManager {
      * @return An {@link OptionalInt}, either empty or containing the amount of the given {@link GEOResource}
      */
     public @Nonnull OptionalInt getSupplies(@Nonnull GEOResource resource, @Nonnull World world, int x, int z) {
-        Validate.notNull(resource, "Cannot get supplies for null");
-        Validate.notNull(world, "World must not be null");
+        Preconditions.checkNotNull(resource, "Cannot get supplies for null");
+        Preconditions.checkNotNull(world, "World must not be null");
 
         String key = resource.getKey().toString().replace(':', '-');
         String value = BlockStorage.getChunkInfo(world, x, z, key);
@@ -134,8 +134,8 @@ public class ResourceManager {
      *            The new supply value
      */
     public void setSupplies(@Nonnull GEOResource resource, @Nonnull World world, int x, int z, int value) {
-        Validate.notNull(resource, "Cannot set supplies for null");
-        Validate.notNull(world, "World cannot be null");
+        Preconditions.checkNotNull(resource, "Cannot set supplies for null");
+        Preconditions.checkNotNull(world, "World cannot be null");
 
         String key = resource.getKey().toString().replace(':', '-');
         BlockStorage.setChunkInfo(world, x, z, key, String.valueOf(value));
@@ -160,8 +160,8 @@ public class ResourceManager {
      * @return The new supply value
      */
     private int generate(@Nonnull GEOResource resource, @Nonnull World world, int x, int y, int z) {
-        Validate.notNull(resource, "Cannot generate resources for null");
-        Validate.notNull(world, "World cannot be null");
+        Preconditions.checkNotNull(resource, "Cannot generate resources for null");
+        Preconditions.checkNotNull(world, "World cannot be null");
 
         // Get the corresponding Block (and Biome)
         Block block = world.getBlockAt(x << 4, y, z << 4);
@@ -171,7 +171,7 @@ public class ResourceManager {
          * getBiome() is marked as NotNull, but it seems like some servers ignore this entirely.
          * We have seen multiple reports on Tuinity where it has indeed returned null.
          */
-        Validate.notNull(biome, "Biome appears to be null for position: " + new BlockPosition(block));
+        Preconditions.checkNotNull(biome, "Biome appears to be null for position: " + new BlockPosition(block));
 
         // Make sure the value is not below zero.
         int value = Math.max(0, resource.getDefaultSupply(world.getEnvironment(), biome));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/GPSNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/GPSNetwork.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -280,8 +280,8 @@ public class GPSNetwork {
      *            The {@link Location} of the new waypoint
      */
     public void createWaypoint(@Nonnull Player p, @Nonnull Location l) {
-        Validate.notNull(p, "Player cannot be null!");
-        Validate.notNull(l, "Waypoint Location cannot be null!");
+        Preconditions.checkNotNull(p, "Player cannot be null!");
+        Preconditions.checkNotNull(l, "Waypoint Location cannot be null!");
 
         PlayerProfile.get(p, profile -> {
             if ((profile.getWaypoints().size() + 2) > inventory.length) {
@@ -307,9 +307,9 @@ public class GPSNetwork {
      *            The {@link Location} of this waypoint
      */
     public void addWaypoint(@Nonnull Player p, @Nonnull String name, @Nonnull Location l) {
-        Validate.notNull(p, "Player cannot be null!");
-        Validate.notNull(name, "Waypoint name cannot be null!");
-        Validate.notNull(l, "Waypoint Location cannot be null!");
+        Preconditions.checkNotNull(p, "Player cannot be null!");
+        Preconditions.checkNotNull(name, "Waypoint name cannot be null!");
+        Preconditions.checkNotNull(l, "Waypoint Location cannot be null!");
 
         PlayerProfile.get(p, profile -> {
             if ((profile.getWaypoints().size() + 2) > inventory.length) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -154,8 +154,8 @@ public final class TeleportationManager {
      * @return The amount of time the teleportation will take
      */
     public int getTeleportationTime(int complexity, @Nonnull Location source, @Nonnull Location destination) {
-        Validate.notNull(source, "Source cannot be null");
-        Validate.notNull(source, "Destination cannot be null");
+        Preconditions.checkNotNull(source, "Source cannot be null");
+        Preconditions.checkNotNull(source, "Destination cannot be null");
 
         if (complexity < 100) {
             return 100;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/Waypoint.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/Waypoint.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World.Environment;
@@ -71,10 +71,10 @@ public class Waypoint {
      */
     @ParametersAreNonnullByDefault
     public Waypoint(UUID ownerId, String id, Location loc, String name) {
-        Validate.notNull(ownerId, "owner ID must never be null!");
-        Validate.notNull(id, "id must never be null!");
-        Validate.notNull(loc, "Location must never be null!");
-        Validate.notNull(name, "Name must never be null!");
+        Preconditions.checkNotNull(ownerId, "owner ID must never be null!");
+        Preconditions.checkNotNull(id, "id must never be null!");
+        Preconditions.checkNotNull(loc, "Location must never be null!");
+        Preconditions.checkNotNull(name, "Name must never be null!");
 
         this.ownerId = ownerId;
         this.id = id;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemGroup.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
@@ -77,8 +77,8 @@ public class ItemGroup implements Keyed {
      */
     @ParametersAreNonnullByDefault
     public ItemGroup(NamespacedKey key, ItemStack item, int tier) {
-        Validate.notNull(key, "An item group's NamespacedKey must not be null!");
-        Validate.notNull(item, "An item group's ItemStack must not be null!");
+        Preconditions.checkNotNull(key, "An item group's NamespacedKey must not be null!");
+        Preconditions.checkNotNull(item, "An item group's ItemStack must not be null!");
 
         this.item = item;
         this.key = key;
@@ -106,7 +106,7 @@ public class ItemGroup implements Keyed {
      *            The {@link SlimefunAddon} that wants to register this {@link ItemGroup}
      */
     public void register(@Nonnull SlimefunAddon addon) {
-        Validate.notNull(addon, "The Addon cannot be null");
+        Preconditions.checkNotNull(addon, "The Addon cannot be null");
 
         if (isRegistered()) {
             throw new UnsupportedOperationException("This ItemGroup has already been registered!");
@@ -179,7 +179,7 @@ public class ItemGroup implements Keyed {
      *            the {@link SlimefunItem} that should be added to this {@link ItemGroup}
      */
     public void add(@Nonnull SlimefunItem item) {
-        Validate.notNull(item, "Cannot add null Items to an ItemGroup!");
+        Preconditions.checkNotNull(item, "Cannot add null Items to an ItemGroup!");
 
         if (items.contains(item)) {
             // Ignore duplicate entries
@@ -200,7 +200,7 @@ public class ItemGroup implements Keyed {
      *            the {@link SlimefunItem} that should be removed from this {@link ItemGroup}
      */
     public void remove(@Nonnull SlimefunItem item) {
-        Validate.notNull(item, "Cannot remove null from an ItemGroup!");
+        Preconditions.checkNotNull(item, "Cannot remove null from an ItemGroup!");
         items.remove(item);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemSetting.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/ItemSetting.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import io.github.bakedlibs.dough.config.Config;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -41,9 +41,9 @@ public class ItemSetting<T> {
      */
     @ParametersAreNonnullByDefault
     public ItemSetting(SlimefunItem item, String key, T defaultValue) {
-        Validate.notNull(item, "The provided SlimefunItem must not be null!");
-        Validate.notNull(key, "The key of an ItemSetting is not allowed to be null!");
-        Validate.notNull(defaultValue, "The default value of an ItemSetting is not allowed to be null!");
+        Preconditions.checkNotNull(item, "The provided SlimefunItem must not be null!");
+        Preconditions.checkNotNull(key, "The key of an ItemSetting is not allowed to be null!");
+        Preconditions.checkNotNull(defaultValue, "The default value of an ItemSetting is not allowed to be null!");
 
         this.item = item;
         this.key = key;
@@ -164,7 +164,7 @@ public class ItemSetting<T> {
      */
     @SuppressWarnings("unchecked")
     public void reload() {
-        Validate.notNull(item, "Cannot apply settings for a non-existing SlimefunItem");
+        Preconditions.checkNotNull(item, "Cannot apply settings for a non-existing SlimefunItem");
 
         Slimefun.getItemCfg().setDefaultValue(item.getId() + '.' + getKey(), getDefaultValue());
         Object configuredValue = Slimefun.getItemCfg().getValue(item.getId() + '.' + getKey());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -14,7 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -147,9 +147,9 @@ public class SlimefunItem implements Placeable {
      */
     @ParametersAreNonnullByDefault
     public SlimefunItem(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, @Nullable ItemStack recipeOutput) {
-        Validate.notNull(itemGroup, "'itemGroup' is not allowed to be null!");
-        Validate.notNull(item, "'item' is not allowed to be null!");
-        Validate.notNull(recipeType, "'recipeType' is not allowed to be null!");
+        Preconditions.checkNotNull(itemGroup, "'itemGroup' is not allowed to be null!");
+        Preconditions.checkNotNull(item, "'item' is not allowed to be null!");
+        Preconditions.checkNotNull(recipeType, "'recipeType' is not allowed to be null!");
 
         this.itemGroup = itemGroup;
         this.itemStackTemplate = item.item();
@@ -177,10 +177,10 @@ public class SlimefunItem implements Placeable {
     // Previously deprecated constructor, now only for internal purposes
     @ParametersAreNonnullByDefault
     protected SlimefunItem(ItemGroup itemGroup, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
-        Validate.notNull(itemGroup, "'itemGroup' is not allowed to be null!");
-        Validate.notNull(item, "'item' is not allowed to be null!");
-        Validate.notNull(id, "'id' is not allowed to be null!");
-        Validate.notNull(recipeType, "'recipeType' is not allowed to be null!");
+        Preconditions.checkNotNull(itemGroup, "'itemGroup' is not allowed to be null!");
+        Preconditions.checkNotNull(item, "'item' is not allowed to be null!");
+        Preconditions.checkNotNull(id, "'id' is not allowed to be null!");
+        Preconditions.checkNotNull(recipeType, "'recipeType' is not allowed to be null!");
 
         this.itemGroup = itemGroup;
         this.itemStackTemplate = item;
@@ -426,8 +426,8 @@ public class SlimefunItem implements Placeable {
      *            The {@link SlimefunAddon} that this {@link SlimefunItem} belongs to.
      */
     public void register(@Nonnull SlimefunAddon addon) {
-        Validate.notNull(addon, "A SlimefunAddon cannot be null!");
-        Validate.notNull(addon.getJavaPlugin(), "SlimefunAddon#getJavaPlugin() is not allowed to return null!");
+        Preconditions.checkNotNull(addon, "A SlimefunAddon cannot be null!");
+        Preconditions.checkNotNull(addon.getJavaPlugin(), "SlimefunAddon#getJavaPlugin() is not allowed to return null!");
 
         this.addon = addon;
 
@@ -680,7 +680,7 @@ public class SlimefunItem implements Placeable {
      *            The {@link RecipeType} for this {@link SlimefunItem}
      */
     public void setRecipeType(@Nonnull RecipeType type) {
-        Validate.notNull(type, "The RecipeType is not allowed to be null!");
+        Preconditions.checkNotNull(type, "The RecipeType is not allowed to be null!");
         this.recipeType = type;
     }
 
@@ -691,7 +691,7 @@ public class SlimefunItem implements Placeable {
      *            The new {@link ItemGroup}
      */
     public void setItemGroup(@Nonnull ItemGroup itemGroup) {
-        Validate.notNull(itemGroup, "The ItemGroup is not allowed to be null!");
+        Preconditions.checkNotNull(itemGroup, "The ItemGroup is not allowed to be null!");
 
         this.itemGroup.remove(this);
         itemGroup.add(this);
@@ -783,7 +783,7 @@ public class SlimefunItem implements Placeable {
      *            Any {@link ItemHandler} that should be added to this {@link SlimefunItem}
      */
     public final void addItemHandler(ItemHandler... handlers) {
-        Validate.notEmpty(handlers, "You cannot add zero handlers...");
+        Preconditions.checkArgument(!handlers, "You cannot add zero handlers...");
         Validate.noNullElements(handlers, "You cannot add any 'null' ItemHandler!");
 
         // Make sure they are added before the item was registered.
@@ -811,7 +811,7 @@ public class SlimefunItem implements Placeable {
      *            Any {@link ItemSetting} that should be added to this {@link SlimefunItem}
      */
     public final void addItemSetting(ItemSetting<?>... settings) {
-        Validate.notEmpty(settings, "You cannot add zero settings...");
+        Preconditions.checkArgument(!settings, "You cannot add zero settings...");
         Validate.noNullElements(settings, "You cannot add any 'null' ItemSettings!");
 
         if (state != ItemState.UNREGISTERED) {
@@ -864,7 +864,7 @@ public class SlimefunItem implements Placeable {
      *            The associated wiki page
      */
     public final void addOfficialWikipage(@Nonnull String page) {
-        Validate.notNull(page, "Wiki page cannot be null.");
+        Preconditions.checkNotNull(page, "Wiki page cannot be null.");
         wikiURL = Optional.of("https://github.com/Slimefun/Slimefun4/wiki/" + page);
     }
 
@@ -967,7 +967,7 @@ public class SlimefunItem implements Placeable {
      */
     @ParametersAreNonnullByDefault
     public void info(String message) {
-        Validate.notNull(addon, "Cannot log a message for an unregistered item!");
+        Preconditions.checkNotNull(addon, "Cannot log a message for an unregistered item!");
 
         String msg = toString() + ": " + message;
         addon.getLogger().log(Level.INFO, msg);
@@ -983,7 +983,7 @@ public class SlimefunItem implements Placeable {
      */
     @ParametersAreNonnullByDefault
     public void warn(String message) {
-        Validate.notNull(addon, "Cannot send a warning for an unregistered item!");
+        Preconditions.checkNotNull(addon, "Cannot send a warning for an unregistered item!");
 
         String msg = toString() + ": " + message;
         addon.getLogger().log(Level.WARNING, msg);
@@ -1005,7 +1005,7 @@ public class SlimefunItem implements Placeable {
      */
     @ParametersAreNonnullByDefault
     public void error(String message, Throwable throwable) {
-        Validate.notNull(addon, "Cannot send an error for an unregistered item!");
+        Preconditions.checkNotNull(addon, "Cannot send an error for an unregistered item!");
         addon.getLogger().log(Level.SEVERE, "Item \"{0}\" from {1} v{2} has caused an Error!", new Object[] { id, addon.getName(), addon.getPluginVersion() });
 
         if (addon.getBugTrackerURL() != null) {
@@ -1030,7 +1030,7 @@ public class SlimefunItem implements Placeable {
      */
     @ParametersAreNonnullByDefault
     public void sendDeprecationWarning(Player player) {
-        Validate.notNull(player, "The Player must not be null.");
+        Preconditions.checkNotNull(player, "The Player must not be null.");
         Slimefun.getLocalization().sendMessage(player, "messages.deprecated-item");
     }
 
@@ -1056,7 +1056,7 @@ public class SlimefunItem implements Placeable {
      * @return Whether this {@link Player} is able to use this {@link SlimefunItem}.
      */
     public boolean canUse(@Nonnull Player p, boolean sendMessage) {
-        Validate.notNull(p, "The Player cannot be null!");
+        Preconditions.checkNotNull(p, "The Player cannot be null!");
 
         if (getState() == ItemState.VANILLA_FALLBACK) {
             // Vanilla items (which fell back) can always be used.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItem.java
@@ -783,8 +783,10 @@ public class SlimefunItem implements Placeable {
      *            Any {@link ItemHandler} that should be added to this {@link SlimefunItem}
      */
     public final void addItemHandler(ItemHandler... handlers) {
-        Preconditions.checkArgument(!handlers, "You cannot add zero handlers...");
-        Validate.noNullElements(handlers, "You cannot add any 'null' ItemHandler!");
+        Preconditions.checkArgument(handlers != null && handlers.length > 0, "You cannot add zero handlers...");
+        for (ItemHandler handler : handlers) {
+            Preconditions.checkNotNull(handler, "You cannot add any 'null' ItemHandler!");
+        }
 
         // Make sure they are added before the item was registered.
         if (state != ItemState.UNREGISTERED) {
@@ -811,8 +813,10 @@ public class SlimefunItem implements Placeable {
      *            Any {@link ItemSetting} that should be added to this {@link SlimefunItem}
      */
     public final void addItemSetting(ItemSetting<?>... settings) {
-        Preconditions.checkArgument(!settings, "You cannot add zero settings...");
-        Validate.noNullElements(settings, "You cannot add any 'null' ItemSettings!");
+        Preconditions.checkArgument(settings != null && settings.length > 0, "You cannot add zero settings...");
+        for (ItemSetting<?> setting : settings) {
+            Preconditions.checkNotNull(setting, "You cannot add any 'null' ItemSettings!");
+        }
 
         if (state != ItemState.UNREGISTERED) {
             throw new UnsupportedOperationException("You cannot add an ItemSetting after the SlimefunItem was registered.");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
@@ -20,7 +20,7 @@ import io.papermc.paper.inventory.tooltip.TooltipContext;
 import io.papermc.paper.registry.set.RegistryKeySet;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -65,8 +65,8 @@ public class SlimefunItemStack {
     public SlimefunItemStack(@Nonnull String id, @Nonnull ItemStack item) {
         delegate = new ItemStack(item);
 
-        Validate.notNull(id, "The Item id must never be null!");
-        Validate.isTrue(id.equals(id.toUpperCase(Locale.ROOT)), "Slimefun Item Ids must be uppercase! (e.g. 'MY_ITEM_ID')");
+        Preconditions.checkNotNull(id, "The Item id must never be null!");
+        Preconditions.checkArgument(id.equals(id.toUpperCase(Locale.ROOT)), "Slimefun Item Ids must be uppercase! (e.g. 'MY_ITEM_ID')");
 
         if (Slimefun.instance() == null) {
             throw new PrematureCodeException("A SlimefunItemStack must never be be created before your Plugin was enabled.");
@@ -289,8 +289,8 @@ public class SlimefunItemStack {
     }
 
     private static @Nonnull String getTexture(@Nonnull String id, @Nonnull String texture) {
-        Validate.notNull(id, "The id cannot be null");
-        Validate.notNull(texture, "The texture cannot be null");
+        Preconditions.checkNotNull(id, "The id cannot be null");
+        Preconditions.checkNotNull(texture, "The texture cannot be null");
 
         if (texture.startsWith("ey")) {
             return texture;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/LockedItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/LockedItemGroup.java
@@ -70,7 +70,9 @@ public class LockedItemGroup extends ItemGroup {
     @ParametersAreNonnullByDefault
     public LockedItemGroup(NamespacedKey key, ItemStack item, int tier, NamespacedKey... parents) {
         super(key, item, tier);
-        Validate.noNullElements(parents, "A LockedItemGroup must not have any 'null' parents!");
+        for (NamespacedKey parent : parents) {
+            Preconditions.checkNotNull(parent, "A LockedItemGroup must not have any 'null' parents!");
+        }
 
         this.keys = parents;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/LockedItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/LockedItemGroup.java
@@ -9,7 +9,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -151,8 +151,8 @@ public class LockedItemGroup extends ItemGroup {
      * @return Whether the {@link Player} has fully completed all parent categories, otherwise false
      */
     public boolean hasUnlocked(@Nonnull Player p, @Nonnull PlayerProfile profile) {
-        Validate.notNull(p, "The player cannot be null!");
-        Validate.notNull(profile, "The Profile cannot be null!");
+        Preconditions.checkNotNull(p, "The player cannot be null!");
+        Preconditions.checkNotNull(profile, "The Profile cannot be null!");
 
         for (ItemGroup parent : parents) {
             for (SlimefunItem item : parent.getItems()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/NestedItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/NestedItemGroup.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -46,7 +46,7 @@ public class NestedItemGroup extends FlexItemGroup {
      *            The {@link SubItemGroup} to add.
      */
     public void addSubGroup(@Nonnull SubItemGroup group) {
-        Validate.notNull(group, "The sub item group cannot be null!");
+        Preconditions.checkNotNull(group, "The sub item group cannot be null!");
 
         subGroups.add(group);
     }
@@ -58,7 +58,7 @@ public class NestedItemGroup extends FlexItemGroup {
      *            The {@link SubItemGroup} to remove.
      */
     public void removeSubGroup(@Nonnull SubItemGroup group) {
-        Validate.notNull(group, "The sub item group cannot be null!");
+        Preconditions.checkNotNull(group, "The sub item group cannot be null!");
 
         subGroups.remove(group);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/SeasonalItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/SeasonalItemGroup.java
@@ -6,7 +6,7 @@ import java.time.Month;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -41,7 +41,7 @@ public class SeasonalItemGroup extends ItemGroup {
     @ParametersAreNonnullByDefault
     public SeasonalItemGroup(NamespacedKey key, Month month, int tier, ItemStack item) {
         super(key, item, tier);
-        Validate.notNull(month, "The Month cannot be null");
+        Preconditions.checkNotNull(month, "The Month cannot be null");
 
         this.month = month;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/SubItemGroup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/groups/SubItemGroup.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.api.items.groups;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -34,7 +34,7 @@ public class SubItemGroup extends ItemGroup {
     public SubItemGroup(NamespacedKey key, NestedItemGroup parent, ItemStack item, int tier) {
         super(key, item, tier);
 
-        Validate.notNull(parent, "The parent group cannot be null");
+        Preconditions.checkNotNull(parent, "The parent group cannot be null");
 
         parentItemGroup = parent;
         parent.addSubGroup(this);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/settings/DoubleRangeSetting.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/settings/DoubleRangeSetting.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.api.items.settings;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -26,7 +26,7 @@ public class DoubleRangeSetting extends ItemSetting<Double> {
     @ParametersAreNonnullByDefault
     public DoubleRangeSetting(SlimefunItem item, String key, double min, double defaultValue, double max) {
         super(item, key, defaultValue);
-        Validate.isTrue(defaultValue >= min && defaultValue <= max, "The default value is not in range.");
+        Preconditions.checkArgument(defaultValue >= min && defaultValue <= max, "The default value is not in range.");
 
         this.min = min;
         this.max = max;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/settings/IntRangeSetting.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/settings/IntRangeSetting.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.api.items.settings;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -26,7 +26,7 @@ public class IntRangeSetting extends ItemSetting<Integer> {
     @ParametersAreNonnullByDefault
     public IntRangeSetting(SlimefunItem item, String key, int min, int defaultValue, int max) {
         super(item, key, defaultValue);
-        Validate.isTrue(defaultValue >= min && defaultValue <= max, "The default value is not in range.");
+        Preconditions.checkArgument(defaultValue >= min && defaultValue <= max, "The default value is not in range.");
 
         this.min = min;
         this.max = max;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/network/Network.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/network/Network.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -68,8 +68,8 @@ public abstract class Network {
      *            The {@link Location} marking the regulator of this {@link Network}.
      */
     protected Network(@Nonnull NetworkManager manager, @Nonnull Location regulator) {
-        Validate.notNull(manager, "A NetworkManager must be provided");
-        Validate.notNull(regulator, "No regulator was specified");
+        Preconditions.checkNotNull(manager, "A NetworkManager must be provided");
+        Preconditions.checkNotNull(regulator, "No regulator was specified");
 
         this.manager = manager;
         this.regulator = regulator;
@@ -131,8 +131,8 @@ public abstract class Network {
      *            The {@link Location} to add
      */
     protected void addLocationToNetwork(@Nonnull Location l) {
-        Validate.notNull(l, "You cannot add a Location to a Network which is null!");
-        Validate.isTrue(l.getWorld().getUID().equals(worldId), "Networks cannot exist in multiple worlds!");
+        Preconditions.checkNotNull(l, "You cannot add a Location to a Network which is null!");
+        Preconditions.checkArgument(l.getWorld().getUID().equals(worldId), "Networks cannot exist in multiple worlds!");
 
         if (positions.add(BlockPosition.getAsLong(l))) {
             markDirty(l);
@@ -163,7 +163,7 @@ public abstract class Network {
      * @return Whether the given {@link Location} is part of this {@link Network}
      */
     public boolean connectsTo(@Nonnull Location l) {
-        Validate.notNull(l, "The Location cannot be null.");
+        Preconditions.checkNotNull(l, "The Location cannot be null.");
 
         if (this.regulator.equals(l)) {
             return true;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/network/NetworkVisualizer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/network/NetworkVisualizer.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.api.network;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle.DustOptions;
@@ -34,8 +34,8 @@ class NetworkVisualizer implements Runnable {
      *            The {@link Network} to visualize
      */
     NetworkVisualizer(@Nonnull Network network, @Nonnull Color color) {
-        Validate.notNull(network, "The network should not be null.");
-        Validate.notNull(color, "The color cannot be null.");
+        Preconditions.checkNotNull(network, "The network should not be null.");
+        Preconditions.checkNotNull(color, "The color cannot be null.");
 
         this.network = network;
         this.particleOptions = new DustOptions(color, 3F);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/player/PlayerProfile.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.github.thebusybiscuit.slimefun4.storage.data.PlayerData;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
@@ -150,7 +150,7 @@ public class PlayerProfile {
      *            Whether the {@link Research} should be unlocked or locked
      */
     public void setResearched(@Nonnull Research research, boolean unlock) {
-        Validate.notNull(research, "Research must not be null!");
+        Preconditions.checkNotNull(research, "Research must not be null!");
         dirty = true;
 
         if (unlock) {
@@ -364,7 +364,7 @@ public class PlayerProfile {
      * @return If the {@link OfflinePlayer} was cached or not.
      */
     public static boolean get(@Nonnull OfflinePlayer p, @Nonnull Consumer<PlayerProfile> callback) {
-        Validate.notNull(p, "Cannot get a PlayerProfile for: null!");
+        Preconditions.checkNotNull(p, "Cannot get a PlayerProfile for: null!");
         UUID uuid = p.getUniqueId();
 
         Debug.log(TestCase.PLAYER_PROFILE_DATA, "Getting PlayerProfile for {}", uuid);
@@ -422,7 +422,7 @@ public class PlayerProfile {
      * @return Whether the {@link PlayerProfile} was already loaded
      */
     public static boolean request(@Nonnull OfflinePlayer p) {
-        Validate.notNull(p, "Cannot request a Profile for null");
+        Preconditions.checkNotNull(p, "Cannot request a Profile for null");
         Debug.log(TestCase.PLAYER_PROFILE_DATA, "Requesting PlayerProfile for {}", p.getName());
 
         UUID uuid = p.getUniqueId();
@@ -505,7 +505,7 @@ public class PlayerProfile {
     }
 
     public boolean hasFullProtectionAgainst(@Nonnull ProtectionType type) {
-        Validate.notNull(type, "ProtectionType must not be null.");
+        Preconditions.checkNotNull(type, "ProtectionType must not be null.");
 
         int armorCount = 0;
         NamespacedKey setId = null;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/PlayerResearchTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/PlayerResearchTask.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -46,7 +46,7 @@ public class PlayerResearchTask implements Consumer<PlayerProfile> {
      *            The callback to run when the task has completed
      */
     PlayerResearchTask(@Nonnull Research research, boolean isInstant, @Nullable Consumer<Player> callback) {
-        Validate.notNull(research, "The Research must not be null");
+        Preconditions.checkNotNull(research, "The Research must not be null");
 
         this.research = research;
         this.isInstant = isInstant;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/researches/Research.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -68,8 +68,8 @@ public class Research implements Keyed {
      * 
      */
     public Research(@Nonnull NamespacedKey key, int id, @Nonnull String defaultName, int defaultCost) {
-        Validate.notNull(key, "A NamespacedKey must be provided");
-        Validate.notNull(defaultName, "A default name must be specified");
+        Preconditions.checkNotNull(key, "A NamespacedKey must be provided");
+        Preconditions.checkNotNull(defaultName, "A default name must be specified");
 
         this.key = key;
         this.id = id;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Server;
 import org.bukkit.entity.Entity;
@@ -94,8 +94,8 @@ public final class SlimefunRegistry {
     private final Map<Class<? extends ItemHandler>, Set<ItemHandler>> globalItemHandlers = new HashMap<>();
 
     public void load(@Nonnull Slimefun plugin, @Nonnull Config cfg) {
-        Validate.notNull(plugin, "The Plugin cannot be null!");
-        Validate.notNull(cfg, "The Config cannot be null!");
+        Preconditions.checkNotNull(plugin, "The Plugin cannot be null!");
+        Preconditions.checkNotNull(cfg, "The Config cannot be null!");
 
         soulboundKey = new NamespacedKey(plugin, "soulbound");
         itemChargeKey = new NamespacedKey(plugin, "item_charge");
@@ -249,7 +249,7 @@ public final class SlimefunRegistry {
      */
     @Nonnull
     public SlimefunGuideImplementation getSlimefunGuide(@Nonnull SlimefunGuideMode mode) {
-        Validate.notNull(mode, "The Guide mode cannot be null");
+        Preconditions.checkNotNull(mode, "The Guide mode cannot be null");
 
         SlimefunGuideImplementation guide = guides.get(mode);
 
@@ -319,7 +319,7 @@ public final class SlimefunRegistry {
 
     @Nonnull
     public Set<ItemHandler> getGlobalItemHandlers(@Nonnull Class<? extends ItemHandler> identifier) {
-        Validate.notNull(identifier, "The identifier for an ItemHandler cannot be null!");
+        Preconditions.checkNotNull(identifier, "The identifier for an ItemHandler cannot be null!");
 
         return globalItemHandlers.computeIfAbsent(identifier, c -> new HashSet<>());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetComponent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/EnergyNetComponent.java
@@ -4,7 +4,7 @@ import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 
 import io.github.bakedlibs.dough.blocks.BlockPosition;
@@ -92,8 +92,8 @@ public interface EnergyNetComponent extends ItemAttribute {
      * @return The charge stored at that {@link Location}
      */
     default int getCharge(@Nonnull Location l, @Nonnull Config data) {
-        Validate.notNull(l, "Location was null!");
-        Validate.notNull(data, "data was null!");
+        Preconditions.checkNotNull(l, "Location was null!");
+        Preconditions.checkNotNull(data, "data was null!");
 
         // Emergency fallback, this cannot hold a charge, so we'll just return zero
         if (!isChargeable()) {
@@ -120,8 +120,8 @@ public interface EnergyNetComponent extends ItemAttribute {
      *            The new charge
      */
     default void setCharge(@Nonnull Location l, int charge) {
-        Validate.notNull(l, "Location was null!");
-        Validate.isTrue(charge >= 0, "You can only set a charge of zero or more!");
+        Preconditions.checkNotNull(l, "Location was null!");
+        Preconditions.checkArgument(charge >= 0, "You can only set a charge of zero or more!");
 
         try {
             int capacity = getCapacity();
@@ -146,8 +146,8 @@ public interface EnergyNetComponent extends ItemAttribute {
     }
 
     default void addCharge(@Nonnull Location l, int charge) {
-        Validate.notNull(l, "Location was null!");
-        Validate.isTrue(charge > 0, "You can only add a positive charge!");
+        Preconditions.checkNotNull(l, "Location was null!");
+        Preconditions.checkArgument(charge > 0, "You can only add a positive charge!");
 
         try {
             int capacity = getCapacity();
@@ -173,8 +173,8 @@ public interface EnergyNetComponent extends ItemAttribute {
     }
 
     default void removeCharge(@Nonnull Location l, int charge) {
-        Validate.notNull(l, "Location was null!");
-        Validate.isTrue(charge > 0, "The charge to remove must be greater than zero!");
+        Preconditions.checkNotNull(l, "Location was null!");
+        Preconditions.checkArgument(charge > 0, "The charge to remove must be greater than zero!");
 
         try {
             int capacity = getCapacity();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/Rechargeable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/Rechargeable.java
@@ -1,6 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.core.attributes;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -91,7 +91,7 @@ public interface Rechargeable extends ItemAttribute {
      * @return Whether the given charge could be added successfully
      */
     default boolean addItemCharge(ItemStack item, float charge) {
-        Validate.isTrue(charge > 0, "Charge must be above zero!");
+        Preconditions.checkArgument(charge > 0, "Charge must be above zero!");
 
         if (item == null || item.getType() == Material.AIR) {
             throw new IllegalArgumentException("Cannot add Item charge for null or AIR");
@@ -126,7 +126,7 @@ public interface Rechargeable extends ItemAttribute {
      * @return Whether the given charge could be removed successfully
      */
     default boolean removeItemCharge(ItemStack item, float charge) {
-        Validate.isTrue(charge > 0, "Charge must be above zero!");
+        Preconditions.checkArgument(charge > 0, "Charge must be above zero!");
 
         if (item == null || item.getType() == Material.AIR) {
             throw new IllegalArgumentException("Cannot remove Item charge for null or AIR");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunCommand.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -44,7 +44,7 @@ public class SlimefunCommand implements CommandExecutor, Listener {
     }
 
     public void register() {
-        Validate.isTrue(!registered, "Slimefun's subcommands have already been registered!");
+        Preconditions.checkArgument(!registered, "Slimefun's subcommands have already been registered!");
 
         registered = true;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/guide/GuideHistory.java
@@ -6,7 +6,7 @@ import java.util.LinkedList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -37,7 +37,7 @@ public class GuideHistory {
      *            The {@link PlayerProfile} this {@link GuideHistory} was made for
      */
     public GuideHistory(@Nonnull PlayerProfile profile) {
-        Validate.notNull(profile, "Cannot create a GuideHistory without a PlayerProfile!");
+        Preconditions.checkNotNull(profile, "Cannot create a GuideHistory without a PlayerProfile!");
         this.profile = profile;
     }
 
@@ -55,7 +55,7 @@ public class GuideHistory {
      *            The current page of the main menu that should be stored
      */
     public void setMainMenuPage(int page) {
-        Validate.isTrue(page >= 1, "page must be greater than 0!");
+        Preconditions.checkArgument(page >= 1, "page must be greater than 0!");
 
         mainMenuPage = page;
     }
@@ -104,7 +104,7 @@ public class GuideHistory {
      *            The {@link SlimefunItem} that should be added to this {@link GuideHistory}
      */
     public void add(@Nonnull SlimefunItem item) {
-        Validate.notNull(item, "Cannot add a non-existing SlimefunItem to the GuideHistory!");
+        Preconditions.checkNotNull(item, "Cannot add a non-existing SlimefunItem to the GuideHistory!");
         queue.add(new GuideEntry<>(item, 0));
     }
 
@@ -115,13 +115,13 @@ public class GuideHistory {
      *            The term that the {@link Player} searched for
      */
     public void add(@Nonnull String searchTerm) {
-        Validate.notNull(searchTerm, "Cannot add an empty Search Term to the GuideHistory!");
+        Preconditions.checkNotNull(searchTerm, "Cannot add an empty Search Term to the GuideHistory!");
         queue.add(new GuideEntry<>(searchTerm, 0));
     }
 
     private <T> void refresh(@Nonnull T object, int page) {
-        Validate.notNull(object, "Cannot add a null Entry to the GuideHistory!");
-        Validate.isTrue(page >= 0, "page must not be negative!");
+        Preconditions.checkNotNull(object, "Cannot add a null Entry to the GuideHistory!");
+        Preconditions.checkArgument(page >= 0, "page must not be negative!");
 
         GuideEntry<?> lastEntry = getLastEntry(false);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/RainbowTickHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/RainbowTickHandler.java
@@ -39,7 +39,9 @@ public class RainbowTickHandler extends BlockTicker {
     private Material material;
 
     public RainbowTickHandler(@Nonnull List<Material> materials) {
-        Validate.noNullElements(materials, "A RainbowTicker cannot have a Material that is null!");
+        for (Material m : materials) {
+            Preconditions.checkNotNull(m, "A RainbowTicker cannot have a Material that is null!");
+        }
 
         if (materials.isEmpty()) {
             throw new IllegalArgumentException("A RainbowTicker must have at least one Material associated with it!");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/RainbowTickHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/RainbowTickHandler.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineProcessor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/machines/MachineProcessor.java
@@ -6,7 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -46,7 +46,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *            The owner of this {@link MachineProcessor}.
      */
     public MachineProcessor(@Nonnull MachineProcessHolder<T> owner) {
-        Validate.notNull(owner, "The MachineProcessHolder cannot be null.");
+        Preconditions.checkNotNull(owner, "The MachineProcessHolder cannot be null.");
 
         this.owner = owner;
     }
@@ -93,8 +93,8 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} has already been started at that {@link Location}.
      */
     public boolean startOperation(@Nonnull Location loc, @Nonnull T operation) {
-        Validate.notNull(loc, "The location must not be null");
-        Validate.notNull(operation, "The operation cannot be null");
+        Preconditions.checkNotNull(loc, "The location must not be null");
+        Preconditions.checkNotNull(operation, "The operation cannot be null");
 
         return startOperation(new BlockPosition(loc), operation);
     }
@@ -111,8 +111,8 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} has already been started at that {@link Block}.
      */
     public boolean startOperation(@Nonnull Block b, @Nonnull T operation) {
-        Validate.notNull(b, "The Block must not be null");
-        Validate.notNull(operation, "The machine operation cannot be null");
+        Preconditions.checkNotNull(b, "The Block must not be null");
+        Preconditions.checkNotNull(operation, "The machine operation cannot be null");
 
         return startOperation(new BlockPosition(b), operation);
     }
@@ -129,8 +129,8 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} has already been started at that {@link BlockPosition}.
      */
     public boolean startOperation(@Nonnull BlockPosition pos, @Nonnull T operation) {
-        Validate.notNull(pos, "The BlockPosition must not be null");
-        Validate.notNull(operation, "The machine operation cannot be null");
+        Preconditions.checkNotNull(pos, "The BlockPosition must not be null");
+        Preconditions.checkNotNull(operation, "The machine operation cannot be null");
 
         return machines.putIfAbsent(pos, operation) == null;
     }
@@ -144,7 +144,7 @@ public class MachineProcessor<T extends MachineOperation> {
      * @return The current {@link MachineOperation} or null.
      */
     public @Nullable T getOperation(@Nonnull Location loc) {
-        Validate.notNull(loc, "The location cannot be null");
+        Preconditions.checkNotNull(loc, "The location cannot be null");
 
         return getOperation(new BlockPosition(loc));
     }
@@ -158,7 +158,7 @@ public class MachineProcessor<T extends MachineOperation> {
      * @return The current {@link MachineOperation} or null.
      */
     public @Nullable T getOperation(@Nonnull Block b) {
-        Validate.notNull(b, "The Block cannot be null");
+        Preconditions.checkNotNull(b, "The Block cannot be null");
 
         return getOperation(new BlockPosition(b));
     }
@@ -172,7 +172,7 @@ public class MachineProcessor<T extends MachineOperation> {
      * @return The current {@link MachineOperation} or null.
      */
     public @Nullable T getOperation(@Nonnull BlockPosition pos) {
-        Validate.notNull(pos, "The BlockPosition must not be null");
+        Preconditions.checkNotNull(pos, "The BlockPosition must not be null");
 
         return machines.get(pos);
     }
@@ -187,7 +187,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} to begin with.
      */
     public boolean endOperation(@Nonnull Location loc) {
-        Validate.notNull(loc, "The location should not be null");
+        Preconditions.checkNotNull(loc, "The location should not be null");
 
         return endOperation(new BlockPosition(loc));
     }
@@ -202,7 +202,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} to begin with.
      */
     public boolean endOperation(@Nonnull Block b) {
-        Validate.notNull(b, "The Block should not be null");
+        Preconditions.checkNotNull(b, "The Block should not be null");
 
         return endOperation(new BlockPosition(b));
     }
@@ -217,7 +217,7 @@ public class MachineProcessor<T extends MachineOperation> {
      *         {@link MachineOperation} to begin with.
      */
     public boolean endOperation(@Nonnull BlockPosition pos) {
-        Validate.notNull(pos, "The BlockPosition cannot be null");
+        Preconditions.checkNotNull(pos, "The BlockPosition cannot be null");
 
         T operation = machines.remove(pos);
 
@@ -240,8 +240,8 @@ public class MachineProcessor<T extends MachineOperation> {
     }
 
     public void updateProgressBar(@Nonnull BlockMenu inv, int slot, @Nonnull T operation) {
-        Validate.notNull(inv, "The inventory must not be null.");
-        Validate.notNull(operation, "The MachineOperation must not be null.");
+        Preconditions.checkNotNull(inv, "The inventory must not be null.");
+        Preconditions.checkNotNull(operation, "The MachineOperation must not be null.");
 
         if (getProgressBar() == null) {
             // No progress bar, no need to update anything.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlock.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.World;
@@ -55,7 +55,7 @@ public class MultiBlock {
     private final boolean isSymmetric;
 
     public MultiBlock(@Nonnull SlimefunItem item, Material[] build, @Nonnull BlockFace trigger) {
-        Validate.notNull(item, "A MultiBlock requires a SlimefunItem!");
+        Preconditions.checkNotNull(item, "A MultiBlock requires a SlimefunItem!");
 
         if (build == null || build.length != 9) {
             throw new IllegalArgumentException("MultiBlocks must have a length of 9!");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -11,7 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.common.base.Preconditions;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -87,7 +87,7 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
     }
 
     public void addRecipe(ItemStack[] input, ItemStack output) {
-        Validate.notNull(output, "Recipes must have an Output!");
+        Preconditions.checkNotNull(output, "Recipes must have an Output!");
 
         recipes.add(input);
         recipes.add(new ItemStack[] { output });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/NetworkManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/NetworkManager.java
@@ -10,7 +10,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.Server;
 
@@ -62,7 +62,7 @@ public class NetworkManager {
      *            Whether excess items from a {@link CargoNet} should be voided
      */
     public NetworkManager(int maxStepSize, boolean enableVisualizer, boolean deleteExcessItems) {
-        Validate.isTrue(maxStepSize > 0, "The maximal Network size must be above zero!");
+        Preconditions.checkArgument(maxStepSize > 0, "The maximal Network size must be above zero!");
 
         this.enableVisualizer = enableVisualizer;
         this.deleteExcessItems = deleteExcessItems;
@@ -125,7 +125,7 @@ public class NetworkManager {
             return Optional.empty();
         }
 
-        Validate.notNull(type, "Type must not be null");
+        Preconditions.checkNotNull(type, "Type must not be null");
 
         for (Network network : networks) {
             if (type.isInstance(network) && network.connectsTo(l)) {
@@ -143,7 +143,7 @@ public class NetworkManager {
             return new ArrayList<>();
         }
 
-        Validate.notNull(type, "Type must not be null");
+        Preconditions.checkNotNull(type, "Type must not be null");
         List<T> list = new ArrayList<>();
 
         for (Network network : networks) {
@@ -162,7 +162,7 @@ public class NetworkManager {
      *            The {@link Network} to register
      */
     public void registerNetwork(@Nonnull Network network) {
-        Validate.notNull(network, "Cannot register a null Network");
+        Preconditions.checkNotNull(network, "Cannot register a null Network");
         networks.add(network);
     }
 
@@ -173,7 +173,7 @@ public class NetworkManager {
      *            The {@link Network} to remove
      */
     public void unregisterNetwork(@Nonnull Network network) {
-        Validate.notNull(network, "Cannot unregister a null Network");
+        Preconditions.checkNotNull(network, "Cannot unregister a null Network");
         networks.remove(network);
     }
 
@@ -185,7 +185,7 @@ public class NetworkManager {
      *            The {@link Location} to update
      */
     public void updateAllNetworks(@Nonnull Location l) {
-        Validate.notNull(l, "The Location cannot be null");
+        Preconditions.checkNotNull(l, "The Location cannot be null");
 
         try {
             /*

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemStackAndInteger.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ItemStackAndInteger.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.core.networks.cargo;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
@@ -14,7 +14,7 @@ class ItemStackAndInteger {
     private int number;
 
     ItemStackAndInteger(@Nonnull ItemStack item, int amount) {
-        Validate.notNull(item, "Item cannot be null!");
+        Preconditions.checkNotNull(item, "Item cannot be null!");
         this.number = amount;
         this.item = item;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/BackupService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/BackupService.java
@@ -17,7 +17,7 @@ import java.util.zip.ZipOutputStream;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
@@ -79,7 +79,7 @@ public class BackupService implements Runnable {
     }
 
     private void createBackup(@Nonnull ZipOutputStream output) throws IOException {
-        Validate.notNull(output, "The Output Stream cannot be null!");
+        Preconditions.checkNotNull(output, "The Output Stream cannot be null!");
 
         for (File folder : new File("data-storage/Slimefun/stored-blocks/").listFiles()) {
             addDirectory(output, folder, "stored-blocks/" + folder.getName());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/BlockDataService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/BlockDataService.java
@@ -7,7 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
@@ -64,8 +64,8 @@ public class BlockDataService implements Keyed {
      *            The value to store
      */
     public void setBlockData(@Nonnull Block b, @Nonnull String value) {
-        Validate.notNull(b, "The block cannot be null!");
-        Validate.notNull(value, "The value cannot be null!");
+        Preconditions.checkNotNull(b, "The block cannot be null!");
+        Preconditions.checkNotNull(value, "The value cannot be null!");
 
         /**
          * Don't use PaperLib here, it seems to be quite buggy in block-placing scenarios
@@ -98,7 +98,7 @@ public class BlockDataService implements Keyed {
      * @return The stored value
      */
     public Optional<String> getBlockData(@Nonnull Block b) {
-        Validate.notNull(b, "The block cannot be null!");
+        Preconditions.checkNotNull(b, "The block cannot be null!");
 
         BlockState state = PaperLib.getBlockState(b, false).getState();
         PersistentDataContainer container = getPersistentDataContainer(state);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomItemDataService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomItemDataService.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -64,8 +64,8 @@ public class CustomItemDataService implements Keyed {
      *            The id to store on the {@link ItemStack}
      */
     public void setItemData(@Nonnull ItemStack item, @Nonnull String id) {
-        Validate.notNull(item, "The Item cannot be null!");
-        Validate.notNull(id, "Cannot store null on an Item!");
+        Preconditions.checkNotNull(item, "The Item cannot be null!");
+        Preconditions.checkNotNull(id, "Cannot store null on an Item!");
 
         ItemMeta im = item.getItemMeta();
         setItemData(im, id);
@@ -82,8 +82,8 @@ public class CustomItemDataService implements Keyed {
      *            The id to store on the {@link ItemMeta}
      */
     public void setItemData(@Nonnull ItemMeta meta, @Nonnull String id) {
-        Validate.notNull(meta, "The ItemMeta cannot be null!");
-        Validate.notNull(id, "Cannot store null on an ItemMeta!");
+        Preconditions.checkNotNull(meta, "The ItemMeta cannot be null!");
+        Preconditions.checkNotNull(id, "Cannot store null on an ItemMeta!");
 
         PersistentDataContainer container = meta.getPersistentDataContainer();
         container.set(namespacedKey, PersistentDataType.STRING, id);
@@ -117,7 +117,7 @@ public class CustomItemDataService implements Keyed {
      * @return An {@link Optional} describing the result
      */
     public @Nonnull Optional<String> getItemData(@Nonnull ItemMeta meta) {
-        Validate.notNull(meta, "Cannot read data from null!");
+        Preconditions.checkNotNull(meta, "Cannot read data from null!");
 
         PersistentDataContainer container = meta.getPersistentDataContainer();
         return Optional.ofNullable(container.get(namespacedKey, PersistentDataType.STRING));
@@ -136,8 +136,8 @@ public class CustomItemDataService implements Keyed {
      * @return Whether both metas have data on them and its the same.
      */
     public boolean hasEqualItemData(@Nonnull ItemMeta meta1, @Nonnull ItemMeta meta2) {
-        Validate.notNull(meta1, "Cannot read data from null (first arg)");
-        Validate.notNull(meta2, "Cannot read data from null (second arg)");
+        Preconditions.checkNotNull(meta1, "Cannot read data from null (first arg)");
+        Preconditions.checkNotNull(meta2, "Cannot read data from null (second arg)");
 
         Optional<String> data1 = getItemData(meta1);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomTextureService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomTextureService.java
@@ -10,7 +10,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
@@ -71,7 +71,7 @@ public class CustomTextureService {
      *            Whether to save this file
      */
     public void register(@Nonnull Collection<SlimefunItem> items, boolean save) {
-        Validate.notEmpty(items, "items must neither be null or empty.");
+        Preconditions.checkArgument(!items, "items must neither be null or empty.");
 
         loadDefaultValues();
 
@@ -130,7 +130,7 @@ public class CustomTextureService {
      * @return The configured custom model data
      */
     public int getModelData(@Nonnull String id) {
-        Validate.notNull(id, "Cannot get the ModelData for 'null'");
+        Preconditions.checkNotNull(id, "Cannot get the ModelData for 'null'");
 
         return config.getInt(id);
     }
@@ -145,8 +145,8 @@ public class CustomTextureService {
      *            The id for which to get the configured model data
      */
     public void setTexture(@Nonnull ItemStack item, @Nonnull String id) {
-        Validate.notNull(item, "The Item cannot be null!");
-        Validate.notNull(id, "Cannot store null on an Item!");
+        Preconditions.checkNotNull(item, "The Item cannot be null!");
+        Preconditions.checkNotNull(id, "Cannot store null on an Item!");
 
         ItemMeta im = item.getItemMeta();
         setTexture(im, id);
@@ -163,8 +163,8 @@ public class CustomTextureService {
      *            The id for which to get the configured model data
      */
     public void setTexture(@Nonnull ItemMeta im, @Nonnull String id) {
-        Validate.notNull(im, "The ItemMeta cannot be null!");
-        Validate.notNull(id, "Cannot store null on an ItemMeta!");
+        Preconditions.checkNotNull(im, "The ItemMeta cannot be null!");
+        Preconditions.checkNotNull(id, "Cannot store null on an ItemMeta!");
 
         int data = getModelData(id);
         im.setCustomModelData(data == 0 ? null : data);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomTextureService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/CustomTextureService.java
@@ -71,7 +71,7 @@ public class CustomTextureService {
      *            Whether to save this file
      */
     public void register(@Nonnull Collection<SlimefunItem> items, boolean save) {
-        Preconditions.checkArgument(!items, "items must neither be null or empty.");
+        Preconditions.checkArgument(items != null && !items.isEmpty(), "items must neither be null or empty.");
 
         loadDefaultValues();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/LocalizationService.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Server;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -113,7 +113,7 @@ public class LocalizationService extends SlimefunLocalization {
     @Override
     @Nullable
     public Language getLanguage(@Nonnull String id) {
-        Validate.notNull(id, "The language id cannot be null");
+        Preconditions.checkNotNull(id, "The language id cannot be null");
         return languages.get(id);
     }
 
@@ -125,7 +125,7 @@ public class LocalizationService extends SlimefunLocalization {
 
     @Override
     public boolean hasLanguage(@Nonnull String id) {
-        Validate.notNull(id, "The language id cannot be null");
+        Preconditions.checkNotNull(id, "The language id cannot be null");
 
         // Checks if our jar files contains a messages.yml file for that language
         String file = LanguageFile.MESSAGES.getFilePath(id);
@@ -141,7 +141,7 @@ public class LocalizationService extends SlimefunLocalization {
      * @return Whether or not this {@link Language} is loaded
      */
     public boolean isLanguageLoaded(@Nonnull String id) {
-        Validate.notNull(id, "The language cannot be null!");
+        Preconditions.checkNotNull(id, "The language cannot be null!");
         return languages.containsKey(id);
     }
 
@@ -152,7 +152,7 @@ public class LocalizationService extends SlimefunLocalization {
 
     @Override
     public Language getLanguage(@Nonnull Player p) {
-        Validate.notNull(p, "Player cannot be null!");
+        Preconditions.checkNotNull(p, "Player cannot be null!");
 
         PersistentDataContainer container = p.getPersistentDataContainer();
         String language = container.get(languageKey, PersistentDataType.STRING);
@@ -205,8 +205,8 @@ public class LocalizationService extends SlimefunLocalization {
 
     @Override
     protected void addLanguage(@Nonnull String id, @Nonnull String texture) {
-        Validate.notNull(id, "The language id cannot be null!");
-        Validate.notNull(texture, "The language texture cannot be null");
+        Preconditions.checkNotNull(id, "The language id cannot be null!");
+        Preconditions.checkNotNull(texture, "The language texture cannot be null");
 
         if (hasLanguage(id)) {
             Language language = new Language(id, texture);
@@ -232,7 +232,7 @@ public class LocalizationService extends SlimefunLocalization {
      * @return A percentage {@code (0.0 - 100.0)} for the progress of translation of that {@link Language}
      */
     public double calculateProgress(@Nonnull Language lang) {
-        Validate.notNull(lang, "Cannot get the language progress of null");
+        Preconditions.checkNotNull(lang, "Cannot get the language progress of null");
 
         Set<String> defaultKeys = getTotalKeys(languages.get("en"));
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MinecraftRecipeService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/MinecraftRecipeService.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
@@ -86,7 +86,7 @@ public class MinecraftRecipeService {
      *            A callback to run when the {@link RecipeSnapshot} has been created.
      */
     public void subscribe(@Nonnull Consumer<RecipeSnapshot> subscription) {
-        Validate.notNull(subscription, "Callback must not be null!");
+        Preconditions.checkNotNull(subscription, "Callback must not be null!");
         subscriptions.add(subscription);
     }
 
@@ -132,7 +132,7 @@ public class MinecraftRecipeService {
      * @return An Array of {@link RecipeChoice} representing the shape of this {@link Recipe}
      */
     public @Nonnull RecipeChoice[] getRecipeShape(@Nonnull Recipe recipe) {
-        Validate.notNull(recipe, "Recipe must not be null!");
+        Preconditions.checkNotNull(recipe, "Recipe must not be null!");
 
         if (recipe instanceof ShapedRecipe shapedRecipe) {
             List<RecipeChoice> choices = new LinkedList<>();
@@ -185,7 +185,7 @@ public class MinecraftRecipeService {
      * @return The corresponding {@link Recipe} or null
      */
     public @Nullable Recipe getRecipe(@Nonnull NamespacedKey key) {
-        Validate.notNull(key, "The NamespacedKey should not be null");
+        Preconditions.checkNotNull(key, "The NamespacedKey should not be null");
 
         if (snapshot != null) {
             // We operate on a cached HashMap which is much faster than Bukkit's method.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PerWorldSettingsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PerWorldSettingsService.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Server;
 import org.bukkit.World;
 
@@ -61,7 +61,7 @@ public class PerWorldSettingsService {
      *            The {@link World} to load
      */
     public void load(@Nonnull World world) {
-        Validate.notNull(world, "Cannot load a world that is null");
+        Preconditions.checkNotNull(world, "Cannot load a world that is null");
         disabledItems.putIfAbsent(world.getUID(), loadWorldFromConfig(world));
     }
 
@@ -76,8 +76,8 @@ public class PerWorldSettingsService {
      * @return Whether the given {@link SlimefunItem} is enabled in that {@link World}
      */
     public boolean isEnabled(@Nonnull World world, @Nonnull SlimefunItem item) {
-        Validate.notNull(world, "The world cannot be null");
-        Validate.notNull(item, "The SlimefunItem cannot be null");
+        Preconditions.checkNotNull(world, "The world cannot be null");
+        Preconditions.checkNotNull(item, "The SlimefunItem cannot be null");
 
         Set<String> items = disabledItems.computeIfAbsent(world.getUID(), id -> loadWorldFromConfig(world));
 
@@ -99,8 +99,8 @@ public class PerWorldSettingsService {
      *            Whether the given {@link SlimefunItem} should be enabled in that world
      */
     public void setEnabled(@Nonnull World world, @Nonnull SlimefunItem item, boolean enabled) {
-        Validate.notNull(world, "The world cannot be null");
-        Validate.notNull(item, "The SlimefunItem cannot be null");
+        Preconditions.checkNotNull(world, "The world cannot be null");
+        Preconditions.checkNotNull(item, "The SlimefunItem cannot be null");
 
         Set<String> items = disabledItems.computeIfAbsent(world.getUID(), id -> loadWorldFromConfig(world));
 
@@ -120,7 +120,7 @@ public class PerWorldSettingsService {
      *            Whether this {@link World} should be enabled or not
      */
     public void setEnabled(@Nonnull World world, boolean enabled) {
-        Validate.notNull(world, "null is not a valid World");
+        Preconditions.checkNotNull(world, "null is not a valid World");
         load(world);
 
         if (enabled) {
@@ -139,7 +139,7 @@ public class PerWorldSettingsService {
      * @return Whether this {@link World} is enabled
      */
     public boolean isWorldEnabled(@Nonnull World world) {
-        Validate.notNull(world, "null is not a valid World");
+        Preconditions.checkNotNull(world, "null is not a valid World");
         load(world);
 
         return !disabledWorlds.contains(world.getUID());
@@ -156,8 +156,8 @@ public class PerWorldSettingsService {
      * @return Whether this addon is enabled in that {@link World}
      */
     public boolean isAddonEnabled(@Nonnull World world, @Nonnull SlimefunAddon addon) {
-        Validate.notNull(world, "World cannot be null");
-        Validate.notNull(addon, "Addon cannot be null");
+        Preconditions.checkNotNull(world, "World cannot be null");
+        Preconditions.checkNotNull(addon, "Addon cannot be null");
         return isWorldEnabled(world) && disabledAddons.getOrDefault(addon, Collections.emptySet()).contains(world.getName());
     }
 
@@ -170,7 +170,7 @@ public class PerWorldSettingsService {
      *            The {@link World} to save
      */
     public void save(@Nonnull World world) {
-        Validate.notNull(world, "Cannot save a World that does not exist");
+        Preconditions.checkNotNull(world, "Cannot save a World that does not exist");
         Set<String> items = disabledItems.computeIfAbsent(world.getUID(), id -> loadWorldFromConfig(world));
 
         Config config = getConfig(world);
@@ -187,7 +187,7 @@ public class PerWorldSettingsService {
 
     @Nonnull
     private Set<String> loadWorldFromConfig(@Nonnull World world) {
-        Validate.notNull(world, "Cannot load a World that does not exist");
+        Preconditions.checkNotNull(world, "Cannot load a World that does not exist");
 
         String name = world.getName();
         Optional<Set<String>> optional = disabledItems.get(world.getUID());
@@ -249,7 +249,7 @@ public class PerWorldSettingsService {
      */
     @Nonnull
     private Config getConfig(@Nonnull World world) {
-        Validate.notNull(world, "World cannot be null");
+        Preconditions.checkNotNull(world, "World cannot be null");
         return new Config(plugin, "world-settings/" + world.getName() + ".yml");
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PermissionsService.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permissible;
 import org.bukkit.permissions.Permission;
@@ -107,7 +107,7 @@ public class PermissionsService {
      */
     @Nonnull
     public Optional<String> getPermission(@Nonnull SlimefunItem item) {
-        Validate.notNull(item, "Cannot get permissions for null");
+        Preconditions.checkNotNull(item, "Cannot get permissions for null");
         String permission = permissions.get(item.getId());
 
         if (permission == null || permission.equals("none")) {
@@ -126,7 +126,7 @@ public class PermissionsService {
      *            The {@link Permission} to set
      */
     public void setPermission(@Nonnull SlimefunItem item, @Nullable String permission) {
-        Validate.notNull(item, "You cannot set the permission for null");
+        Preconditions.checkNotNull(item, "You cannot set the permission for null");
         permissions.put(item.getId(), permission != null ? permission : "none");
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/Contributor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/Contributor.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 
 import io.github.bakedlibs.dough.data.TriStateOptional;
@@ -48,8 +48,8 @@ public class Contributor {
      *            A link to their GitHub profile
      */
     public Contributor(@Nonnull String minecraftName, @Nonnull String profile) {
-        Validate.notNull(minecraftName, "Username must never be null!");
-        Validate.notNull(profile, "The profile cannot be null!");
+        Preconditions.checkNotNull(minecraftName, "Username must never be null!");
+        Preconditions.checkNotNull(profile, "The profile cannot be null!");
 
         githubUsername = profile.substring(profile.lastIndexOf('/') + 1);
         minecraftUsername = minecraftName;
@@ -63,7 +63,7 @@ public class Contributor {
      *            The username of this {@link Contributor}
      */
     public Contributor(@Nonnull String username) {
-        Validate.notNull(username, "Username must never be null!");
+        Preconditions.checkNotNull(username, "Username must never be null!");
 
         githubUsername = username;
         minecraftUsername = username;
@@ -80,8 +80,8 @@ public class Contributor {
      *            The amount of contributions made as that role
      */
     public void setContributions(@Nonnull String role, int commits) {
-        Validate.notNull(role, "The role cannot be null!");
-        Validate.isTrue(commits >= 0, "Contributions cannot be negative");
+        Preconditions.checkNotNull(role, "The role cannot be null!");
+        Preconditions.checkArgument(commits >= 0, "Contributions cannot be negative");
 
         contributions.put(role, commits);
     }
@@ -141,7 +141,7 @@ public class Contributor {
      * @return The amount of contributions this {@link Contributor} submitted as the given role
      */
     public int getContributions(@Nonnull String role) {
-        Validate.notNull(role, "The role cannot be null!");
+        Preconditions.checkNotNull(role, "The role cannot be null!");
 
         return contributions.getOrDefault(role, 0);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubService.java
@@ -14,7 +14,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import io.github.bakedlibs.dough.config.Config;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
@@ -105,10 +105,10 @@ public class GitHubService {
     }
 
     public @Nonnull Contributor addContributor(@Nonnull String minecraftName, @Nonnull String profileURL, @Nonnull String role, int commits) {
-        Validate.notNull(minecraftName, "Minecraft username must not be null.");
-        Validate.notNull(profileURL, "GitHub profile url must not be null.");
-        Validate.notNull(role, "Role should not be null.");
-        Validate.isTrue(commits >= 0, "Commit count cannot be negative.");
+        Preconditions.checkNotNull(minecraftName, "Minecraft username must not be null.");
+        Preconditions.checkNotNull(profileURL, "GitHub profile url must not be null.");
+        Preconditions.checkNotNull(role, "Role should not be null.");
+        Preconditions.checkArgument(commits >= 0, "Commit count cannot be negative.");
 
         String username = profileURL.substring(profileURL.lastIndexOf('/') + 1);
 
@@ -119,9 +119,9 @@ public class GitHubService {
     }
 
     public @Nonnull Contributor addContributor(@Nonnull String username, @Nonnull String role, int commits) {
-        Validate.notNull(username, "Username must not be null.");
-        Validate.notNull(role, "Role should not be null.");
-        Validate.isTrue(commits >= 0, "Commit count cannot be negative.");
+        Preconditions.checkNotNull(username, "Username must not be null.");
+        Preconditions.checkNotNull(role, "Role should not be null.");
+        Preconditions.checkArgument(commits >= 0, "Commit count cannot be negative.");
 
         Contributor contributor = contributors.computeIfAbsent(username, key -> new Contributor(username));
         contributor.setContributions(role, commits);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/holograms/HologramsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/holograms/HologramsService.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -128,7 +128,7 @@ public class HologramsService {
      */
     @Nullable
     private Hologram getHologram(@Nonnull Location loc, boolean createIfNoneExists) {
-        Validate.notNull(loc, "Location cannot be null");
+        Preconditions.checkNotNull(loc, "Location cannot be null");
 
         BlockPosition position = new BlockPosition(loc);
         Hologram hologram = cache.get(position);
@@ -249,8 +249,8 @@ public class HologramsService {
      *            The callback to run
      */
     private void updateHologram(@Nonnull Location loc, @Nonnull Consumer<Hologram> consumer) {
-        Validate.notNull(loc, "Location must not be null");
-        Validate.notNull(consumer, "Callbacks must not be null");
+        Preconditions.checkNotNull(loc, "Location must not be null");
+        Preconditions.checkNotNull(consumer, "Callbacks must not be null");
 
         Runnable runnable = () -> {
             try {
@@ -284,7 +284,7 @@ public class HologramsService {
      *         exist or was already removed
      */
     public boolean removeHologram(@Nonnull Location loc) {
-        Validate.notNull(loc, "Location cannot be null");
+        Preconditions.checkNotNull(loc, "Location cannot be null");
 
         if (Bukkit.isPrimaryThread()) {
             try {
@@ -316,7 +316,7 @@ public class HologramsService {
      *            The label to set, can be null
      */
     public void setHologramLabel(@Nonnull Location loc, @Nullable String label) {
-        Validate.notNull(loc, "Location must not be null");
+        Preconditions.checkNotNull(loc, "Location must not be null");
 
         updateHologram(loc, hologram -> hologram.setLabel(label));
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/Language.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/Language.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -45,8 +45,8 @@ public final class Language {
      *            The hash of the skull texture to use
      */
     public Language(@Nonnull String id, @Nonnull String hash) {
-        Validate.notNull(id, "A Language must have an id that is not null!");
-        Validate.notNull(hash, "A Language must have a texture that is not null!");
+        Preconditions.checkNotNull(id, "A Language must have an id that is not null!");
+        Preconditions.checkNotNull(hash, "A Language must have a texture that is not null!");
 
         this.id = id;
         this.item = SlimefunUtils.getCustomHead(hash);
@@ -88,8 +88,8 @@ public final class Language {
     }
 
     public void setFile(@Nonnull LanguageFile file, @Nonnull FileConfiguration config) {
-        Validate.notNull(file, "The provided file should not be null.");
-        Validate.notNull(config, "The provided config should not be null.");
+        Preconditions.checkNotNull(file, "The provided file should not be null.");
+        Preconditions.checkNotNull(config, "The provided config should not be null.");
 
         files.put(file, config);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/LanguageFile.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/LanguageFile.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.core.services.localization;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 /**
  * This enum holds the different types of files each {@link Language} holds.
@@ -36,7 +36,7 @@ public enum LanguageFile {
 
     @Nonnull
     public String getFilePath(@Nonnull String languageId) {
-        Validate.notNull(languageId, "Language id must not be null!");
+        Preconditions.checkNotNull(languageId, "Language id must not be null!");
         return "/languages/" + languageId + '/' + fileName;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/localization/SlimefunLocalization.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
@@ -167,8 +167,8 @@ public abstract class SlimefunLocalization implements Keyed {
 
     @ParametersAreNonnullByDefault
     private @Nullable String getStringOrNull(@Nullable Language language, LanguageFile file, String path) {
-        Validate.notNull(file, "You need to provide a LanguageFile!");
-        Validate.notNull(path, "The path cannot be null!");
+        Preconditions.checkNotNull(file, "You need to provide a LanguageFile!");
+        Preconditions.checkNotNull(path, "The path cannot be null!");
 
         if (language == null) {
             // Unit-Test scenario (or something went horribly wrong)
@@ -202,8 +202,8 @@ public abstract class SlimefunLocalization implements Keyed {
 
     @ParametersAreNonnullByDefault
     private @Nullable List<String> getStringListOrNull(@Nullable Language language, LanguageFile file, String path) {
-        Validate.notNull(file, "You need to provide a LanguageFile!");
-        Validate.notNull(path, "The path cannot be null!");
+        Preconditions.checkNotNull(file, "You need to provide a LanguageFile!");
+        Preconditions.checkNotNull(path, "The path cannot be null!");
 
         if (language == null) {
             // Unit-Test scenario (or something went horribly wrong)
@@ -236,7 +236,7 @@ public abstract class SlimefunLocalization implements Keyed {
     }
 
     public @Nonnull String getMessage(@Nonnull String key) {
-        Validate.notNull(key, "Message key must not be null!");
+        Preconditions.checkNotNull(key, "Message key must not be null!");
 
         Language language = getDefaultLanguage();
 
@@ -250,8 +250,8 @@ public abstract class SlimefunLocalization implements Keyed {
     }
 
     public @Nonnull String getMessage(@Nonnull Player p, @Nonnull String key) {
-        Validate.notNull(p, "Player must not be null!");
-        Validate.notNull(key, "Message key must not be null!");
+        Preconditions.checkNotNull(p, "Player must not be null!");
+        Preconditions.checkNotNull(key, "Message key must not be null!");
 
         return getString(getLanguage(p), LanguageFile.MESSAGES, key);
     }
@@ -268,17 +268,17 @@ public abstract class SlimefunLocalization implements Keyed {
     }
 
     public @Nonnull List<String> getMessages(@Nonnull Player p, @Nonnull String key) {
-        Validate.notNull(p, "Player should not be null.");
-        Validate.notNull(key, "Message key cannot be null.");
+        Preconditions.checkNotNull(p, "Player should not be null.");
+        Preconditions.checkNotNull(key, "Message key cannot be null.");
 
         return getStringList(getLanguage(p), LanguageFile.MESSAGES, key);
     }
 
     @ParametersAreNonnullByDefault
     public @Nonnull List<String> getMessages(Player p, String key, UnaryOperator<String> function) {
-        Validate.notNull(p, "Player cannot be null.");
-        Validate.notNull(key, "Message key cannot be null.");
-        Validate.notNull(function, "Function cannot be null.");
+        Preconditions.checkNotNull(p, "Player cannot be null.");
+        Preconditions.checkNotNull(key, "Message key cannot be null.");
+        Preconditions.checkNotNull(function, "Function cannot be null.");
 
         List<String> messages = getMessages(p, key);
         messages.replaceAll(function);
@@ -287,29 +287,29 @@ public abstract class SlimefunLocalization implements Keyed {
     }
 
     public @Nullable String getResearchName(@Nonnull Player p, @Nonnull NamespacedKey key) {
-        Validate.notNull(p, "Player must not be null.");
-        Validate.notNull(key, "NamespacedKey cannot be null.");
+        Preconditions.checkNotNull(p, "Player must not be null.");
+        Preconditions.checkNotNull(key, "NamespacedKey cannot be null.");
 
         return getStringOrNull(getLanguage(p), LanguageFile.RESEARCHES, key.getNamespace() + '.' + key.getKey());
     }
 
     public @Nullable String getItemGroupName(@Nonnull Player p, @Nonnull NamespacedKey key) {
-        Validate.notNull(p, "Player must not be null.");
-        Validate.notNull(key, "NamespacedKey cannot be null!");
+        Preconditions.checkNotNull(p, "Player must not be null.");
+        Preconditions.checkNotNull(key, "NamespacedKey cannot be null!");
 
         return getStringOrNull(getLanguage(p), LanguageFile.CATEGORIES, key.getNamespace() + '.' + key.getKey());
     }
 
     public @Nullable String getResourceString(@Nonnull Player p, @Nonnull String key) {
-        Validate.notNull(p, "Player should not be null!");
-        Validate.notNull(key, "Message key should not be null!");
+        Preconditions.checkNotNull(p, "Player should not be null!");
+        Preconditions.checkNotNull(key, "Message key should not be null!");
 
         return getStringOrNull(getLanguage(p), LanguageFile.RESOURCES, key);
     }
 
     public @Nonnull ItemStack getRecipeTypeItem(@Nonnull Player p, @Nonnull RecipeType recipeType) {
-        Validate.notNull(p, "Player cannot be null!");
-        Validate.notNull(recipeType, "Recipe type cannot be null!");
+        Preconditions.checkNotNull(p, "Player cannot be null!");
+        Preconditions.checkNotNull(recipeType, "Recipe type cannot be null!");
 
         ItemStack item = recipeType.toItem();
 
@@ -343,8 +343,8 @@ public abstract class SlimefunLocalization implements Keyed {
     }
 
     public void sendMessage(@Nonnull CommandSender recipient, @Nonnull String key, boolean addPrefix) {
-        Validate.notNull(recipient, "Recipient cannot be null!");
-        Validate.notNull(key, "Message key cannot be null!");
+        Preconditions.checkNotNull(recipient, "Recipient cannot be null!");
+        Preconditions.checkNotNull(key, "Message key cannot be null!");
 
         String prefix = addPrefix ? getChatPrefix() : "";
 
@@ -356,8 +356,8 @@ public abstract class SlimefunLocalization implements Keyed {
     }
 
     public void sendActionbarMessage(@Nonnull Player player, @Nonnull String key, boolean addPrefix) {
-        Validate.notNull(player, "Player cannot be null!");
-        Validate.notNull(key, "Message key cannot be null!");
+        Preconditions.checkNotNull(player, "Player cannot be null!");
+        Preconditions.checkNotNull(key, "Message key cannot be null!");
 
         String prefix = addPrefix ? getChatPrefix() : "";
         String message = ChatColors.color(prefix + getMessage(player, key));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
@@ -5,7 +5,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 
 /**
@@ -35,7 +35,7 @@ public enum PerformanceRating implements Predicate<Float> {
     private final float threshold;
 
     PerformanceRating(@Nonnull ChatColor color, float threshold) {
-        Validate.notNull(color, "Color cannot be null");
+        Preconditions.checkNotNull(color, "Color cannot be null");
         this.color = color;
         this.threshold = threshold;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
@@ -15,7 +15,7 @@ import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Server;
@@ -154,8 +154,8 @@ public class SlimefunProfiler {
      * @return The total timings of this entry
      */
     public long closeEntry(@Nonnull Location l, @Nonnull SlimefunItem item, long timestamp) {
-        Validate.notNull(l, "Location must not be null!");
-        Validate.notNull(item, "You need to specify a SlimefunItem!");
+        Preconditions.checkNotNull(l, "Location must not be null!");
+        Preconditions.checkNotNull(item, "You need to specify a SlimefunItem!");
 
         if (timestamp == 0) {
             return 0;
@@ -255,7 +255,7 @@ public class SlimefunProfiler {
      *            The {@link PerformanceInspector} who shall receive this summary.
      */
     public void requestSummary(@Nonnull PerformanceInspector inspector) {
-        Validate.notNull(inspector, "Cannot request a summary for null");
+        Preconditions.checkNotNull(inspector, "Cannot request a summary for null");
 
         requests.add(inspector);
     }
@@ -299,7 +299,7 @@ public class SlimefunProfiler {
     }
 
     protected int getBlocksInChunk(@Nonnull String chunk) {
-        Validate.notNull(chunk, "The chunk cannot be null!");
+        Preconditions.checkNotNull(chunk, "The chunk cannot be null!");
         int blocks = 0;
 
         for (ProfiledBlock block : timings.keySet()) {
@@ -316,7 +316,7 @@ public class SlimefunProfiler {
     }
 
     protected int getBlocksOfId(@Nonnull String id) {
-        Validate.notNull(id, "The id cannot be null!");
+        Preconditions.checkNotNull(id, "The id cannot be null!");
         int blocks = 0;
 
         for (ProfiledBlock block : timings.keySet()) {
@@ -329,7 +329,7 @@ public class SlimefunProfiler {
     }
 
     protected int getBlocksFromPlugin(@Nonnull String pluginName) {
-        Validate.notNull(pluginName, "The Plugin name cannot be null!");
+        Preconditions.checkNotNull(pluginName, "The Plugin name cannot be null!");
         int blocks = 0;
 
         for (ProfiledBlock block : timings.keySet()) {
@@ -385,27 +385,27 @@ public class SlimefunProfiler {
      * @return Whether timings of this {@link Block} have been collected
      */
     public boolean hasTimings(@Nonnull Block b) {
-        Validate.notNull(b, "Cannot get timings for a null Block");
+        Preconditions.checkNotNull(b, "Cannot get timings for a null Block");
 
         return timings.containsKey(new ProfiledBlock(b));
     }
 
     public String getTime(@Nonnull Block b) {
-        Validate.notNull(b, "Cannot get timings for a null Block");
+        Preconditions.checkNotNull(b, "Cannot get timings for a null Block");
 
         long time = timings.getOrDefault(new ProfiledBlock(b), 0L);
         return NumberUtils.getAsMillis(time);
     }
 
     public String getTime(@Nonnull Chunk chunk) {
-        Validate.notNull(chunk, "Cannot get timings for a null Chunk");
+        Preconditions.checkNotNull(chunk, "Cannot get timings for a null Chunk");
 
         long time = getByChunk().getOrDefault(chunk.getWorld().getName() + " (" + chunk.getX() + ',' + chunk.getZ() + ')', 0L);
         return NumberUtils.getAsMillis(time);
     }
 
     public String getTime(@Nonnull SlimefunItem item) {
-        Validate.notNull(item, "Cannot get timings for a null SlimefunItem");
+        Preconditions.checkNotNull(item, "Cannot get timings for a null SlimefunItem");
 
         long time = getByItem().getOrDefault(item.getId(), 0L);
         return NumberUtils.getAsMillis(time);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/ConsolePerformanceInspector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/ConsolePerformanceInspector.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import io.github.thebusybiscuit.slimefun4.core.services.profiler.SummaryOrderType;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 
@@ -47,8 +47,8 @@ public class ConsolePerformanceInspector implements PerformanceInspector {
      */
     @ParametersAreNonnullByDefault
     public ConsolePerformanceInspector(CommandSender console, boolean verbose, SummaryOrderType orderType) {
-        Validate.notNull(console, "CommandSender cannot be null");
-        Validate.notNull(orderType, "SummaryOrderType cannot be null");
+        Preconditions.checkNotNull(console, "CommandSender cannot be null");
+        Preconditions.checkNotNull(orderType, "SummaryOrderType cannot be null");
 
         this.console = console;
         this.verbose = verbose;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/PlayerPerformanceInspector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/inspectors/PlayerPerformanceInspector.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.github.thebusybiscuit.slimefun4.core.services.profiler.SummaryOrderType;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -42,8 +42,8 @@ public class PlayerPerformanceInspector implements PerformanceInspector {
      *            The {@link SummaryOrderType} of the timings
      */
     public PlayerPerformanceInspector(@Nonnull Player player, @Nonnull SummaryOrderType orderType) {
-        Validate.notNull(player, "Player cannot be null");
-        Validate.notNull(orderType, "SummaryOrderType cannot be null");
+        Preconditions.checkNotNull(player, "Player cannot be null");
+        Preconditions.checkNotNull(orderType, "SummaryOrderType cannot be null");
 
         this.uuid = player.getUniqueId();
         this.orderType = orderType;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 import io.github.thebusybiscuit.slimefun4.storage.Storage;
 import io.github.thebusybiscuit.slimefun4.storage.backend.legacy.LegacyStorage;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.World;
@@ -1038,8 +1038,8 @@ public class Slimefun extends JavaPlugin implements SlimefunAddon {
      * @return The resulting {@link BukkitTask} or null if Slimefun was disabled
      */
     public static @Nullable BukkitTask runSync(@Nonnull Runnable runnable, long delay) {
-        Validate.notNull(runnable, "Cannot run null");
-        Validate.isTrue(delay >= 0, "The delay cannot be negative");
+        Preconditions.checkNotNull(runnable, "Cannot run null");
+        Preconditions.checkArgument(delay >= 0, "The delay cannot be negative");
 
         // Run the task instantly within a Unit Test
         if (getMinecraftVersion() == MinecraftVersion.UNIT_TEST) {
@@ -1067,7 +1067,7 @@ public class Slimefun extends JavaPlugin implements SlimefunAddon {
      * @return The resulting {@link BukkitTask} or null if Slimefun was disabled
      */
     public static @Nullable BukkitTask runSync(@Nonnull Runnable runnable) {
-        Validate.notNull(runnable, "Cannot run null");
+        Preconditions.checkNotNull(runnable, "Cannot run null");
 
         // Run the task instantly within a Unit Test
         if (getMinecraftVersion() == MinecraftVersion.UNIT_TEST) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/SurvivalSlimefunGuide.java
@@ -11,7 +11,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -582,9 +582,9 @@ public class SurvivalSlimefunGuide implements SlimefunGuideImplementation {
 
     @ParametersAreNonnullByDefault
     public void createHeader(Player p, PlayerProfile profile, ChestMenu menu) {
-        Validate.notNull(p, "The Player cannot be null!");
-        Validate.notNull(profile, "The Profile cannot be null!");
-        Validate.notNull(menu, "The Inventory cannot be null!");
+        Preconditions.checkNotNull(p, "The Player cannot be null!");
+        Preconditions.checkNotNull(profile, "The Profile cannot be null!");
+        Preconditions.checkNotNull(menu, "The Inventory cannot be null!");
 
         for (int i = 0; i < 9; i++) {
             menu.addItem(i, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/VanillaInventoryDropHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/handlers/VanillaInventoryDropHandler.java
@@ -5,7 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
@@ -49,7 +49,7 @@ public class VanillaInventoryDropHandler<T extends BlockState & InventoryHolder>
      */
     public VanillaInventoryDropHandler(@Nonnull Class<T> blockStateClass) {
         super(false, true);
-        Validate.notNull(blockStateClass, "The provided class must not be null!");
+        Preconditions.checkNotNull(blockStateClass, "The provided class must not be null!");
 
         this.blockStateClass = blockStateClass;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/LimitedUseItem.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -70,7 +70,7 @@ public abstract class LimitedUseItem extends SimpleSlimefunItem<ItemUseHandler> 
      * @return The {@link LimitedUseItem} for chaining of setters
      */
     public final @Nonnull LimitedUseItem setMaxUseCount(int count) {
-        Validate.isTrue(count > 0, "The maximum use count must be greater than zero!");
+        Preconditions.checkArgument(count > 0, "The maximum use count must be greater than zero!");
 
         maxUseCount = count;
         return this;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Instruction.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -282,7 +282,7 @@ public enum Instruction {
 
     @ParametersAreNonnullByDefault
     public void execute(ProgrammableAndroid android, Block b, BlockMenu inventory, BlockFace face) {
-        Validate.notNull(method, "Instruction '" + name() + "' must be executed manually!");
+        Preconditions.checkNotNull(method, "Instruction '" + name() + "' must be executed manually!");
         method.perform(android, b, inventory, face);
     }
 
@@ -299,7 +299,7 @@ public enum Instruction {
      */
     @Nullable
     public static Instruction getInstruction(@Nonnull String value) {
-        Validate.notNull(value, "An Instruction cannot be null!");
+        Preconditions.checkNotNull(value, "An Instruction cannot be null!");
         return nameLookup.get(value);
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -10,7 +10,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -577,17 +577,17 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
     @Nonnull
     public String getScript(@Nonnull Location l) {
-        Validate.notNull(l, "Location for android not specified");
+        Preconditions.checkNotNull(l, "Location for android not specified");
         String script = BlockStorage.getLocationInfo(l, "script");
         return script != null ? script : DEFAULT_SCRIPT;
     }
 
     public void setScript(@Nonnull Location l, @Nonnull String script) {
-        Validate.notNull(l, "Location for android not specified");
-        Validate.notNull(script, "No script given");
-        Validate.isTrue(script.startsWith(Instruction.START.name() + '-'), "A script must begin with a 'START' token.");
-        Validate.isTrue(script.endsWith('-' + Instruction.REPEAT.name()), "A script must end with a 'REPEAT' token.");
-        Validate.isTrue(CommonPatterns.DASH.split(script).length <= MAX_SCRIPT_LENGTH, "Scripts may not have more than " + MAX_SCRIPT_LENGTH + " segments");
+        Preconditions.checkNotNull(l, "Location for android not specified");
+        Preconditions.checkNotNull(script, "No script given");
+        Preconditions.checkArgument(script.startsWith(Instruction.START.name() + '-'), "A script must begin with a 'START' token.");
+        Preconditions.checkArgument(script.endsWith('-' + Instruction.REPEAT.name()), "A script must end with a 'REPEAT' token.");
+        Preconditions.checkArgument(CommonPatterns.DASH.split(script).length <= MAX_SCRIPT_LENGTH, "Scripts may not have more than " + MAX_SCRIPT_LENGTH + " segments");
 
         BlockStorage.addBlockInfo(l, "script", script);
     }
@@ -629,7 +629,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
     }
 
     public void registerFuelType(@Nonnull MachineFuel fuel) {
-        Validate.notNull(fuel, "Cannot register null as a Fuel type");
+        Preconditions.checkNotNull(fuel, "Cannot register null as a Fuel type");
 
         fuelTypes.add(fuel);
     }
@@ -852,7 +852,7 @@ public class ProgrammableAndroid extends SlimefunItem implements InventoryBlock,
 
     @ParametersAreNonnullByDefault
     public void addItems(Block b, ItemStack... items) {
-        Validate.notNull(b, "The Block cannot be null.");
+        Preconditions.checkNotNull(b, "The Block cannot be null.");
 
         BlockMenu inv = BlockStorage.getInventory(b);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Script.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Script.java
@@ -12,7 +12,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -45,18 +45,18 @@ public final class Script {
      *            The {@link Config}
      */
     private Script(@Nonnull Config config) {
-        Validate.notNull(config);
+        Preconditions.checkNotNull(config);
 
         this.config = config;
         this.name = config.getString("name");
         this.code = config.getString("code");
         String uuid = config.getString("author");
 
-        Validate.notNull(name);
-        Validate.notNull(code);
-        Validate.notNull(uuid);
-        Validate.notNull(config.getStringList("rating.positive"));
-        Validate.notNull(config.getStringList("rating.negative"));
+        Preconditions.checkNotNull(name);
+        Preconditions.checkNotNull(code);
+        Preconditions.checkNotNull(uuid);
+        Preconditions.checkNotNull(config.getStringList("rating.positive"));
+        Preconditions.checkNotNull(config.getStringList("rating.negative"));
 
         OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(uuid));
         this.author = player.getName() != null ? player.getName() : config.getString("author_name");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/RainbowArmorPiece.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/RainbowArmorPiece.java
@@ -39,7 +39,7 @@ public class RainbowArmorPiece extends SlimefunArmorPiece {
         super(itemGroup, item, recipeType, recipe, new PotionEffect[0]);
 
         // TODO Change this validation over to our custom validation blocked by https://github.com/baked-libs/dough/pull/184
-        Preconditions.checkArgument(!dyeColors, "RainbowArmorPiece colors cannot be empty!");
+        Preconditions.checkArgument(dyeColors != null && dyeColors.length > 0, "RainbowArmorPiece colors cannot be empty!");
 
         if (!SlimefunTag.LEATHER_ARMOR.isTagged(item.getType())) {
             throw new IllegalArgumentException("Rainbow armor needs to be a leather armor piece!");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/RainbowArmorPiece.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/armor/RainbowArmorPiece.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.inventory.ItemStack;
@@ -39,7 +39,7 @@ public class RainbowArmorPiece extends SlimefunArmorPiece {
         super(itemGroup, item, recipeType, recipe, new PotionEffect[0]);
 
         // TODO Change this validation over to our custom validation blocked by https://github.com/baked-libs/dough/pull/184
-        Validate.notEmpty(dyeColors, "RainbowArmorPiece colors cannot be empty!");
+        Preconditions.checkArgument(!dyeColors, "RainbowArmorPiece colors cannot be empty!");
 
         if (!SlimefunTag.LEATHER_ARMOR.isTagged(item.getType())) {
             throw new IllegalArgumentException("Rainbow armor needs to be a leather armor piece!");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractAutoCrafter.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -125,8 +125,8 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      */
     @ParametersAreNonnullByDefault
     public void onRightClick(Block b, Player p) {
-        Validate.notNull(b, "The Block must not be null!");
-        Validate.notNull(p, "The Player cannot be null!");
+        Preconditions.checkNotNull(b, "The Block must not be null!");
+        Preconditions.checkNotNull(p, "The Player cannot be null!");
 
         // Check if we have a valid chest below
         if (!isValidInventory(b.getRelative(BlockFace.DOWN))) {
@@ -238,7 +238,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      *            The {@link AbstractRecipe} to select
      */
     protected void setSelectedRecipe(@Nonnull Block b, @Nullable AbstractRecipe recipe) {
-        Validate.notNull(b, "The Block cannot be null!");
+        Preconditions.checkNotNull(b, "The Block cannot be null!");
 
         BlockStateSnapshotResult result = PaperLib.getBlockState(b, false);
         BlockState state = result.getState();
@@ -274,9 +274,9 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      */
     @ParametersAreNonnullByDefault
     protected void showRecipe(Player p, Block b, AbstractRecipe recipe) {
-        Validate.notNull(p, "The Player should not be null");
-        Validate.notNull(b, "The Block should not be null");
-        Validate.notNull(recipe, "The Recipe should not be null");
+        Preconditions.checkNotNull(p, "The Player should not be null");
+        Preconditions.checkNotNull(b, "The Block should not be null");
+        Preconditions.checkNotNull(recipe, "The Recipe should not be null");
 
         ChestMenu menu = new ChestMenu(getItemName());
         menu.setPlayerInventoryClickable(false);
@@ -399,8 +399,8 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      * @return Whether this crafting operation was successful or not
      */
     public boolean craft(@Nonnull Inventory inv, @Nonnull AbstractRecipe recipe) {
-        Validate.notNull(inv, "The Inventory must not be null");
-        Validate.notNull(recipe, "The Recipe shall not be null");
+        Preconditions.checkNotNull(inv, "The Inventory must not be null");
+        Preconditions.checkNotNull(recipe, "The Recipe shall not be null");
 
         // Make sure that the Recipe is actually enabled
         if (!recipe.isEnabled()) {
@@ -513,7 +513,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      */
     @Nonnull
     public final AbstractAutoCrafter setCapacity(int capacity) {
-        Validate.isTrue(capacity > 0, "The capacity must be greater than zero!");
+        Preconditions.checkArgument(capacity > 0, "The capacity must be greater than zero!");
 
         if (getState() == ItemState.UNREGISTERED) {
             this.energyCapacity = capacity;
@@ -533,9 +533,9 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
      */
     @Nonnull
     public final AbstractAutoCrafter setEnergyConsumption(int energyConsumption) {
-        Validate.isTrue(energyConsumption > 0, "The energy consumption must be greater than zero!");
-        Validate.isTrue(energyCapacity > 0, "You must specify the capacity before you can set the consumption amount.");
-        Validate.isTrue(energyConsumption <= energyCapacity, "The energy consumption cannot be higher than the capacity (" + energyCapacity + ')');
+        Preconditions.checkArgument(energyConsumption > 0, "The energy consumption must be greater than zero!");
+        Preconditions.checkArgument(energyCapacity > 0, "You must specify the capacity before you can set the consumption amount.");
+        Preconditions.checkArgument(energyConsumption <= energyCapacity, "The energy consumption cannot be higher than the capacity (" + energyCapacity + ')');
 
         this.energyConsumed = energyConsumption;
         return this;
@@ -543,7 +543,7 @@ public abstract class AbstractAutoCrafter extends SlimefunItem implements Energy
 
     @Override
     public void register(@Nonnull SlimefunAddon addon) {
-        Validate.notNull(addon, "A SlimefunAddon cannot be null!");
+        Preconditions.checkNotNull(addon, "A SlimefunAddon cannot be null!");
         this.addon = addon;
 
         if (getCapacity() <= 0) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractRecipe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractRecipe.java
@@ -7,7 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.RecipeChoice.MaterialChoice;
@@ -60,8 +60,8 @@ public abstract class AbstractRecipe {
      */
     @ParametersAreNonnullByDefault
     protected AbstractRecipe(Collection<Predicate<ItemStack>> ingredients, ItemStack result) {
-        Validate.notEmpty(ingredients, "The input predicates cannot be null or an empty array");
-        Validate.notNull(result, "The recipe result must not be null!");
+        Preconditions.checkArgument(!ingredients, "The input predicates cannot be null or an empty array");
+        Preconditions.checkNotNull(result, "The recipe result must not be null!");
 
         this.ingredients = ingredients;
         this.result = result;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractRecipe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/AbstractRecipe.java
@@ -60,7 +60,7 @@ public abstract class AbstractRecipe {
      */
     @ParametersAreNonnullByDefault
     protected AbstractRecipe(Collection<Predicate<ItemStack>> ingredients, ItemStack result) {
-        Preconditions.checkArgument(!ingredients, "The input predicates cannot be null or an empty array");
+        Preconditions.checkArgument(ingredients != null && !ingredients.isEmpty(), "The input predicates cannot be null or an empty array");
         Preconditions.checkNotNull(result, "The recipe result must not be null!");
 
         this.ingredients = ingredients;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunAutoCrafter.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -56,7 +56,7 @@ public class SlimefunAutoCrafter extends AbstractAutoCrafter {
     @Override
     @Nullable
     public AbstractRecipe getSelectedRecipe(@Nonnull Block b) {
-        Validate.notNull(b, "The Block cannot be null!");
+        Preconditions.checkNotNull(b, "The Block cannot be null!");
 
         BlockState state = PaperLib.getBlockState(b, false).getState();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunItemRecipe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/SlimefunItemRecipe.java
@@ -7,7 +7,7 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
@@ -54,8 +54,8 @@ class SlimefunItemRecipe extends AbstractRecipe {
 
     @Override
     public void show(@Nonnull ChestMenu menu, @Nonnull AsyncRecipeChoiceTask task) {
-        Validate.notNull(menu, "The ChestMenu cannot be null!");
-        Validate.notNull(task, "The RecipeChoiceTask cannot be null!");
+        Preconditions.checkNotNull(menu, "The ChestMenu cannot be null!");
+        Preconditions.checkNotNull(task, "The RecipeChoiceTask cannot be null!");
         menu.addItem(24, getResult().clone(), ChestMenuUtils.getEmptyClickHandler());
         ItemStack[] recipe = item.getRecipe();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaAutoCrafter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaAutoCrafter.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -130,7 +130,7 @@ public class VanillaAutoCrafter extends AbstractAutoCrafter {
 
     @ParametersAreNonnullByDefault
     private void offerRecipe(Player p, Block b, List<Recipe> recipes, int index, ChestMenu menu, AsyncRecipeChoiceTask task) {
-        Validate.isTrue(index >= 0 && index < recipes.size(), "page must be between 0 and " + (recipes.size() - 1));
+        Preconditions.checkArgument(index >= 0 && index < recipes.size(), "page must be between 0 and " + (recipes.size() - 1));
 
         menu.replaceExistingItem(46, ChestMenuUtils.getPreviousButton(p, index + 1, recipes.size()));
         menu.addMenuClickHandler(46, (pl, slot, item, action) -> {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/VanillaRecipe.java
@@ -7,7 +7,7 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Keyed;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
@@ -72,8 +72,8 @@ class VanillaRecipe extends AbstractRecipe {
 
     @Override
     public void show(@Nonnull ChestMenu menu, @Nonnull AsyncRecipeChoiceTask task) {
-        Validate.notNull(menu, "The ChestMenu cannot be null!");
-        Validate.notNull(task, "The RecipeChoiceTask cannot be null!");
+        Preconditions.checkNotNull(menu, "The ChestMenu cannot be null!");
+        Preconditions.checkNotNull(task, "The RecipeChoiceTask cannot be null!");
 
         menu.replaceExistingItem(24, getResult().clone());
         menu.addMenuClickHandler(24, ChestMenuUtils.getEmptyClickHandler());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/AbstractMonsterSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/AbstractMonsterSpawner.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
@@ -50,7 +50,7 @@ public abstract class AbstractMonsterSpawner extends SlimefunItem {
      */
     @Nonnull
     public Optional<EntityType> getEntityType(@Nonnull ItemStack item) {
-        Validate.notNull(item, "The Item cannot be null");
+        Preconditions.checkNotNull(item, "The Item cannot be null");
 
         ItemMeta meta = item.getItemMeta();
 
@@ -77,7 +77,7 @@ public abstract class AbstractMonsterSpawner extends SlimefunItem {
      */
     @Nonnull
     public ItemStack getItemForEntityType(@Nonnull EntityType type) {
-        Validate.notNull(type, "The EntityType cannot be null");
+        Preconditions.checkNotNull(type, "The EntityType cannot be null");
 
         ItemStack item = getItem().clone();
         ItemMeta meta = item.getItemMeta();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/IgnitionChamber.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -71,8 +71,8 @@ public class IgnitionChamber extends SlimefunItem {
      */
     @ParametersAreNonnullByDefault
     public static boolean useFlintAndSteel(Player p, Block smelteryBlock) {
-        Validate.notNull(p, "The Player must not be null!");
-        Validate.notNull(smelteryBlock, "The smeltery block cannot be null!");
+        Preconditions.checkNotNull(p, "The Player must not be null!");
+        Preconditions.checkNotNull(smelteryBlock, "The smeltery block cannot be null!");
 
         Inventory inv = findIgnitionChamber(smelteryBlock);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/OutputChest.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -68,8 +68,8 @@ public class OutputChest extends SlimefunItem {
      */
     @Nonnull
     public static Optional<Inventory> findOutputChestFor(@Nonnull Block b, @Nonnull ItemStack item) {
-        Validate.notNull(b, "The target block must not be null!");
-        Validate.notNull(item, "The ItemStack should not be null!");
+        Preconditions.checkNotNull(b, "The target block must not be null!");
+        Preconditions.checkNotNull(item, "The ItemStack should not be null!");
 
         for (BlockFace face : possibleFaces) {
             Block potentialOutput = b.getRelative(face);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AbstractCargoNode.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -128,7 +128,7 @@ abstract class AbstractCargoNode extends SimpleSlimefunItem<BlockPlaceHandler> i
 
     @Override
     public int getSelectedChannel(@Nonnull Block b) {
-        Validate.notNull(b, "Block must not be null");
+        Preconditions.checkNotNull(b, "Block must not be null");
 
         if (!BlockStorage.hasBlockInfo(b)) {
             return 0;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/AbstractEnergyProvider.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/AbstractEnergyProvider.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -90,7 +90,7 @@ public abstract class AbstractEnergyProvider extends SlimefunItem implements Inv
     }
 
     public void registerFuel(@Nonnull MachineFuel fuel) {
-        Validate.notNull(fuel, "Machine Fuel cannot be null!");
+        Preconditions.checkNotNull(fuel, "Machine Fuel cannot be null!");
         fuelTypes.add(fuel);
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AnimalProduce.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/AnimalProduce.java
@@ -5,7 +5,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 
@@ -26,7 +26,7 @@ public class AnimalProduce extends MachineRecipe implements Predicate<LivingEnti
     @ParametersAreNonnullByDefault
     public AnimalProduce(ItemStack input, ItemStack result, Predicate<LivingEntity> predicate) {
         super(5, new ItemStack[] { input }, new ItemStack[] { result });
-        Validate.notNull(predicate, "The Predicate must not be null");
+        Preconditions.checkNotNull(predicate, "The Predicate must not be null");
 
         this.predicate = predicate;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Ageable;
@@ -90,7 +90,7 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
      *            The {@link AnimalProduce} to add
      */
     public void addProduce(@Nonnull AnimalProduce produce) {
-        Validate.notNull(produce, "A produce cannot be null");
+        Preconditions.checkNotNull(produce, "A produce cannot be null");
 
         this.animalProduces.add(produce);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/elevator/ElevatorFloor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/elevator/ElevatorFloor.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.elevator;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -41,8 +41,8 @@ class ElevatorFloor {
      *            The {@link Block} of this floor
      */
     public ElevatorFloor(@Nonnull String name, int number, @Nonnull Block block) {
-        Validate.notNull(name, "An ElevatorFloor must have a name");
-        Validate.notNull(block, "An ElevatorFloor must have a block");
+        Preconditions.checkNotNull(name, "An ElevatorFloor must have a name");
+        Preconditions.checkNotNull(block, "An ElevatorFloor must have a block");
 
         this.name = name;
         this.number = number;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
@@ -7,7 +7,7 @@ import java.util.OptionalInt;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -118,7 +118,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
      * @return This method will return the current instance of {@link GEOMiner}, so that can be chained.
      */
     public final GEOMiner setCapacity(int capacity) {
-        Validate.isTrue(capacity > 0, "The capacity must be greater than zero!");
+        Preconditions.checkArgument(capacity > 0, "The capacity must be greater than zero!");
 
         if (getState() == ItemState.UNREGISTERED) {
             this.energyCapacity = capacity;
@@ -137,7 +137,7 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
      * @return This method will return the current instance of {@link GEOMiner}, so that can be chained.
      */
     public final GEOMiner setProcessingSpeed(int speed) {
-        Validate.isTrue(speed > 0, "The speed must be greater than zero!");
+        Preconditions.checkArgument(speed > 0, "The speed must be greater than zero!");
 
         this.processingSpeed = speed;
         return this;
@@ -152,9 +152,9 @@ public class GEOMiner extends SlimefunItem implements RecipeDisplayItem, EnergyN
      * @return This method will return the current instance of {@link GEOMiner}, so that can be chained.
      */
     public final GEOMiner setEnergyConsumption(int energyConsumption) {
-        Validate.isTrue(energyConsumption > 0, "The energy consumption must be greater than zero!");
-        Validate.isTrue(energyCapacity > 0, "You must specify the capacity before you can set the consumption amount.");
-        Validate.isTrue(energyConsumption <= energyCapacity, "The energy consumption cannot be higher than the capacity (" + energyCapacity + ')');
+        Preconditions.checkArgument(energyConsumption > 0, "The energy consumption must be greater than zero!");
+        Preconditions.checkArgument(energyCapacity > 0, "You must specify the capacity before you can set the consumption amount.");
+        Preconditions.checkArgument(energyConsumption <= energyCapacity, "The energy consumption cannot be higher than the capacity (" + energyCapacity + ')');
 
         this.energyConsumedPerTick = energyConsumption;
         return this;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -74,8 +74,8 @@ public class MagicianTalisman extends Talisman {
      */
     @Nullable
     public TalismanEnchantment getRandomEnchantment(@Nonnull ItemStack item, @Nonnull Set<Enchantment> existingEnchantments) {
-        Validate.notNull(item, "The ItemStack cannot be null");
-        Validate.notNull(existingEnchantments, "The Enchantments Set cannot be null");
+        Preconditions.checkNotNull(item, "The ItemStack cannot be null");
+        Preconditions.checkNotNull(existingEnchantments, "The Enchantments Set cannot be null");
 
         // @formatter:off
         List<TalismanEnchantment> enabled = enchantments.stream()

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
@@ -280,7 +280,7 @@ public class Talisman extends SlimefunItem {
      *            The {@link Player} who shall receive the message
      */
     public void sendMessage(@Nonnull Player p) {
-        Validate.notNull(p, "The Player must not be null.");
+        Preconditions.checkNotNull(p, "The Player must not be null.");
 
         // Check if this Talisman has a message
         if (!isSilent()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/GoldIngot.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/GoldIngot.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.misc;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -33,8 +33,8 @@ public class GoldIngot extends SlimefunItem {
     public GoldIngot(ItemGroup itemGroup, int caratRating, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
-        Validate.isTrue(caratRating > 0, "Carat rating must be above zero.");
-        Validate.isTrue(caratRating <= 24, "Carat rating cannot go above 24.");
+        Preconditions.checkArgument(caratRating > 0, "Carat rating must be above zero.");
+        Preconditions.checkArgument(caratRating <= 24, "Carat rating cannot go above 24.");
         this.caratRating = caratRating;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/IndustrialMiner.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -146,8 +146,8 @@ public class IndustrialMiner extends MultiBlockMachine {
      *            The item that shall be consumed
      */
     public void addFuelType(int ores, @Nonnull ItemStack item) {
-        Validate.isTrue(ores > 1 && ores % 2 == 0, "The amount of ores must be at least 2 and a multiple of 2.");
-        Validate.notNull(item, "The fuel item cannot be null");
+        Preconditions.checkArgument(ores > 1 && ores % 2 == 0, "The amount of ores must be at least 2 and a multiple of 2.");
+        Preconditions.checkNotNull(item, "The fuel item cannot be null");
 
         fuelTypes.add(new MachineFuel(ores / 2, item));
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ClimbingPick.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ClimbingPick.java
@@ -14,7 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
@@ -124,7 +124,7 @@ public class ClimbingPick extends SimpleSlimefunItem<ItemUseHandler> implements 
      * @return The climbing speed for this {@link Material} or 0.
      */
     public double getClimbingSpeed(@Nonnull Material type) {
-        Validate.notNull(type, "The surface cannot be null");
+        Preconditions.checkNotNull(type, "The surface cannot be null");
         ClimbableSurface surface = surfaces.get(type);
 
         if (surface != null) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -193,8 +193,8 @@ public class BackpackListener implements Listener {
      *            The id of this backpack
      */
     public void setBackpackId(@Nonnull OfflinePlayer backpackOwner, @Nonnull ItemStack item, int line, int id) {
-        Validate.notNull(backpackOwner, "Backpacks must have an owner!");
-        Validate.notNull(item, "Cannot set the id onto null!");
+        Preconditions.checkNotNull(backpackOwner, "Backpacks must have an owner!");
+        Preconditions.checkNotNull(item, "Cannot set the id onto null!");
 
         ItemMeta im = item.getItemMeta();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -28,8 +28,8 @@ public class CraftingOperation implements MachineOperation {
     }
 
     public CraftingOperation(@Nonnull ItemStack[] ingredients, @Nonnull ItemStack[] results, int totalTicks) {
-        Preconditions.checkArgument(!ingredients, "The Ingredients array cannot be empty or null");
-        Preconditions.checkArgument(!results, "The results array cannot be empty or null");
+        Preconditions.checkArgument(ingredients != null && ingredients.length > 0, "The Ingredients array cannot be empty or null");
+        Preconditions.checkArgument(results != null && results.length > 0, "The results array cannot be empty or null");
         Preconditions.checkArgument(totalTicks >= 0, "The amount of total ticks must be a positive integer or zero, received: " + totalTicks);
 
         this.ingredients = ingredients;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/CraftingOperation.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.operations;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
@@ -28,9 +28,9 @@ public class CraftingOperation implements MachineOperation {
     }
 
     public CraftingOperation(@Nonnull ItemStack[] ingredients, @Nonnull ItemStack[] results, int totalTicks) {
-        Validate.notEmpty(ingredients, "The Ingredients array cannot be empty or null");
-        Validate.notEmpty(results, "The results array cannot be empty or null");
-        Validate.isTrue(totalTicks >= 0, "The amount of total ticks must be a positive integer or zero, received: " + totalTicks);
+        Preconditions.checkArgument(!ingredients, "The Ingredients array cannot be empty or null");
+        Preconditions.checkArgument(!results, "The results array cannot be empty or null");
+        Preconditions.checkArgument(totalTicks >= 0, "The amount of total ticks must be a positive integer or zero, received: " + totalTicks);
 
         this.ingredients = ingredients;
         this.results = results;
@@ -39,7 +39,7 @@ public class CraftingOperation implements MachineOperation {
 
     @Override
     public void addProgress(int num) {
-        Validate.isTrue(num > 0, "Progress must be positive.");
+        Preconditions.checkArgument(num > 0, "Progress must be positive.");
         currentTicks += num;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/FuelOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/FuelOperation.java
@@ -3,7 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.operations;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
@@ -29,8 +29,8 @@ public class FuelOperation implements MachineOperation {
     }
 
     public FuelOperation(@Nonnull ItemStack ingredient, @Nullable ItemStack result, int totalTicks) {
-        Validate.notNull(ingredient, "The Ingredient cannot be null");
-        Validate.isTrue(totalTicks > 0, "The amount of total ticks must be a positive integer");
+        Preconditions.checkNotNull(ingredient, "The Ingredient cannot be null");
+        Preconditions.checkArgument(totalTicks > 0, "The amount of total ticks must be a positive integer");
 
         this.ingredient = ingredient;
         this.result = result;
@@ -39,7 +39,7 @@ public class FuelOperation implements MachineOperation {
 
     @Override
     public void addProgress(int num) {
-        Validate.isTrue(num > 0, "Progress must be positive.");
+        Preconditions.checkArgument(num > 0, "Progress must be positive.");
         currentTicks += num;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/MiningOperation.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/operations/MiningOperation.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.operations;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.machines.MachineOperation;
@@ -22,8 +22,8 @@ public class MiningOperation implements MachineOperation {
     private int currentTicks = 0;
 
     public MiningOperation(@Nonnull ItemStack result, int totalTicks) {
-        Validate.notNull(result, "The result cannot be null");
-        Validate.isTrue(totalTicks >= 0, "The amount of total ticks must be a positive integer or zero, received: " + totalTicks);
+        Preconditions.checkNotNull(result, "The result cannot be null");
+        Preconditions.checkArgument(totalTicks >= 0, "The amount of total ticks must be a positive integer or zero, received: " + totalTicks);
 
         this.result = result;
         this.totalTicks = totalTicks;
@@ -31,7 +31,7 @@ public class MiningOperation implements MachineOperation {
 
     @Override
     public void addProgress(int num) {
-        Validate.isTrue(num > 0, "Progress must be positive.");
+        Preconditions.checkArgument(num > 0, "Progress must be positive.");
         currentTicks += num;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/AbstractResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/AbstractResource.java
@@ -5,7 +5,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 
@@ -37,9 +37,9 @@ abstract class AbstractResource implements GEOResource {
 
     @ParametersAreNonnullByDefault
     AbstractResource(String key, String defaultName, ItemStack item, int maxDeviation, boolean geoMiner) {
-        Validate.notNull(key, "NamespacedKey cannot be null!");
-        Validate.notNull(defaultName, "The default name cannot be null!");
-        Validate.notNull(item, "item cannot be null!");
+        Preconditions.checkNotNull(key, "NamespacedKey cannot be null!");
+        Preconditions.checkNotNull(defaultName, "The default name cannot be null!");
+        Preconditions.checkNotNull(item, "item cannot be null!");
 
         this.key = new NamespacedKey(Slimefun.instance(), key);
         this.defaultName = defaultName;
@@ -89,8 +89,8 @@ abstract class AbstractResource implements GEOResource {
      */
     @ParametersAreNonnullByDefault
     static final @Nonnull BiomeMap<Integer> getBiomeMap(AbstractResource resource, String path) {
-        Validate.notNull(resource, "Resource cannot be null.");
-        Validate.notNull(path, "Path cannot be null.");
+        Preconditions.checkNotNull(resource, "Resource cannot be null.");
+        Preconditions.checkNotNull(path, "Path cannot be null.");
 
         try {
             return BiomeMap.fromResource(resource.getKey(), Slimefun.instance(), path, JsonElement::getAsInt);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AsyncRecipeChoiceTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AsyncRecipeChoiceTask.java
@@ -7,7 +7,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -47,14 +47,14 @@ public class AsyncRecipeChoiceTask implements Runnable {
      *            The {@link Inventory} to start this task for
      */
     public void start(@Nonnull Inventory inv) {
-        Validate.notNull(inv, "Inventory must not be null");
+        Preconditions.checkNotNull(inv, "Inventory must not be null");
 
         inventory = inv;
         id = Bukkit.getScheduler().runTaskTimerAsynchronously(Slimefun.instance(), this, 0, UPDATE_INTERVAL).getTaskId();
     }
 
     public void add(int slot, @Nonnull MaterialChoice choice) {
-        Validate.notNull(choice, "Cannot add a null RecipeChoice");
+        Preconditions.checkNotNull(choice, "Cannot add a null RecipeChoice");
 
         lock.writeLock().lock();
 
@@ -66,7 +66,7 @@ public class AsyncRecipeChoiceTask implements Runnable {
     }
 
     public void add(int slot, @Nonnull Tag<Material> tag) {
-        Validate.notNull(tag, "Cannot add a null Tag");
+        Preconditions.checkNotNull(tag, "Cannot add a null Tag");
 
         lock.writeLock().lock();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/CapacitorTextureUpdateTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/CapacitorTextureUpdateTask.java
@@ -2,7 +2,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.tasks;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Server;
@@ -45,7 +45,7 @@ public class CapacitorTextureUpdateTask implements Runnable {
      *            The capacity of this {@link Capacitor}
      */
     public CapacitorTextureUpdateTask(@Nonnull Location l, double charge, double capacity) {
-        Validate.notNull(l, "The Location cannot be null");
+        Preconditions.checkNotNull(l, "The Location cannot be null");
 
         this.l = l;
         this.filledPercentage = charge / capacity;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -13,7 +13,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -223,15 +223,15 @@ public class TickerTask implements Runnable {
 
     @ParametersAreNonnullByDefault
     public void queueMove(Location from, Location to) {
-        Validate.notNull(from, "Source Location cannot be null!");
-        Validate.notNull(to, "Target Location cannot be null!");
+        Preconditions.checkNotNull(from, "Source Location cannot be null!");
+        Preconditions.checkNotNull(to, "Target Location cannot be null!");
 
         movingQueue.put(from, to);
     }
 
     @ParametersAreNonnullByDefault
     public void queueDelete(Location l, boolean destroy) {
-        Validate.notNull(l, "Location must not be null!");
+        Preconditions.checkNotNull(l, "Location must not be null!");
 
         deletionQueue.put(l, destroy);
     }
@@ -239,11 +239,11 @@ public class TickerTask implements Runnable {
 
     @ParametersAreNonnullByDefault
     public void queueDelete(Collection<Location> locations, boolean destroy) {
-        Validate.notNull(locations, "Locations must not be null");
+        Preconditions.checkNotNull(locations, "Locations must not be null");
 
         Map<Location, Boolean> toDelete = new HashMap<>(locations.size(), 1.0F);
         for (Location location : locations) {
-            Validate.notNull(location, "Locations must not contain null locations");
+            Preconditions.checkNotNull(location, "Locations must not contain null locations");
             toDelete.put(location, destroy);
         }
         deletionQueue.putAll(toDelete);
@@ -251,10 +251,10 @@ public class TickerTask implements Runnable {
 
     @ParametersAreNonnullByDefault
     public void queueDelete(Map<Location, Boolean> locations) {
-        Validate.notNull(locations, "Locations must not be null");
+        Preconditions.checkNotNull(locations, "Locations must not be null");
         for (Map.Entry<Location, Boolean> entry : locations.entrySet()) {
-            Validate.notNull(entry.getKey(), "Location in locations cannot be null");
-            Validate.notNull(entry.getValue(), "Boolean toDestroy in locations cannot be null");
+            Preconditions.checkNotNull(entry.getKey(), "Location in locations cannot be null");
+            Preconditions.checkNotNull(entry.getValue(), "Boolean toDestroy in locations cannot be null");
         }
         deletionQueue.putAll(locations);
     }
@@ -273,7 +273,7 @@ public class TickerTask implements Runnable {
      * @return Whether this {@link Location} has been reserved and will be filled upon the next tick
      */
     public boolean isOccupiedSoon(@Nonnull Location l) {
-        Validate.notNull(l, "Null is not a valid Location!");
+        Preconditions.checkNotNull(l, "Null is not a valid Location!");
 
         return movingQueue.containsValue(l);
     }
@@ -287,7 +287,7 @@ public class TickerTask implements Runnable {
      * @return Whether this {@link Location} will be deleted on the next tick
      */
     public boolean isDeletedSoon(@Nonnull Location l) {
-        Validate.notNull(l, "Null is not a valid Location!");
+        Preconditions.checkNotNull(l, "Null is not a valid Location!");
 
         return deletionQueue.containsKey(l);
     }
@@ -328,7 +328,7 @@ public class TickerTask implements Runnable {
      */
     @Nonnull
     public Set<Location> getLocations(@Nonnull Chunk chunk) {
-        Validate.notNull(chunk, "The Chunk cannot be null!");
+        Preconditions.checkNotNull(chunk, "The Chunk cannot be null!");
 
         Set<Location> locations = tickingLocations.getOrDefault(new ChunkPosition(chunk), Collections.emptySet());
         return Collections.unmodifiableSet(locations);
@@ -341,7 +341,7 @@ public class TickerTask implements Runnable {
      *            The {@link Location} to activate
      */
     public void enableTicker(@Nonnull Location l) {
-        Validate.notNull(l, "Location cannot be null!");
+        Preconditions.checkNotNull(l, "Location cannot be null!");
 
         ChunkPosition chunk = new ChunkPosition(l.getWorld(), l.getBlockX() >> 4, l.getBlockZ() >> 4);
 
@@ -373,7 +373,7 @@ public class TickerTask implements Runnable {
      *            The {@link Location} to remove
      */
     public void disableTicker(@Nonnull Location l) {
-        Validate.notNull(l, "Location cannot be null!");
+        Preconditions.checkNotNull(l, "Location cannot be null!");
 
         ChunkPosition chunk = new ChunkPosition(l.getWorld(), l.getBlockX() >> 4, l.getBlockZ() >> 4);
         Set<Location> locations = tickingLocations.get(chunk);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/storage/data/PlayerData.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/storage/data/PlayerData.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 /**
  * The data which backs {@link io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile}
@@ -39,12 +39,12 @@ public class PlayerData {
     }
 
     public void addResearch(@Nonnull Research research) {
-        Validate.notNull(research, "Cannot add a 'null' research!");
+        Preconditions.checkNotNull(research, "Cannot add a 'null' research!");
         researches.add(research);
     }
 
     public void removeResearch(@Nonnull Research research) {
-        Validate.notNull(research, "Cannot remove a 'null' research!");
+        Preconditions.checkNotNull(research, "Cannot remove a 'null' research!");
         researches.remove(research);
     }
 
@@ -59,12 +59,12 @@ public class PlayerData {
     }
 
     public void addBackpack(@Nonnull PlayerBackpack backpack) {
-        Validate.notNull(backpack, "Cannot add a 'null' backpack!");
+        Preconditions.checkNotNull(backpack, "Cannot add a 'null' backpack!");
         backpacks.put(backpack.getId(), backpack);
     }
 
     public void removeBackpack(@Nonnull PlayerBackpack backpack) {
-        Validate.notNull(backpack, "Cannot remove a 'null' backpack!");
+        Preconditions.checkNotNull(backpack, "Cannot remove a 'null' backpack!");
         backpacks.remove(backpack.getId());
     }
 
@@ -73,7 +73,7 @@ public class PlayerData {
     }
 
     public void addWaypoint(@Nonnull Waypoint waypoint) {
-        Validate.notNull(waypoint, "Cannot add a 'null' waypoint!");
+        Preconditions.checkNotNull(waypoint, "Cannot add a 'null' waypoint!");
 
         for (Waypoint wp : waypoints) {
             if (wp.getId().equals(waypoint.getId())) {
@@ -90,7 +90,7 @@ public class PlayerData {
     }
 
     public void removeWaypoint(@Nonnull Waypoint waypoint) {
-        Validate.notNull(waypoint, "Cannot remove a 'null' waypoint!");
+        Preconditions.checkNotNull(waypoint, "Cannot remove a 'null' waypoint!");
         waypoints.remove(waypoint);
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChargeUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChargeUtils.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -37,10 +37,10 @@ public final class ChargeUtils {
     private ChargeUtils() {}
 
     public static void setCharge(@Nonnull ItemMeta meta, float charge, float capacity) {
-        Validate.notNull(meta, "Meta cannot be null!");
-        Validate.isTrue(charge >= 0, "Charge has to be equal to or greater than 0!");
-        Validate.isTrue(capacity > 0, "Capacity has to be greater than 0!");
-        Validate.isTrue(charge <= capacity, "Charge may not be bigger than the capacity!");
+        Preconditions.checkNotNull(meta, "Meta cannot be null!");
+        Preconditions.checkArgument(charge >= 0, "Charge has to be equal to or greater than 0!");
+        Preconditions.checkArgument(capacity > 0, "Capacity has to be greater than 0!");
+        Preconditions.checkArgument(charge <= capacity, "Charge may not be bigger than the capacity!");
 
         BigDecimal decimal = BigDecimal.valueOf(charge).setScale(2, RoundingMode.HALF_UP);
         float value = decimal.floatValue();
@@ -64,7 +64,7 @@ public final class ChargeUtils {
     }
 
     public static float getCharge(@Nonnull ItemMeta meta) {
-        Validate.notNull(meta, "Meta cannot be null!");
+        Preconditions.checkNotNull(meta, "Meta cannot be null!");
 
         NamespacedKey key = Slimefun.getRegistry().getItemChargeDataKey();
         PersistentDataContainer container = meta.getPersistentDataContainer();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
@@ -216,7 +216,9 @@ public enum ColoredMaterial {
      *            The {@link Material Materials} for this {@link ColoredMaterial}.
      */
     ColoredMaterial(@Nonnull Material[] materials) {
-        Validate.noNullElements(materials, "The List cannot contain any null elements");
+        for (Material m : materials) {
+            Preconditions.checkNotNull(m, "The List cannot contain any null elements");
+        }
         Preconditions.checkArgument(materials.length == 16, "Expected 16, received: " + materials.length + ". Did you miss a color?");
 
         list = Collections.unmodifiableList(Arrays.asList(materials));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ColoredMaterial.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 
@@ -217,7 +217,7 @@ public enum ColoredMaterial {
      */
     ColoredMaterial(@Nonnull Material[] materials) {
         Validate.noNullElements(materials, "The List cannot contain any null elements");
-        Validate.isTrue(materials.length == 16, "Expected 16, received: " + materials.length + ". Did you miss a color?");
+        Preconditions.checkArgument(materials.length == 16, "Expected 16, received: " + materials.length + ". Did you miss a color?");
 
         list = Collections.unmodifiableList(Arrays.asList(materials));
     }
@@ -241,7 +241,7 @@ public enum ColoredMaterial {
      * @return The {@link Material} at that index
      */
     public @Nonnull Material get(int index) {
-        Validate.isTrue(index >= 0 && index < 16, "The index must be between 0 and 15 (inclusive).");
+        Preconditions.checkArgument(index >= 0 && index < 16, "The index must be between 0 and 15 (inclusive).");
 
         return list.get(index);
     }
@@ -255,7 +255,7 @@ public enum ColoredMaterial {
      * @return The {@link Material} with that {@link DyeColor}
      */
     public @Nonnull Material get(@Nonnull DyeColor color) {
-        Validate.notNull(color, "Color cannot be null!");
+        Preconditions.checkNotNull(color, "Color cannot be null!");
 
         return get(color.ordinal());
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/HeadTexture.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/HeadTexture.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.common.CommonPatterns;
@@ -127,8 +127,8 @@ public enum HeadTexture {
     private final UUID uuid;
 
     HeadTexture(@Nonnull String texture) {
-        Validate.notNull(texture, "Texture cannot be null");
-        Validate.isTrue(CommonPatterns.HEXADECIMAL.matcher(texture).matches(), "Textures must be in hexadecimal.");
+        Preconditions.checkNotNull(texture, "Texture cannot be null");
+        Preconditions.checkArgument(CommonPatterns.HEXADECIMAL.matcher(texture).matches(), "Textures must be in hexadecimal.");
 
         this.texture = texture;
         this.uuid = UUID.nameUUIDFromBytes(texture.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/InfiniteBlockGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/InfiniteBlockGenerator.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -74,7 +74,7 @@ public enum InfiniteBlockGenerator implements Predicate<Block> {
      */
     @Override
     public boolean test(@Nonnull Block b) {
-        Validate.notNull(b, "Block cannot be null!");
+        Preconditions.checkNotNull(b, "Block cannot be null!");
 
         /*
          * This will eliminate non-matching base materials If we
@@ -106,8 +106,8 @@ public enum InfiniteBlockGenerator implements Predicate<Block> {
 
     @ParametersAreNonnullByDefault
     private boolean hasSurroundingMaterials(Block b, Material... materials) {
-        Validate.notNull(b, "The Block cannot be null!");
-        Validate.notEmpty(materials, "Materials need to have a size of at least one!");
+        Preconditions.checkNotNull(b, "The Block cannot be null!");
+        Preconditions.checkArgument(!materials, "Materials need to have a size of at least one!");
 
         boolean[] matches = new boolean[materials.length];
         int count = 0;
@@ -143,7 +143,7 @@ public enum InfiniteBlockGenerator implements Predicate<Block> {
      * @return Our called {@link BlockFormEvent}
      */
     public @Nonnull BlockFormEvent callEvent(@Nonnull Block block) {
-        Validate.notNull(block, "The Block cannot be null!");
+        Preconditions.checkNotNull(block, "The Block cannot be null!");
         BlockState state = PaperLib.getBlockState(block, false).getState();
         BlockFormEvent event = new BlockFormEvent(block, state);
         Bukkit.getPluginManager().callEvent(event);
@@ -159,7 +159,7 @@ public enum InfiniteBlockGenerator implements Predicate<Block> {
      * @return An {@link InfiniteBlockGenerator} or null if none was found.
      */
     public static @Nullable InfiniteBlockGenerator findAt(@Nonnull Block b) {
-        Validate.notNull(b, "Cannot find a generator without a Location!");
+        Preconditions.checkNotNull(b, "Cannot find a generator without a Location!");
 
         for (InfiniteBlockGenerator generator : valuesCached) {
             if (generator.test(b)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/InfiniteBlockGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/InfiniteBlockGenerator.java
@@ -107,7 +107,7 @@ public enum InfiniteBlockGenerator implements Predicate<Block> {
     @ParametersAreNonnullByDefault
     private boolean hasSurroundingMaterials(Block b, Material... materials) {
         Preconditions.checkNotNull(b, "The Block cannot be null!");
-        Preconditions.checkArgument(!materials, "Materials need to have a size of at least one!");
+        Preconditions.checkArgument(materials != null && materials.length > 0, "Materials need to have a size of at least one!");
 
         boolean[] matches = new boolean[materials.length];
         int count = 0;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -11,7 +11,7 @@ import java.util.logging.Level;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 
 import io.github.bakedlibs.dough.common.CommonPatterns;
@@ -89,7 +89,7 @@ public final class NumberUtils {
      * @return The {@link LocalDateTime} for the given input
      */
     public static @Nonnull LocalDateTime parseGitHubDate(@Nonnull String date) {
-        Validate.notNull(date, "Provided date was null");
+        Preconditions.checkNotNull(date, "Provided date was null");
         return LocalDateTime.parse(date.substring(0, date.length() - 1));
     }
 
@@ -155,8 +155,8 @@ public final class NumberUtils {
      * @return The elapsed time as a {@link String}
      */
     public static @Nonnull String getElapsedTime(@Nonnull LocalDateTime current, @Nonnull LocalDateTime priorDate) {
-        Validate.notNull(current, "Provided current date was null");
-        Validate.notNull(priorDate, "Provided past date was null");
+        Preconditions.checkNotNull(current, "Provided current date was null");
+        Preconditions.checkNotNull(priorDate, "Provided past date was null");
 
         long hours = Duration.between(priorDate, current).toHours();
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/SlimefunUtils.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -224,7 +224,7 @@ public final class SlimefunUtils {
      * @return An {@link ItemStack} with this Head texture
      */
     public static @Nonnull ItemStack getCustomHead(@Nonnull String texture) {
-        Validate.notNull(texture, "The provided texture is null");
+        Preconditions.checkNotNull(texture, "The provided texture is null");
 
         if (Slimefun.instance() == null) {
             throw new PrematureCodeException("You cannot instantiate a custom head before Slimefun was loaded.");
@@ -521,8 +521,8 @@ public final class SlimefunUtils {
      * @return Whether the two lores are equal
      */
     public static boolean equalsLore(@Nonnull List<String> lore1, @Nonnull List<String> lore2) {
-        Validate.notNull(lore1, "Cannot compare lore that is null!");
-        Validate.notNull(lore2, "Cannot compare lore that is null!");
+        Preconditions.checkNotNull(lore1, "Cannot compare lore that is null!");
+        Preconditions.checkNotNull(lore2, "Cannot compare lore that is null!");
 
         List<String> longerList = lore1.size() > lore2.size() ? lore1 : lore2;
         List<String> shorterList = lore1.size() > lore2.size() ? lore2 : lore1;
@@ -560,8 +560,8 @@ public final class SlimefunUtils {
     }
 
     public static void updateCapacitorTexture(@Nonnull Location l, int charge, int capacity) {
-        Validate.notNull(l, "Cannot update a texture for null");
-        Validate.isTrue(capacity > 0, "Capacity must be greater than zero!");
+        Preconditions.checkNotNull(l, "Cannot update a texture for null");
+        Preconditions.checkArgument(capacity > 0, "Capacity must be greater than zero!");
 
         Slimefun.runSync(new CapacitorTextureUpdateTask(l, charge, capacity));
     }
@@ -582,7 +582,7 @@ public final class SlimefunUtils {
      * @return Whether the {@link Player} is able to use that item.
      */
     public static boolean canPlayerUseItem(@Nonnull Player p, @Nullable ItemStack item, boolean sendMessage) {
-        Validate.notNull(p, "The player cannot be null");
+        Preconditions.checkNotNull(p, "The player cannot be null");
 
         SlimefunItem sfItem = SlimefunItem.getByItem(item);
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMap.java
@@ -12,7 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Biome;
@@ -60,31 +60,31 @@ public class BiomeMap<T> implements Keyed {
      */
     @ParametersAreNonnullByDefault
     public BiomeMap(NamespacedKey namespacedKey) {
-        Validate.notNull(namespacedKey, "The key must not be null.");
+        Preconditions.checkNotNull(namespacedKey, "The key must not be null.");
 
         this.namespacedKey = namespacedKey;
     }
 
     public @Nullable T get(@Nonnull Biome biome) {
-        Validate.notNull(biome, "The biome shall not be null.");
+        Preconditions.checkNotNull(biome, "The biome shall not be null.");
 
         return dataMap.get(biome);
     }
 
     public @Nonnull T getOrDefault(@Nonnull Biome biome, T defaultValue) {
-        Validate.notNull(biome, "The biome should not be null.");
+        Preconditions.checkNotNull(biome, "The biome should not be null.");
 
         return dataMap.getOrDefault(biome, defaultValue);
     }
 
     public boolean containsKey(@Nonnull Biome biome) {
-        Validate.notNull(biome, "The biome must not be null.");
+        Preconditions.checkNotNull(biome, "The biome must not be null.");
 
         return dataMap.containsKey(biome);
     }
 
     public boolean containsValue(@Nonnull T value) {
-        Validate.notNull(value, "The value must not be null.");
+        Preconditions.checkNotNull(value, "The value must not be null.");
 
         return dataMap.containsValue(value);
     }
@@ -100,26 +100,26 @@ public class BiomeMap<T> implements Keyed {
     }
 
     public boolean put(@Nonnull Biome biome, @Nonnull T value) {
-        Validate.notNull(biome, "The biome should not be null.");
-        Validate.notNull(value, "Values cannot be null.");
+        Preconditions.checkNotNull(biome, "The biome should not be null.");
+        Preconditions.checkNotNull(value, "Values cannot be null.");
 
         return dataMap.put(biome, value) == null;
     }
 
     public void putAll(@Nonnull Map<Biome, T> map) {
-        Validate.notNull(map, "The map should not be null.");
+        Preconditions.checkNotNull(map, "The map should not be null.");
 
         dataMap.putAll(map);
     }
 
     public void putAll(@Nonnull BiomeMap<T> map) {
-        Validate.notNull(map, "The map should not be null.");
+        Preconditions.checkNotNull(map, "The map should not be null.");
 
         dataMap.putAll(map.dataMap);
     }
 
     public boolean remove(@Nonnull Biome biome) {
-        Validate.notNull(biome, "The biome cannot be null.");
+        Preconditions.checkNotNull(biome, "The biome cannot be null.");
 
         return dataMap.remove(biome) != null;
     }
@@ -162,9 +162,9 @@ public class BiomeMap<T> implements Keyed {
     @Nonnull
     @ParametersAreNonnullByDefault
     public static <T> BiomeMap<T> fromResource(NamespacedKey key, JavaPlugin plugin, String path, BiomeDataConverter<T> valueConverter) throws BiomeMapException {
-        Validate.notNull(key, "The key shall not be null.");
-        Validate.notNull(plugin, "The plugin shall not be null.");
-        Validate.notNull(path, "The path should not be null!");
+        Preconditions.checkNotNull(key, "The key shall not be null.");
+        Preconditions.checkNotNull(plugin, "The plugin shall not be null.");
+        Preconditions.checkNotNull(path, "The path should not be null!");
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(plugin.getClass().getResourceAsStream(path), StandardCharsets.UTF_8))) {
             return fromJson(key, reader.lines().collect(Collectors.joining("")), valueConverter);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMapParser.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/biomes/BiomeMapParser.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Biome;
 
@@ -63,8 +63,8 @@ public class BiomeMapParser<T> {
      */
     @ParametersAreNonnullByDefault
     public BiomeMapParser(NamespacedKey key, BiomeDataConverter<T> valueConverter) {
-        Validate.notNull(key, "The key shall not be null.");
-        Validate.notNull(valueConverter, "You must provide a Function to convert raw json values to your desired data type.");
+        Preconditions.checkNotNull(key, "The key shall not be null.");
+        Preconditions.checkNotNull(valueConverter, "You must provide a Function to convert raw json values to your desired data type.");
 
         this.key = key;
         this.valueConverter = valueConverter;
@@ -98,7 +98,7 @@ public class BiomeMapParser<T> {
     }
 
     public void read(@Nonnull String json) throws BiomeMapException {
-        Validate.notNull(json, "The JSON string should not be null!");
+        Preconditions.checkNotNull(json, "The JSON string should not be null!");
         JsonArray root = null;
 
         try {
@@ -115,7 +115,7 @@ public class BiomeMapParser<T> {
     }
 
     public void read(@Nonnull JsonArray json) throws BiomeMapException {
-        Validate.notNull(json, "The JSON Array should not be null!");
+        Preconditions.checkNotNull(json, "The JSON Array should not be null!");
 
         for (JsonElement element : json) {
             if (element instanceof JsonObject) {
@@ -127,7 +127,7 @@ public class BiomeMapParser<T> {
     }
 
     private void readEntry(@Nonnull JsonObject entry) throws BiomeMapException {
-        Validate.notNull(entry, "The JSON entry should not be null!");
+        Preconditions.checkNotNull(entry, "The JSON entry should not be null!");
 
         /*
          * Check if the entry has a "value" element.
@@ -159,7 +159,7 @@ public class BiomeMapParser<T> {
     }
 
     private @Nonnull Set<Biome> readBiomes(@Nonnull JsonArray array) throws BiomeMapException {
-        Validate.notNull(array, "The JSON array should not be null!");
+        Preconditions.checkNotNull(array, "The JSON array should not be null!");
         Set<Biome> biomes = new HashSet<>();
 
         for (JsonElement element : array) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ItemStackWrapper.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/itemstack/ItemStackWrapper.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -114,7 +114,7 @@ public final class ItemStackWrapper extends ItemStack {
      * @see #wrap(ItemStack)
      */
     public static @Nonnull ItemStackWrapper forceWrap(@Nonnull ItemStack itemStack) {
-        Validate.notNull(itemStack, "The ItemStack cannot be null!");
+        Preconditions.checkNotNull(itemStack, "The ItemStack cannot be null!");
 
         return new ItemStackWrapper(itemStack);
     }
@@ -130,7 +130,7 @@ public final class ItemStackWrapper extends ItemStack {
      * @see #forceWrap(ItemStack)
      */
     public static @Nonnull ItemStackWrapper wrap(@Nonnull ItemStack itemStack) {
-        Validate.notNull(itemStack, "The ItemStack cannot be null!");
+        Preconditions.checkNotNull(itemStack, "The ItemStack cannot be null!");
 
         if (itemStack instanceof ItemStackWrapper wrapper) {
             return wrapper;
@@ -148,7 +148,7 @@ public final class ItemStackWrapper extends ItemStack {
      * @return An {@link ItemStackWrapper} array
      */
     public static @Nonnull ItemStackWrapper[] wrapArray(@Nonnull ItemStack[] items) {
-        Validate.notNull(items, "The array must not be null!");
+        Preconditions.checkNotNull(items, "The array must not be null!");
 
         ItemStackWrapper[] array = new ItemStackWrapper[items.length];
 
@@ -170,7 +170,7 @@ public final class ItemStackWrapper extends ItemStack {
      * @return An {@link ItemStackWrapper} array
      */
     public static @Nonnull List<ItemStackWrapper> wrapList(@Nonnull List<ItemStack> items) {
-        Validate.notNull(items, "The list must not be null!");
+        Preconditions.checkNotNull(items, "The list must not be null!");
         List<ItemStackWrapper> list = new ArrayList<>(items.size());
 
         for (ItemStack item : items) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.java
@@ -12,7 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.autocrafters.AbstractAutoCrafter;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
@@ -433,7 +433,7 @@ public enum SlimefunTag implements Tag<Material> {
      * @return The {@link SlimefunTag} or null if it does not exist.
      */
     public static @Nullable SlimefunTag getTag(@Nonnull String value) {
-        Validate.notNull(value, "A tag cannot be null!");
+        Preconditions.checkNotNull(value, "A tag cannot be null!");
 
         return nameLookup.get(value);
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/TagParser.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/tags/TagParser.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
@@ -92,7 +92,7 @@ public class TagParser implements Keyed {
      *             {@link Material} or {@link Tag} could be found
      */
     public void parse(@Nonnull String json, @Nonnull BiConsumer<Set<Material>, Set<Tag<Material>>> callback) throws TagMisconfigurationException {
-        Validate.notNull(json, "Cannot parse a null String");
+        Preconditions.checkNotNull(json, "Cannot parse a null String");
 
         try {
             Set<Material> materials = new HashSet<>();

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -180,7 +180,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
      * @return This method will return the current instance of {@link AContainer}, so that can be chained.
      */
     public final AContainer setCapacity(int capacity) {
-        Validate.isTrue(capacity > 0, "The capacity must be greater than zero!");
+        Preconditions.checkArgument(capacity > 0, "The capacity must be greater than zero!");
 
         if (getState() == ItemState.UNREGISTERED) {
             this.energyCapacity = capacity;
@@ -199,7 +199,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
      * @return This method will return the current instance of {@link AContainer}, so that can be chained.
      */
     public final AContainer setProcessingSpeed(int speed) {
-        Validate.isTrue(speed > 0, "The speed must be greater than zero!");
+        Preconditions.checkArgument(speed > 0, "The speed must be greater than zero!");
 
         this.processingSpeed = speed;
         return this;
@@ -214,9 +214,9 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
      * @return This method will return the current instance of {@link AContainer}, so that can be chained.
      */
     public final AContainer setEnergyConsumption(int energyConsumption) {
-        Validate.isTrue(energyConsumption > 0, "The energy consumption must be greater than zero!");
-        Validate.isTrue(energyCapacity > 0, "You must specify the capacity before you can set the consumption amount.");
-        Validate.isTrue(energyConsumption <= energyCapacity, "The energy consumption cannot be higher than the capacity (" + energyCapacity + ')');
+        Preconditions.checkArgument(energyConsumption > 0, "The energy consumption must be greater than zero!");
+        Preconditions.checkArgument(energyCapacity > 0, "You must specify the capacity before you can set the consumption amount.");
+        Preconditions.checkArgument(energyConsumption <= energyCapacity, "The energy consumption cannot be higher than the capacity (" + energyCapacity + ')');
 
         this.energyConsumedPerTick = energyConsumption;
         return this;
@@ -391,7 +391,7 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
      * @return Whether charge was taken if its chargeable
      */
     protected boolean takeCharge(@Nonnull Location l) {
-        Validate.notNull(l, "Can't attempt to take charge from a null location!");
+        Preconditions.checkNotNull(l, "Can't attempt to take charge from a null location!");
 
         if (isChargeable()) {
             int charge = getCharge(l);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -7,7 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -237,7 +237,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
      * @return This method will return the current instance of {@link AGenerator}, so that can be chained.
      */
     public final AGenerator setCapacity(int capacity) {
-        Validate.isTrue(capacity >= 0, "The capacity cannot be negative!");
+        Preconditions.checkArgument(capacity >= 0, "The capacity cannot be negative!");
 
         if (getState() == ItemState.UNREGISTERED) {
             this.energyCapacity = capacity;
@@ -256,7 +256,7 @@ public abstract class AGenerator extends AbstractEnergyProvider implements Machi
      * @return This method will return the current instance of {@link AGenerator}, so that can be chained.
      */
     public final AGenerator setEnergyProduction(int energyProduced) {
-        Validate.isTrue(energyProduced > 0, "The energy production must be greater than zero!");
+        Preconditions.checkArgument(energyProduced > 0, "The energy production must be greater than zero!");
 
         this.energyProducedPerTick = energyProduced;
         return this;

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/MachineFuel.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/MachineFuel.java
@@ -3,7 +3,7 @@ package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems;
 import java.util.function.Predicate;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
@@ -24,8 +24,8 @@ public class MachineFuel implements Predicate<ItemStack> {
     }
 
     public MachineFuel(int seconds, ItemStack fuel, ItemStack output) {
-        Validate.notNull(fuel, "Fuel must never be null!");
-        Validate.isTrue(seconds > 0, "Fuel must last at least one second!");
+        Preconditions.checkNotNull(fuel, "Fuel must never be null!");
+        Preconditions.checkArgument(seconds > 0, "Fuel must last at least one second!");
 
         this.ticks = seconds * 2;
         this.fuel = fuel;
@@ -38,8 +38,8 @@ public class MachineFuel implements Predicate<ItemStack> {
     }
 
     public MachineFuel(int seconds, SlimefunItemStack fuel, SlimefunItemStack output) {
-        Validate.notNull(fuel, "Fuel must never be null!");
-        Validate.isTrue(seconds > 0, "Fuel must last at least one second!");
+        Preconditions.checkNotNull(fuel, "Fuel must never be null!");
+        Preconditions.checkArgument(seconds > 0, "Fuel must last at least one second!");
 
         this.ticks = seconds * 2;
         this.fuel = fuel.item();

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -403,7 +403,7 @@ public class BlockStorage {
      */
     @Nullable
     public static Map<Location, Config> getRawStorage(@Nonnull World world) {
-        Validate.notNull(world, "World cannot be null!");
+        Preconditions.checkNotNull(world, "World cannot be null!");
 
         BlockStorage storage = getStorage(world);
         if (storage != null) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -41,7 +41,7 @@ public abstract class BlockMenuPreset extends ChestMenu {
     protected BlockMenuPreset(@Nonnull String id, @Nonnull String title, boolean universal) {
         super(title);
 
-        Validate.notNull(id, "You need to specify an id!");
+        Preconditions.checkNotNull(id, "You need to specify an id!");
 
         this.id = id;
         this.inventoryTitle = title;
@@ -119,7 +119,7 @@ public abstract class BlockMenuPreset extends ChestMenu {
      *            The slots which should be treated as background
      */
     public void drawBackground(@Nonnull ItemStack item, @Nonnull int[] slots) {
-        Validate.notNull(item, "The background item cannot be null!");
+        Preconditions.checkNotNull(item, "The background item cannot be null!");
         checkIfLocked();
 
         for (int slot : slots) {
@@ -248,7 +248,7 @@ public abstract class BlockMenuPreset extends ChestMenu {
     }
 
     public void newInstance(@Nonnull BlockMenu menu, @Nonnull Location l) {
-        Validate.notNull(l, "Cannot create a new BlockMenu without a Location");
+        Preconditions.checkNotNull(l, "Cannot create a new BlockMenu without a Location");
 
         Slimefun.runSync(() -> {
             locked = true;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/localization/AbstractLocaleRegexChecker.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/localization/AbstractLocaleRegexChecker.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -31,7 +31,7 @@ class AbstractLocaleRegexChecker {
     private final Pattern pattern;
 
     AbstractLocaleRegexChecker(@Nonnull Pattern pattern) {
-        Validate.notNull(pattern, "The pattern cannot be null.");
+        Preconditions.checkNotNull(pattern, "The pattern cannot be null.");
 
         this.pattern = pattern;
     }


### PR DESCRIPTION
Migrated all usages of org.apache.commons.lang.Validate to com.google.common.base.Preconditions as discussed in issue #3586. This removes the dependency on commons-lang for validation checks.

## Description
<!-- Please explain why you are making this pull request. -->
<!-- Start writing below this line -->

## Proposed changes
<!-- Please explain what changes you have made to the code. -->
<!-- Start writing below this line -->

## Related Issues (if applicable)
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
<!-- Start writing below this line -->

## Checklist
<!-- Here is a little checklist you can follow. -->
<!-- Click on these checkboxes after you created the pull request. -->
<!-- Don't worry, these are not requirements. They only serve as guidance. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I have made sure that the proposed changes do not break compatibility across the supported Minecraft versions (1.16.* - 1.20.*).
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
